### PR TITLE
rename process to verdaccio

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@ if (process.getuid && process.getuid() === 0) {
   global.console.error("Sinopia doesn't need superuser privileges. Don't run it under root.")
 }
 
-process.title = 'sinopia'
+process.title = 'verdaccio'
 require('es6-shim')
 
 try {


### PR DESCRIPTION
The process still named sinopia, that might be confuse.
```
Juans-MBP:verdaccio jpicado$ ps -ef |grep verdaccio
  501 19904 18047   0  8:34PM ttys001    0:00.00 grep verdaccio
Juans-MBP:verdaccio jpicado$ ps -ef |grep sinopia
  501 19906 18047   0  8:34PM ttys001    0:00.00 grep sinopia
  501 19875 19616   0  8:30PM ttys003    0:01.05 sinopia 
Juans-MBP:verdaccio jpicado$ 
```