### PR TITLE
#144 Add fallback support to previous config files

### DIFF
--- a/lib/notify.js
+++ b/lib/notify.js
@@ -13,7 +13,18 @@ module.exports.notify = function(metadata, config) {
       body: content
     }
 
-    if ( config.notify.headers ) {
+    // provides fallback support, it's accept an Object {} and Array of {}
+    if ( config.notify.headers && Array.isArray(config.notify.headers) ) {
+      var header = {};
+      config.notify.headers.map(function(item) {
+        if (Object.is(item, item)) {
+          for (var key in item) {
+            header[key] = item[key];
+          }
+        }
+      });
+      options.headers = header;
+    } else if (Object.is(config.notify.headers, config.notify.headers)) {
       options.headers = config.notify.headers;
     }
 


### PR DESCRIPTION
Fix #144 

Instead update full.yaml file, it's provide support for array of headers and simple literal object.