### PR TITLE
Allow configuring a tagline that is displayed on the webpage between …

### DIFF
--- a/conf/full.yaml
+++ b/conf/full.yaml
@@ -20,6 +20,9 @@ web:
   title: Verdaccio
   # logo: logo.png
   # template: custom.hbs
+  # tagline: "Some <b>HTML</b> enabled tagline that sits between the actual \
+#header and the list of packages. You can even add <a \
+#href=\"https://github.com\">links</a>!"
 
 auth:
   htpasswd:

--- a/lib/GUI/index.hbs
+++ b/lib/GUI/index.hbs
@@ -59,6 +59,13 @@
         <code class="white no-bg">{{ baseUrl }}</code><br>
       </header>
       <header class="packages-header container">
+        {{#if tagline}}
+        <div class="row">
+          <div class="col-md-12">
+            {{{tagline}}}
+          </div>
+        </div>
+        {{/if}}
         <div class="row">
           <div class="col-md-5 hidden-xs hidden-sm">
             <h2 class="title">Available Packages</h2>

--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -72,6 +72,7 @@ module.exports = function(config, auth, storage) {
 
         next(template({
           name:       config.web && config.web.title ? config.web.title : 'Verdaccio',
+          tagline:    config.web && config.web.tagline ? config.web.tagline : '',
           packages:   packages,
           baseUrl:    base,
           username:   req.remote_user.name,


### PR DESCRIPTION
…the header and the list of packages.

We use this to display a link where the npm setup is described.