### PR TITLE
Problem with docker.yaml

### DIFF
--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -11,7 +11,7 @@ storage: /verdaccio/storage
 
 auth:
   htpasswd:
-    file: /verdaccio/config/htpasswd
+    file: /verdaccio/conf/htpasswd
     # Maximum amount of users allowed to register, defaults to "+inf".
     # You can set this to -1 to disable registration.
     #max_users: 1000


### PR DESCRIPTION
There is a problem with the docker.yaml file.

auth:
   htpasswd:
     file:/verdaccio/config/htpasswd

The file property should point to /verdaccio/conf/htpasswd because folder /verdaccio/config dosen't exist and therefore dosen't let to create users.

Thank you for working on this great tool.

Regards
