### PR TITLE
Increase verbose on notify request, helps #144

### DIFF
--- a/lib/notify.js
+++ b/lib/notify.js
@@ -1,5 +1,6 @@
 var Handlebars    = require('handlebars')
 var request       = require('request')
+var Logger        = require('./logger')
 
 module.exports.notify = function(metadata, config) {
 
@@ -18,11 +19,20 @@ module.exports.notify = function(metadata, config) {
 
     options.method = config.notify.method;
 
-    if(config.notify.endpoint) {
+    if (config.notify.endpoint) {
       options.url = config.notify.endpoint
     }
 
-    request(options);
+    request(options, function(err, response, body) {
+      if (err) {
+        Logger.logger.error( { err: err }, ' notify error: @{err.message}' );
+      } else {
+        Logger.logger.info({ content: content}, 'A notification has been shipped: @{content}')
+        if (body) {
+          Logger.logger.debug( { body: body }, ' body: @{body}' );
+        }
+      }
+    });
 
   }
 }


### PR DESCRIPTION
There was a lack of feedback on notifications. This commit add a bit of verbose if all goes well.
<img width="1054" alt="screen shot 2017-04-11 at 9 47 20 pm" src="https://cloud.githubusercontent.com/assets/558752/24928280/32ca80a0-1f02-11e7-9e4c-6f6da950039b.png">
and a bit more for additional information 
<img width="1080" alt="screen shot 2017-04-11 at 9 48 21 pm" src="https://cloud.githubusercontent.com/assets/558752/24928326/5fe07072-1f02-11e7-8dac-6688b3bd8fd3.png">
I tested this against the hipchat REST API, perhaps needs an improvement for different sort of  integrations.

