### PR TITLE
optional scope in the readme package name.

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -150,8 +150,10 @@ module.exports = function(config, auth, storage) {
     }
   })
 
-  app.get('/-/readme/:package/:version?', can('access'), function(req, res, next) {
-    storage.get_package(req.params.package, {req: req}, function(err, info) {
+  app.get('/-/readme(/@:scope?)?/:package/:version?', can('access'), function(req, res, next) {
+    var packageName = req.params.package;
+    if (req.params.scope) packageName = "@"+ req.params.scope + "/" + packageName;
+    storage.get_package(packageName, {req: req}, function(err, info) {
       if (err) return next(err)
       next( renderReadme(info.readme || 'ERROR: No README data found!') )
     })


### PR DESCRIPTION
When trying to access readme's under private local scopes "@scopename/test" it fails to load the readme because the express.js route can't handle slash's in it's parameters. Added another parameter to the route to allow for the optional scope.