### PR TITLE
Prevent the server from crashing if a repo is accessed that the user …

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -51,7 +51,11 @@ module.exports = function(config, auth, storage) {
       async.filterSeries(packages, function(package, cb) {
         auth.allow_access(package.name, req.remote_user, function(err, allowed) {
           setImmediate(function () {
-            cb(err, allowed)
+            if (err) {
+              cb(null, false);
+            } else {
+              cb(err, allowed)
+            }
           })
         })
       }, function(err, packages) {


### PR DESCRIPTION
…does not have access to

Currently if there are any repos that require logged in permissions, the web view will crash if the user was not already authenticated.

See #56 