### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ EXPOSE 4873
 
 VOLUME ["/verdaccio/conf", "/verdaccio/storage"]
 
-CMD ["/usr/src/app/bin/sinopia", "--config", "/verdaccio/conf/config.yaml", "--listen", "0.0.0.0:4873"]
+CMD ["/usr/src/app/bin/verdaccio", "--config", "/verdaccio/conf/config.yaml", "--listen", "0.0.0.0:4873"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 FROM node:6.1.0-onbuild
 
-RUN adduser --disabled-password --gecos "" verdaccio && \
-  mkdir -p /verdaccio/storage /verdaccio/conf && \
-  chown -R verdaccio.verdaccio /verdaccio
+RUN mkdir -p /verdaccio/storage /verdaccio/conf
 
-USER verdaccio
 WORKDIR /verdaccio
 
 ADD conf/docker.yaml /verdaccio/conf/config.yaml


### PR DESCRIPTION
- container was failing to start, updated the process name in Dockerfile
- container process was failing to write files in mounted volumes when using -v as in the README.md example; no need to run the contained process as non-root