### PR TITLE
Fix missing version numbers

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,11 +29,13 @@ var URL       = require('url')
 var server    = require('./index')
 var Utils     = require('./utils')
 var pkginfo = require('pkginfo')(module); // eslint-disable-line no-unused-vars
+var pkgVersion = module.exports.version
+var pkgName    = module.exports.name
 
 commander
   .option('-l, --listen <[host:]port>', 'host:port number to listen on (default: localhost:4873)')
   .option('-c, --config <config.yaml>', 'use this configuration file (default: ./config.yaml)')
-  .version(module.exports.version)
+  .version(pkgVersion)
   .parse(process.argv)
 
 if (commander.args.length == 1 && !commander.config) {
@@ -160,7 +162,7 @@ function afterConfigLoad() {
                 pathname: '/',
               })
             ),
-      version: 'Sinopia/'+module.exports.version,
+      version: pkgName + '/' + pkgVersion,
     }, 'http address - @{addr}')
   })
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,7 +6,9 @@ var Path      = require('path')
 var LocalData = require('./local-data')
 var Utils     = require('./utils')
 var Utils     = require('./utils')
-var pkginfo = require('pkginfo')(module); // eslint-disable-line no-unused-vars
+var pkginfo = require('pkginfo')(module) // eslint-disable-line no-unused-vars
+var pkgVersion = module.exports.version
+var pkgName    = module.exports.name
 
 // [[a, [b, c]], d] -> [a, b, c, d]
 function flatten(array) {
@@ -26,7 +28,7 @@ function Config(config) {
   for (var i in config) {
     if (self[i] == null) self[i] = config[i]
   }
-  if (!self.user_agent) self.user_agent = 'Sinopia/'+module.exports.version
+  if (!self.user_agent) self.user_agent = pkgName + '/' + pkgVersion
 
   // some weird shell scripts are valid yaml files parsed as string
   assert.equal(typeof(config), 'object', 'CONFIG: it doesn\'t look like a valid config file')


### PR DESCRIPTION
Fix version numbers that got lost as a consequence of #13. This meant the user agent string and version reported in the log were incomplete.