### PR TITLE
Allow url_prefix to be only the path

### DIFF
--- a/SERVER.md
+++ b/SERVER.md
@@ -28,6 +28,12 @@ url_prefix: 'https://your-domain:8888'
 # or
 url_prefix: 'https://your-domain:8888/your-path'
 ```
+
+If you do not know the protocol and host, you can define only subpath as `url_prefix`. Full URL will be constructed from the request.
+```yaml
+url_prefix: '/your-path'
+```
+
 > Nginx or Apache configure? Please check out Wiki ;-)
 
 ## Keeping verdaccio running forever

--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -9,6 +9,7 @@ let Handlebars = require('handlebars');
 let renderReadme = require('render-readme');
 let Search = require('./search');
 let Middleware = require('./middleware');
+let Utils = require('./utils');
 let match = Middleware.match;
 let validate_name = Middleware.validate_name;
 let validate_pkg = Middleware.validate_package;
@@ -43,9 +44,7 @@ module.exports = function(config, auth, storage) {
     template = Handlebars.compile(fs.readFileSync(require.resolve('./GUI/index.hbs'), 'utf8'));
   }
   app.get('/', function(req, res, next) {
-    let base = config.url_prefix
-             ? config.url_prefix.replace(/\/$/, '')
-             : req.protocol + '://' + req.get('host');
+    let base = Utils.get_base_url(req.protocol, req.get('host'), config.url_prefix);
     res.setHeader('Content-Type', 'text/html');
 
     storage.get_local(function(err, packages) {

--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -44,7 +44,7 @@ module.exports = function(config, auth, storage) {
     template = Handlebars.compile(fs.readFileSync(require.resolve('./GUI/index.hbs'), 'utf8'));
   }
   app.get('/', function(req, res, next) {
-    let base = Utils.get_base_url(req.protocol, req.get('host'), config.url_prefix);
+    let base = Utils.combineBaseUrl(req.protocol, req.get('host'), config.url_prefix);
     res.setHeader('Content-Type', 'text/html');
 
     storage.get_local(function(err, packages) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,14 +87,14 @@ function validate_metadata(object, name) {
  * @param {String} prefix
  * @return {String} base registry url
  */
-function get_base_url(protocol, host, prefix) {
-	let result = protocol + '://' + host;
+function combineBaseUrl(protocol, host, prefix) {
+	let result = '@{protocol}://@{host}';
 
 	if (prefix) {
 		prefix = prefix.replace(/\/$/, '');
 
 		result = (prefix.indexOf('/') === 0)
-			? result + prefix
+			? '@{result}@{prefix}'
 			: prefix;
 	}
 
@@ -119,7 +119,7 @@ function filter_tarball_urls(pkg, req, config) {
 			return _url;
 		}
 		const filename = URL.parse(_url).pathname.replace(/^.*\//, '');
-		const base = get_base_url(req.protocol, req.headers.host, config.url_prefix);
+		const base = combineBaseUrl(req.protocol, req.headers.host, config.url_prefix);
 
 		return `${base}/${pkg.name.replace(/\//g, '%2f')}/-/${filename}`;
 	};
@@ -280,7 +280,7 @@ module.exports.parse_address = parse_address;
 module.exports.get_version = get_version;
 module.exports.normalize_dist_tags = normalize_dist_tags;
 module.exports.tag_version = tag_version;
-module.exports.get_base_url = get_base_url;
+module.exports.combineBaseUrl = combineBaseUrl;
 module.exports.filter_tarball_urls = filter_tarball_urls;
 module.exports.validate_metadata = validate_metadata;
 module.exports.is_object = is_object;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,6 +81,27 @@ function validate_metadata(object, name) {
 }
 
 /**
+ * Create base url for registry.
+ * @param {String} protocol
+ * @param {String} host
+ * @param {String} prefix
+ * @return {String} base registry url
+ */
+function get_base_url(protocol, host, prefix) {
+	let result = protocol + '://' + host;
+
+	if (prefix) {
+		prefix = prefix.replace(/\/$/, '');
+
+		result = (prefix.indexOf('/') === 0)
+			? result + prefix
+			: prefix;
+	}
+
+	return result;
+}
+
+/**
  * Iterate a packages's versions and filter each original tarbal url.
  * @param {*} pkg
  * @param {*} req
@@ -98,13 +119,9 @@ function filter_tarball_urls(pkg, req, config) {
 			return _url;
 		}
 		const filename = URL.parse(_url).pathname.replace(/^.*\//, '');
-		let result;
-		if (config.url_prefix != null) {
-			result = config.url_prefix.replace(/\/$/, '');
-		} else {
-			result = `${req.protocol}://${req.headers.host}`;
-		}
-		return `${result}/${pkg.name.replace(/\//g, '%2f')}/-/${filename}`;
+		const base = get_base_url(req.protocol, req.headers.host, config.url_prefix);
+
+		return `${base}/${pkg.name.replace(/\//g, '%2f')}/-/${filename}`;
 	};
 
 	for (let ver in pkg.versions) {
@@ -263,6 +280,7 @@ module.exports.parse_address = parse_address;
 module.exports.get_version = get_version;
 module.exports.normalize_dist_tags = normalize_dist_tags;
 module.exports.tag_version = tag_version;
+module.exports.get_base_url = get_base_url;
 module.exports.filter_tarball_urls = filter_tarball_urls;
 module.exports.validate_metadata = validate_metadata;
 module.exports.is_object = is_object;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,13 +88,13 @@ function validate_metadata(object, name) {
  * @return {String} base registry url
  */
 function combineBaseUrl(protocol, host, prefix) {
-	let result = '${protocol}://${host}';
+	let result = `${protocol}://${host}`;
 
 	if (prefix) {
 		prefix = prefix.replace(/\/$/, '');
 
 		result = (prefix.indexOf('/') === 0)
-			? '${result}${prefix}'
+			? `${result}${prefix}`
 			: prefix;
 	}
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,13 +88,13 @@ function validate_metadata(object, name) {
  * @return {String} base registry url
  */
 function combineBaseUrl(protocol, host, prefix) {
-	let result = '@{protocol}://@{host}';
+	let result = '${protocol}://${host}';
 
 	if (prefix) {
 		prefix = prefix.replace(/\/$/, '');
 
 		result = (prefix.indexOf('/') === 0)
-			? '@{result}@{prefix}'
+			? '${result}${prefix}'
 			: prefix;
 	}
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue

**Description:**

 * Define utils function `get_base_url`.
 * If url_prefix start with `/` construct base URL using protocol and host form request.
 * Update SERVER.md with description of new `url_prefix` option.

Resolves #193