### PR TITLE
Register entry partial even if custom template is provided

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -33,11 +33,12 @@ module.exports = function(config, auth, storage) {
 
   Search.configureStorage(storage)
 
+  Handlebars.registerPartial('entry', fs.readFileSync(require.resolve('./GUI/entry.hbs'), 'utf8'))
+
   if(config.web && config.web.template) {
     var template = Handlebars.compile(fs.readFileSync(config.web.template, 'utf8'));
   }
   else {
-    Handlebars.registerPartial('entry', fs.readFileSync(require.resolve('./GUI/entry.hbs'), 'utf8'))
     var template = Handlebars.compile(fs.readFileSync(require.resolve('./GUI/index.hbs'), 'utf8'))
   }
   app.get('/', function(req, res, next) {
@@ -153,4 +154,3 @@ module.exports = function(config, auth, storage) {
   })
   return app
 }
-


### PR DESCRIPTION
When using a custom index.hbs, if you try to render the entry template (after login) an exception is thrown. It makes sense to register the official entry template so it can be used.