### PR TITLE
Prevent logging of user and password

### DIFF
--- a/lib/plugins/htpasswd/index.js
+++ b/lib/plugins/htpasswd/index.js
@@ -100,8 +100,6 @@ HTPasswd.prototype.adduser = function (user, password, real_cb) {
     if (s_err) return cb(s_err)
 
     try {
-      console.log('body = utils.add_user_to_htpasswd(body, user, password)')
-      console.log(user, password)
       body = utils.add_user_to_htpasswd(body, user, password)
     } catch (err) {
       return cb(err)


### PR DESCRIPTION
This otherwise logs the user's full username and password in plaintext on `npm adduser`.