### PR TITLE
Fix load of plugins

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -16,7 +16,7 @@ function load_plugins(config, plugin_configs, params, sanity_check) {
     var plugin
 
     // try local plugins first
-    plugin = try_load(Path.resolve('./lib/plugins', p))
+    plugin = try_load(Path.resolve(__dirname + '/plugins', p))
 
     // npm package
     if (plugin === null && p.match(/^[^\.\/]/)) {


### PR DESCRIPTION
Without this change I get the "plugin not found" error in node 6.1