### PR TITLE
Better Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
-FROM node:6.1.0-onbuild
+FROM node:alpine
+
+ENV appdir /usr/local/app
+
+RUN mkdir -p $appdir
+WORKDIR  $appdir
+COPY . $appdir
+RUN npm install
 
 RUN mkdir -p /verdaccio/storage /verdaccio/conf
-
-WORKDIR /verdaccio
-
 ADD conf/docker.yaml /verdaccio/conf/config.yaml
+
+RUN addgroup -S verdaccio && adduser -S -g verdaccio verdaccio && \
+chown -R verdaccio:verdaccio $appdir && \
+chown -R verdaccio:verdaccio /verdaccio
+
+USER verdaccio
 
 EXPOSE 4873
 
-VOLUME ["/verdaccio/conf", "/verdaccio/storage"]
+VOLUME ["/verdaccio"]
 
-CMD ["/usr/src/app/bin/verdaccio", "--config", "/verdaccio/conf/config.yaml", "--listen", "0.0.0.0:4873"]
+CMD ["sh", "-c", "${appdir}/bin/verdaccio --config /verdaccio/conf/config.yaml --listen 0.0.0.0:4873"]

--- a/README.md
+++ b/README.md
@@ -49,22 +49,32 @@ Now you can navigate to [http://localhost:4873/](http://localhost:4873/) where y
 
 ### Docker
 
-To use the pre-built docker image:
+#### To use the pre-built docker image:
 
 `docker pull verdaccio/verdaccio`
 
-To build your own image:
+#### To use your own image:
 
-`docker build -t verdaccio .`
+1. Get the latest version of [docker-compose](https://github.com/docker/compose).
+2. Build and run the container: 
 
-To run the docker container:
-
+```bash
+$ docker-compose up --build
 ```
-docker run -it --rm --name verdaccio -p 4873:4873 \
-  -v /<path to verdaccio directory>/conf:/verdaccio/conf \
-  -v /<path to verdaccio directory>/storage:/verdaccio/storage \
-  -v /<path to verdaccio directory>/local_storage:/verdaccio/local_storage \
-  verdaccio
+
+Docker will generate a named volume in which to store persistent application data. You can use `docker inspect` or `docker volume inspect` to reveal the physical location of the volume and edit the configuration, such as:
+ 
+```bash
+$ docker volume inspect verdaccio_verdaccio
+[
+    {
+        "Name": "verdaccio_verdaccio",
+        "Driver": "local",
+        "Mountpoint": "/var/lib/docker/volumes/verdaccio_verdaccio/_data",
+        "Labels": null,
+        "Scope": "local"
+    }
+]
 ```
 
 ### Chef

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  verdaccio:
+    build: .
+    container_name: verdaccio
+    ports:
+      - "4873:4873"
+    volumes:
+       - verdaccio:/verdaccio
+volumes:
+  verdaccio:
+    driver: local


### PR DESCRIPTION
Improves the Docker experience by leveraging Data volumes, dropping root permissions, using a more lightweight and secure base image (node:alpine), and moving unwieldy run arguments into a docker-compose file. The net result is you can now issue a single command `docker-compose up --build` to have a fully-functional verdaccio instance running.