### PR TITLE
[GH-88] rename to Verdaccio instead of Sinopia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 npm-debug.log
-sinopia-*.tgz
+verdaccio-*.tgz
 .DS_Store
 
 ###
-!bin/sinopia
+!bin/verdaccio
 test-storage*
 
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - '0.10'
   - '0.12'
-  - '1'
-  - '2'
+  - '4'
+  - '6'
   - 'iojs'
 sudo: false
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
-  - '0.12'
   - '4'
   - '6'
-  - 'iojs'
+  - '7'
 sudo: false
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 `verdaccio` is a fork of `sinopia`. It aims to keep backwards compatibility with `sinopia`, while keeping up with npm changes.
 
-`sinopia` - a private/caching npm repository server
+`verdaccio` - a private/caching npm repository server
 
 [![travis badge](http://img.shields.io/travis/verdaccio/verdaccio.svg)](https://travis-ci.org/verdaccio/verdaccio)
 
@@ -69,11 +69,11 @@ docker run -it --rm --name verdaccio -p 4873:4873 \
 
 ### Chef
 
-A Sinopia Chef cookbook [is available at Opscode community](http://community.opscode.com/cookbooks/sinopia) source: https://github.com/BarthV/sinopia-cookbook
+The original Sinopia Chef cookbook [is available at Opscode community](http://community.opscode.com/cookbooks/sinopia) source: https://github.com/BarthV/sinopia-cookbook
 
 ### Puppet
 
-A Sinopia puppet module [is available at puppet forge](http://forge.puppetlabs.com/saheba/sinopia) source: https://github.com/saheba/puppet-sinopia
+The original Sinopia puppet module [is available at puppet forge](http://forge.puppetlabs.com/saheba/sinopia) source: https://github.com/saheba/puppet-sinopia
 
 ## Configuration
 
@@ -154,4 +154,3 @@ If you want to use a database instead, ask for it, we'll come up with some kind 
 - [gemfury](http://www.gemfury.com/l/npm-registry) and others - those are closed-source cloud services, and I'm not in a mood to trust my private code to somebody (security through obscurity yeah!)
 - npm-registry-proxy, npm-delegate, npm-proxy - those are just proxies...
 - Is there something else?
-

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -3,7 +3,7 @@
 # so don't use it on production systems.
 #
 # Look here for more config file examples:
-# https://github.com/rlidwka/sinopia/tree/master/conf
+# https://github.com/verdaccio/verdaccio/tree/master/conf
 #
 
 # path to a directory with all packages
@@ -46,5 +46,4 @@ packages:
 # log settings
 logs:
   - {type: stdout, format: pretty, level: http}
-  #- {type: file, path: sinopia.log, level: info}
-
+  #- {type: file, path: verdaccio.log, level: info}

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ require('es6-shim')
 module.exports = require('./lib')
 
 /**package
-{ "name": "sinopia",
+{ "name": "verdaccio",
   "version": "0.0.0",
   "dependencies": {"js-yaml": "*"},
   "scripts": {"postinstall": "js-yaml package.yaml > package.json ; npm install"}

--- a/lib/GUI/css/styles.less
+++ b/lib/GUI/css/styles.less
@@ -27,7 +27,7 @@
     .npm-logo {
       width: 79px;
       height: @mainHeaderHeight;
-      // https://example.org/sinopia/-/static/../../-/logo
+      // https://example.org/verdaccio/-/static/../../-/logo
       background-image: url( ../../-/logo );
       background-repeat: no-repeat;
       background-position: center center;

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -30,7 +30,7 @@ function Auth(config) {
   })
 
   self.plugins.unshift({
-    sinopia_version: '1.1.0',
+    verdaccio_version: '1.1.0',
 
     authenticate: function(user, password, cb) {
       if (config.users != null
@@ -377,4 +377,3 @@ function AuthenticatedUser(name, groups) {
     real_groups: groups,
   }
 }
-

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,7 +3,7 @@
 /*eslint no-sync:0*/
 
 if (process.getuid && process.getuid() === 0) {
-  global.console.error("Sinopia doesn't need superuser privileges. Don't run it under root.")
+  global.console.error("Verdaccio doesn't need superuser privileges. Don't run it under root.")
 }
 
 process.title = 'verdaccio'
@@ -39,7 +39,7 @@ commander
   .parse(process.argv)
 
 if (commander.args.length == 1 && !commander.config) {
-  // handling "sinopia [config]" case if "-c" is missing in commandline
+  // handling "verdaccio [config]" case if "-c" is missing in commandline
   commander.config = commander.args.pop()
 }
 
@@ -115,14 +115,14 @@ function afterConfigLoad() {
           '',
           // commands are borrowed from node.js docs
           'To quickly create self-signed certificate, use:',
-          ' $ openssl genrsa -out ' + conf_path('sinopia-key.pem') + ' 2048',
-          ' $ openssl req -new -sha256 -key ' + conf_path('sinopia-key.pem') + ' -out ' + conf_path('sinopia-csr.pem'),
-          ' $ openssl x509 -req -in ' + conf_path('sinopia-csr.pem') + ' -signkey ' + conf_path('sinopia-key.pem') + ' -out ' + conf_path('sinopia-cert.pem'),
+          ' $ openssl genrsa -out ' + conf_path('verdaccio-key.pem') + ' 2048',
+          ' $ openssl req -new -sha256 -key ' + conf_path('verdaccio-key.pem') + ' -out ' + conf_path('verdaccio-csr.pem'),
+          ' $ openssl x509 -req -in ' + conf_path('verdaccio-csr.pem') + ' -signkey ' + conf_path('verdaccio-key.pem') + ' -out ' + conf_path('verdaccio-cert.pem'),
           '',
           'And then add to config file (' + conf_path() + '):',
           '  https:',
-          '    key: sinopia-key.pem',
-          '    cert: sinopia-cert.pem',
+          '    key: verdaccio-key.pem',
+          '    cert: verdaccio-cert.pem',
         ].join('\n'))
         process.exit(2)
       }
@@ -168,7 +168,7 @@ function afterConfigLoad() {
 
   // undocumented stuff for tests
   if (typeof(process.send) === 'function') {
-    process.send({ sinopia_started: true })
+    process.send({ verdaccio_started: true })
   }
 }
 
@@ -177,4 +177,3 @@ process.on('uncaughtException', function(err) {
                      , 'uncaught exception, please report this\n@{err.stack}' )
   process.exit(255)
 })
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,7 +37,7 @@ function Config(config) {
   self.localList = LocalData(
     Path.join(
       Path.resolve(Path.dirname(self.self_path || ''), self.storage),
-      '.sinopia-db.json'
+      '.verdaccio-db.json'
     )
   )
   if (!self.secret) {
@@ -193,4 +193,3 @@ module.exports.parse_interval = function(interval) {
   })
   return result
 }
-

--- a/lib/config.js
+++ b/lib/config.js
@@ -37,7 +37,7 @@ function Config(config) {
   self.localList = LocalData(
     Path.join(
       Path.resolve(Path.dirname(self.self_path || ''), self.storage),
-      '.verdaccio-db.json'
+      '.sinopia-db.json'
     )
   )
   if (!self.secret) {

--- a/lib/local-storage.js
+++ b/lib/local-storage.js
@@ -158,16 +158,16 @@ Storage.prototype.update_versions = function(name, newdata, callback) {
               sha: verdata.dist.shasum,
             }
 
-            if (verdata._sinopia_uplink) {
+            if (verdata._verdaccio_uplink) {
               // if we got this information from a known registry,
               // use the same protocol for the tarball
               //
               // see https://github.com/rlidwka/sinopia/issues/166
               var tarball_url = URL.parse(hash.url)
-              var uplink_url  = URL.parse(self.config.uplinks[verdata._sinopia_uplink].url)
+              var uplink_url  = URL.parse(self.config.uplinks[verdata._verdaccio_uplink].url)
               if (uplink_url.host === tarball_url.host) {
                 tarball_url.protocol = uplink_url.protocol
-                hash.registry = verdata._sinopia_uplink
+                hash.registry = verdata._verdaccio_uplink
                 hash.url = URL.format(tarball_url)
               }
             }
@@ -695,4 +695,3 @@ var Path_Wrapper = (function() {
 })()
 
 module.exports = Storage
-

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -67,7 +67,7 @@ module.exports.setup = function(logs) {
   })
 
   var logger = new Logger({
-    name: 'sinopia',
+    name: 'verdaccio',
     streams: streams,
     serializers: {
       err: Logger.stdSerializers.err,
@@ -155,4 +155,3 @@ function print(type, msg, obj, colors) {
     return ' ' + (pad(type)) + ' ' + sub + ' ' + finalmsg
   }
 }
-

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -110,7 +110,7 @@ module.exports.final = function(body, req, res, next) {
 
       if (typeof(body) === 'object' && body != null) {
         if (typeof(body.error) === 'string') {
-          res._sinopia_error = body.error
+          res._verdaccio_error = body.error
         }
         body = JSON.stringify(body, undefined, '  ') + '\n'
       }
@@ -123,7 +123,7 @@ module.exports.final = function(body, req, res, next) {
       // send(null), send(204), etc.
     }
   } catch(err) {
-    // if sinopia sends headers first, and then calls res.send()
+    // if verdaccio sends headers first, and then calls res.send()
     // as an error handler, we can't report error properly,
     // and should just close socket
     if (err.message.match(/set headers after they are sent/)) {
@@ -168,7 +168,7 @@ module.exports.log = function(req, res, next) {
 
   function log() {
     var message = "@{status}, user: @{user}, req: '@{request.method} @{request.url}'"
-    if (res._sinopia_error) {
+    if (res._verdaccio_error) {
       message += ', error: @{!error}'
     } else {
       message += ', bytes: @{bytes.in}/@{bytes.out}'
@@ -180,7 +180,7 @@ module.exports.log = function(req, res, next) {
       level   : 35, // http
       user    : req.remote_user && req.remote_user.name,
       status  : res.statusCode,
-      error   : res._sinopia_error,
+      error   : res._verdaccio_error,
       bytes   : {
         in  : bytesin,
         out : bytesout,
@@ -201,4 +201,3 @@ module.exports.log = function(req, res, next) {
   }
   next()
 }
-

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -20,7 +20,7 @@ function load_plugins(config, plugin_configs, params, sanity_check) {
 
     // npm package
     if (plugin === null && p.match(/^[^\.\/]/)) {
-      plugin = try_load('sinopia-' + p)
+      plugin = try_load('verdaccio-' + p)
     }
 
     if (plugin === null) {
@@ -33,7 +33,7 @@ function load_plugins(config, plugin_configs, params, sanity_check) {
     }
 
     if (plugin === null) {
-      throw Error('"' + p + '" plugin not found\ntry "npm install sinopia-' + p + '"')
+      throw Error('"' + p + '" plugin not found\ntry "npm install verdaccio-' + p + '"')
     }
 
     if (typeof(plugin) !== 'function')

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -21,6 +21,8 @@ function load_plugins(config, plugin_configs, params, sanity_check) {
     // npm package
     if (plugin === null && p.match(/^[^\.\/]/)) {
       plugin = try_load('verdaccio-' + p)
+      // compatibility for old sinopia plugins
+      plugin = try_load('sinopia-' + p)
     }
 
     if (plugin === null) {

--- a/lib/plugins/htpasswd/index.js
+++ b/lib/plugins/htpasswd/index.js
@@ -11,23 +11,23 @@ function HTPasswd(config, stuff) {
   // config for this module
   self._config = config
 
-  // sinopia logger
+  // verdaccio logger
   self._logger = stuff.logger
 
-  // sinopia main config object
-  self._sinopia_config = stuff.config
+  // verdaccio main config object
+  self._verdaccio_config = stuff.config
 
-  // all this "sinopia_config" stuff is for b/w compatibility only
+  // all this "verdaccio_config" stuff is for b/w compatibility only
   self._maxusers = self._config.max_users
-  if (!self._maxusers) self._maxusers = self._sinopia_config.max_users
+  if (!self._maxusers) self._maxusers = self._verdaccio_config.max_users
   // set maxusers to Infinity if not specified
   if (!self._maxusers) self._maxusers = Infinity
 
   self._last_time = null
   var file = self._config.file
-  if (!file) file = self._sinopia_config.users_file
+  if (!file) file = self._verdaccio_config.users_file
   if (!file) throw new Error('should specify "file" in config')
-  self._path = Path.resolve(Path.dirname(self._sinopia_config.self_path), file)
+  self._path = Path.resolve(Path.dirname(self._verdaccio_config.self_path), file)
   return self
 }
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -458,7 +458,7 @@ Storage.prototype._sync_package_with_uplinks = function(name, pkginfo, options, 
       for (var i in up_res.versions) {
         // this won't be serialized to json,
         // kinda like an ES6 Symbol
-        Object.defineProperty(up_res.versions[i], '_sinopia_uplink', {
+        Object.defineProperty(up_res.versions[i], '_verdaccio_uplink', {
           value        : up.upname,
           enumerable   : false,
           configurable : false,
@@ -519,4 +519,3 @@ Storage._merge_versions = function(local, up, config) {
     }
   }
 }
-

--- a/lib/up-storage.js
+++ b/lib/up-storage.js
@@ -199,7 +199,7 @@ Storage.prototype.request = function(options, cb) {
 
   var status_called = false
   req.on('response', function(res) {
-    if (!req._sinopia_aborted && !status_called) {
+    if (!req._verdaccio_aborted && !status_called) {
       status_called = true
       self.status_check(true)
     }
@@ -216,7 +216,7 @@ Storage.prototype.request = function(options, cb) {
     }
   })
   req.on('error', function(_err) {
-    if (!req._sinopia_aborted && !status_called) {
+    if (!req._verdaccio_aborted && !status_called) {
       status_called = true
       self.status_check(false)
     }
@@ -390,6 +390,5 @@ Storage.prototype._add_proxy_headers = function(req, headers) {
     ? req.headers['via'] + ', '
     : ''
 
-  headers['Via'] += '1.1 ' + this.server_id + ' (Sinopia)'
+  headers['Via'] += '1.1 ' + this.server_id + ' (Verdaccio)'
 }
-

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,7 +73,7 @@ module.exports.filter_tarball_urls = function(pkg, req, config) {
   for (var ver in pkg.versions) {
     var dist = pkg.versions[ver].dist
     if (dist != null && dist.tarball != null) {
-      //dist.__sinopia_orig_tarball = dist.tarball
+      //dist.__verdaccio_orig_tarball = dist.tarball
       dist.tarball = filter(dist.tarball)
     }
   }

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 All tests are split in three folders:
 
  - `unit` - Tests that cover functions that transform data in an non-trivial way. These tests simply `require()` a few files and run code in there, so they are very fast.
- - `functional` - Tests that launch a sinopia instance and perform a series of requests to it over http. They are slower than unit tests.
- - `integration` - Tests that launch a sinopia instance and do requests to it using npm. They are really slow and can hit a real npm registry.
+ - `functional` - Tests that launch a verdaccio instance and perform a series of requests to it over http. They are slower than unit tests.
+ - `integration` - Tests that launch a verdaccio instance and do requests to it using npm. They are really slow and can hit a real npm registry.
 
 Unit and functional tests are executed automatically by running `npm test` from the project's root directory. Integration tests are supposed to be executed manually from time to time.

--- a/test/functional/lib/startup.js
+++ b/test/functional/lib/startup.js
@@ -23,7 +23,7 @@ module.exports.start = function start(dir, conf, cb) {
     )
     forks.push(f)
     f.on('message', function(msg) {
-      if ('sinopia_started' in msg) {
+      if ('verdaccio_started' in msg) {
         cb(), cb = function(){}
       }
     })
@@ -38,4 +38,3 @@ process.on('exit', function() {
   if (forks[0]) forks[0].kill()
   if (forks[1]) forks[1].kill()
 })
-

--- a/test/functional/plugins/authenticate.js
+++ b/test/functional/plugins/authenticate.js
@@ -8,7 +8,7 @@ function Plugin(config, stuff) {
 }
 
 // plugin is expected to be compatible with...
-Plugin.prototype.sinopia_version = '1.1.0'
+Plugin.prototype.verdaccio_version = '1.1.0'
 
 Plugin.prototype.authenticate = function(user, password, cb) {
   var self = this
@@ -23,4 +23,3 @@ Plugin.prototype.authenticate = function(user, password, cb) {
   }
   return cb(null, [ user ])
 }
-

--- a/test/functional/plugins/authorize.js
+++ b/test/functional/plugins/authorize.js
@@ -8,7 +8,7 @@ function Plugin(config, stuff) {
 }
 
 // plugin is expected to be compatible with...
-Plugin.prototype.sinopia_version = '1.1.0'
+Plugin.prototype.verdaccio_version = '1.1.0'
 
 Plugin.prototype.allow_access = function(user, package, cb) {
   var self = this
@@ -28,4 +28,3 @@ Plugin.prototype.allow_access = function(user, package, cb) {
   }
   return cb(null, true)
 }
-

--- a/test/integration/config.yaml
+++ b/test/integration/config.yaml
@@ -1,4 +1,4 @@
-storage: ./.sinopia_test_env/test-storage
+storage: ./.verdaccio_test_env/test-storage
 
 users:
   test:
@@ -22,4 +22,3 @@ packages:
     allow_publish: all
 
 listen: 55501
-

--- a/test/integration/test.pl
+++ b/test/integration/test.pl
@@ -6,8 +6,8 @@ use strict;
 # setting up working environment && chdir there
 use Cwd 'abs_path';
 use File::Basename;
-$ENV{HOME} = dirname(abs_path( __FILE__ )) . '/.sinopia_test_env';
-system('rm -rf .sinopia_test_env ; mkdir .sinopia_test_env') and quit('fail');
+$ENV{HOME} = dirname(abs_path( __FILE__ )) . '/.verdaccio_test_env';
+system('rm -rf .verdaccio_test_env ; mkdir .verdaccio_test_env') and quit('fail');
 chdir $ENV{HOME};
 
 use Data::Dumper;
@@ -18,16 +18,16 @@ sub quit {
 	exec("kill $pid ; exit 1");
 }
 
-# run sinopia in a child process
+# run verdaccio in a child process
 if (($pid = fork()) == 0) {
-	exec "../../../bin/sinopia ../config.yaml";
+	exec "../../../bin/verdaccio ../config.yaml";
 	die "exec failed";
 }
 
 system('mkdir node_modules') and quit('fail');
-system('npm set sinopia_test_config 12345') and quit('fail');
+system('npm set verdaccio_test_config 12345') and quit('fail');
 
-if (`cat .npmrc` !~ /sinopia_test_config/) {
+if (`cat .npmrc` !~ /verdaccio_test_config/) {
 	quit "npm is using wrong config";
 }
 
@@ -37,14 +37,13 @@ system(q{/bin/echo -e 'test\ntest\ns@s.s\n' | npm adduser}) and quit('fail');
 system('npm install jju') and quit('fail');
 (`node -e 'console.log(require("jju").parse("{qwerty:123}").qwerty+456)'` =~ /579/) or quit('fail');
 
-system('npm publish ../sinopia-test-1.2.3.tgz') and quit('fail');
-system('npm tag sinopia-test@1.2.3 meow') and quit('fail');
-system('npm install sinopia-test@meow') and quit('fail');
+system('npm publish ../verdaccio-test-1.2.3.tgz') and quit('fail');
+system('npm tag verdaccio-test@1.2.3 meow') and quit('fail');
+system('npm install verdaccio-test@meow') and quit('fail');
 
-(`node -e 'require("sinopia-test")'` =~ /w==w/) or quit('fail');
+(`node -e 'require("verdaccio-test")'` =~ /w==w/) or quit('fail');
 
 quit("
 ==================================================================
 All tests seem to be executed successfully, nothing is broken yet.
 ==================================================================");
-

--- a/test/unit/toplevel.js
+++ b/test/unit/toplevel.js
@@ -2,7 +2,7 @@ var assert  = require('assert')
 var express = require('express')
 var request = require('request')
 var rimraf  = require('rimraf')
-var sinopia = require('../../')
+var verdaccio = require('../../')
 
 var config = {
   storage: __dirname + '/test-storage',
@@ -25,7 +25,7 @@ describe('toplevel', function() {
 
   before(function(done) {
     var app = express()
-    app.use(sinopia(config))
+    app.use(verdaccio(config))
 
     var server = require('http').createServer(app)
     server.listen(0, function() {

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -3,7 +3,7 @@ var validate = require('../../lib/utils').validate_name
 
 describe('Validate', function() {
   it('good ones', function() {
-    assert( validate('sinopia') )
+    assert( validate('verdaccio') )
     assert( validate('some.weird.package-zzz') )
     assert( validate('old-package@0.1.2.tgz') )
   })


### PR DESCRIPTION
Based on issue #88

__CHANGES:__

* Aside from a few locations (such as links to issues & the history), 'sinopia' has been renamed to  'verdaccio'.

* The [.travis.yml](https://github.com/kgrubb/verdaccio/blob/master/.travis.yml) has been updated to run on officially supported node versions (I can switch this back if needed).