### PR TITLE
Allow htpasswd-created users to log in

### DIFF
--- a/lib/plugins/htpasswd/utils.js
+++ b/lib/plugins/htpasswd/utils.js
@@ -1,5 +1,6 @@
 var crypto = require('crypto')
 var crypt3 = require('./crypt3')
+var md5 = require('apache-md5')
 var locker = require('../../file-locking')
 
 // this function neither unlocks file nor closes it
@@ -32,10 +33,12 @@ function verify_password(user, passwd, hash) {
     return passwd === hash.substr(7)
   } else if (hash.indexOf('{SHA}') === 0) {
     return crypto.createHash('sha1').update(passwd, 'binary').digest('base64') === hash.substr(5)
-  } else if (crypt3) {
-    return crypt3(passwd, hash) === hash
   } else {
-    return false
+    return (
+      // for backwards compatibility, first check md5 then check crypt3
+      md5(passwd, hash) === hash ||
+      crypt3(passwd, hash) === hash
+    )
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.1.1",
+    "apache-md5": "^1.1.2",
     "async": "^2.0.1",
     "body-parser": "^1.15.0",
     "bunyan": "^1.8.0",

--- a/test/functional/adduser.js
+++ b/test/functional/adduser.js
@@ -1,4 +1,6 @@
 var Server = require('./lib/server')
+var fs = require('fs')
+var path = require('path')
 
 module.exports = function() {
   var server = new Server('http://localhost:55551/')
@@ -24,6 +26,22 @@ module.exports = function() {
       return server.auth(String(Math.random()), String(Math.random()))
                .status(409)
                .body_error(/maximum amount of users reached/)
+    })
+  })
+
+  describe('adduser created with htpasswd', function() {
+    var user = 'preexisting'
+    var pass = 'preexisting'
+    before(function () {
+      return fs.appendFileSync(
+        path.join(__dirname, 'test-storage', '.htpasswd'),
+        'preexisting:$apr1$4YSboUa9$yVKjE7.PxIOuK3M4D7VjX.'
+      )
+    })
+    it('should log in', function () {
+      return server.auth(user, pass)
+               .status(201)
+               .body_ok(/you are authenticated as/)
     })
   })
 }


### PR DESCRIPTION
Right now, htpasswd's default (eg. ```htpasswd .htpasswd myuser```) seems to be md5. Verdaccio tries to authenticate these using crypt3 - and thus users created in this method cannot log in.

This PR fixes it and maintains backwards compatibility by trying to decrypt with either crypt3 or md5.