### PR TITLE
Load the plugin relative to the path where verdaccio is installed vs.…

### DIFF
--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -16,7 +16,7 @@ function load_plugins(config, plugin_configs, params, sanity_check) {
     var plugin
 
     // try local plugins first
-    plugin = try_load(Path.resolve('./lib/plugins', p))
+    plugin = try_load(Path.resolve(__dirname, 'plugins', p))
 
     // npm package
     if (plugin === null && p.match(/^[^\.\/]/)) {


### PR DESCRIPTION
… from where it is run. Allows having installed verdaccio globally

We plan to have verdaccio installed globally ("npm -g i verdaccio") and have several users run their own instances. This was possible with sinopia since it used the "sinopia-htpasswd" plugin as a node_module. With verdaccio, the plugin is looked for in the path from where verdaccio is run. This is fine as long as one doesn't install it globally and it runs from another path.