### PR TITLE
Add headers

### DIFF
--- a/conf/full.yaml
+++ b/conf/full.yaml
@@ -51,6 +51,11 @@ uplinks:
     # timeouts are defined in the same way as nginx, see:
     # http://wiki.nginx.org/ConfigNotation
 
+    # add/override HTTP headers sent to the uplink server
+    # this allows for HTTP Basic auth for example:
+    #headers:
+    #  authorization: "Basic YourBase64EncodedCredentials=="
+
 packages:
   # uncomment this for packages with "local-" prefix to be available
   # for admin only, it's a recommended way of handling private packages

--- a/lib/up-storage.js
+++ b/lib/up-storage.js
@@ -116,6 +116,11 @@ Storage.prototype.request = function(options, cb) {
   headers['User-Agent']      = headers['User-Agent']      || this.userAgent
   this._add_proxy_headers(options.req, headers)
 
+  // add/override headers specified in the config
+  for (var key in this.config.headers) {
+    headers[key] = this.config.headers[key]
+  }
+
   var method = options.method   || 'GET'
   var uri    = options.uri_full || (this.config.url + options.uri)
 


### PR DESCRIPTION
Allow adding/overriding headers for uplinks via config. This allows stuff like using HTTP Basic Authentication for uplinks or specifying the User-Agent/Via.
Also documents this in conf/full.yaml