### PR TITLE
fixed publish fail in YARN

### DIFF
--- a/lib/index-api.js
+++ b/lib/index-api.js
@@ -352,7 +352,7 @@ module.exports = function(config, auth, storage) {
       if (metadata._attachments == null) {
         if (err) return next(err);
         res.status(201);
-        return next({ok: ok_message});
+        return next({ok: ok_message,success:true});
       }
 
       // npm-registry-client 0.3+ embeds tarball into the json upload
@@ -384,7 +384,7 @@ module.exports = function(config, auth, storage) {
             if (err) return next(err);
             notify(metadata, config);
             res.status(201);
-            return next({ok: ok_message});
+            return next({ok: ok_message,success:true});
           });
         });
       });


### PR DESCRIPTION
when using with yarn v0.23.2, it check for a ```success``` property from the response of PUT request.
