### PR TITLE
Adding users without `npm adduser` for authenticated only packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ npm adduser --registry http://localhost:4873/
 
 This will prompt you for user credentials which will be saved on the Sinopia server.
 
+### Pre-adding users
+
+If you want to prevent users from being able to create them selves, you may want to have the users setup on initialisation of your to be able to do this you can enter the node console and run
+
+```bash
+crypto = require('crypto')
+password = 'Put your password here'
+hash = '{SHA}' + crypto.createHash('sha1').update(password, 'binary').digest('base64')
+```
+
+The result of hash would then be added to your htpasswd file as:
+
+```
+username:password
+```
+
+This will then allow you to not allow any users to be self-created and therefore self authenticated.
+
 ## Using private packages
 
 You can add users and manage which users can access which packages.
@@ -138,4 +156,3 @@ If you want to use a database instead, ask for it, we'll come up with some kind 
 - [gemfury](http://www.gemfury.com/l/npm-registry) and others - those are closed-source cloud services, and I'm not in a mood to trust my private code to somebody (security through obscurity yeah!)
 - npm-registry-proxy, npm-delegate, npm-proxy - those are just proxies...
 - Is there something else?
-


### PR DESCRIPTION
I have been doing this for my own system and thought it would probably be worth sharing as part of the documentation.

It is highly likely that anyone using Verdaccio will be wanting only authenticated users to be able to publish and install packages as they are likely to be private packages. This will prevent users from being able to add themselves to the private registry and have multiple users for an entire team.