### PR TITLE
Fix #52 binary file missing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 node_modules
 npm-debug.log
-sinopia-*.tgz
 verdaccio-*.tgz
 test-storage*
 /.*

--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,6 @@
 node_modules
 npm-debug.log
 sinopia-*.tgz
-
-###
-bin/**
-!bin/sinopia
+verdaccio-*.tgz
 test-storage*
-
 /.*


### PR DESCRIPTION
Trying to install verdaccio 2.0.0 fails on create binary links, file not found. Removing the restrictions from .npmignore fix the problem