### PR TITLE
Add additional requirement to output message

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -134,7 +134,7 @@ function afterConfigLoad() {
           '  https:',
           '    key: verdaccio-key.pem',
           '    cert: verdaccio-cert.pem',
-          '    ca: verdaccio-cert.pem'
+          '    ca: verdaccio-cert.pem',
         ].join('\n'));
         process.exit(2);
       }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -134,6 +134,7 @@ function afterConfigLoad() {
           '  https:',
           '    key: verdaccio-key.pem',
           '    cert: verdaccio-cert.pem',
+          '    ca: verdaccio-cert.pem'
         ].join('\n'));
         process.exit(2);
       }


### PR DESCRIPTION
With out the ca parameter in the https config section the server fails to start with a 500 error and complains that path must be a string.