### PR TITLE
Lightweight system for webhooks

### DIFF
--- a/conf/full.yaml
+++ b/conf/full.yaml
@@ -119,3 +119,25 @@ logs:
 # maximum size of uploaded json document
 # increase it if you have "request entity too large" errors
 #max_body_size: 1mb
+
+# Notify Settings
+# Notify was built primarily to use with Slack's Incoming
+# webhooks, but will also deliver a simple payload to
+# any endpoint. Currently only active for publish / create
+# commands.
+notify:
+  # Choose a method. Technically this will accept any HTTP
+  # request method, but probably stick to GET or POST
+  method: POST
+  # If this endpoint requires specific headers, set them here
+  # as an array of key: value objects.
+  headers: [{'Content-type': 'application/x-www-form-urlencoded'}]
+  # set the URL endpoint for this call
+  endpoint: https://hooks.slack.com/...
+  # Finally, the content you will be sending in the body.
+  # This data will first be run through Handlebars to parse
+  # any Handlebar expressions. All data housed in the metadata object
+  # is available for use within the expressions.
+  content: ' {{ handlebar-expression }}'
+  # For Slack, follow the following format:
+  # content: '{ "text": "Package *{{ name }}* published to version *{{ dist-tags.latest }}*", "username": "Verdaccio", "icon_emoji": ":package:" }'

--- a/lib/index-api.js
+++ b/lib/index-api.js
@@ -4,6 +4,7 @@ var bodyParser    = require('body-parser')
 var Error         = require('http-errors')
 var Path          = require('path')
 var Middleware    = require('./middleware')
+var Notify        = require('./notify')
 var Utils         = require('./utils')
 var expect_json   = Middleware.expect_json
 var match         = Middleware.match
@@ -14,6 +15,7 @@ var validate_pkg  = Middleware.validate_package
 module.exports = function(config, auth, storage) {
   var app = express.Router()
   var can = Middleware.allow(auth)
+  var notify = Notify.notify;
 
   // validate all of these params as a package name
   // this might be too harsh, so ask if it causes trouble
@@ -336,7 +338,7 @@ module.exports = function(config, auth, storage) {
 
           add_tags(metadata['dist-tags'], function(err) {
             if (err) return next(err)
-
+            notify(metadata, config)
             res.status(201)
             return next({ ok: ok_message })
           })

--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,0 +1,28 @@
+var Handlebars    = require('handlebars')
+var request       = require('request')
+
+module.exports.notify = function(metadata, config) {
+
+  if (config.notify && config.notify.content) {
+
+    var template  = Handlebars.compile(config.notify.content)
+    var content = template( metadata )
+
+    var options = {
+      body: content
+    }
+
+    if ( config.notify.headers ) {
+      options.headers = config.notify.headers;
+    }
+
+    options.method = config.notify.method;
+
+    if(config.notify.endpoint) {
+      options.url = config.notify.endpoint
+    }
+
+    request(options);
+
+  }
+}


### PR DESCRIPTION
Created a lightweight system to provide an external service notification of a create / new publish event. Built primarily with Slack in mind, it is flexible enough to provide that type of notification for any similarity simple web hook service.

(This is a second PR for the same functionality as the first PR wasn't auto-mergable.)