### PR TITLE
don't blindly clobber local dist-tags

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const async = require('async');
 const Error = require('http-errors');
+const semver = require('semver');
 const Stream = require('stream');
 const Local = require('./local-storage');
 const Logger = require('./logger');
@@ -589,8 +590,10 @@ class Storage {
     // refresh dist-tags
     for (let i in up['dist-tags']) {
       if (local['dist-tags'][i] !== up['dist-tags'][i]) {
-        local['dist-tags'][i] = up['dist-tags'][i];
-        if (i === 'latest') {
+        if (!local['dist-tags'][i] || semver.lte(local['dist-tags'][i], up['dist-tags'][i])) {
+          local['dist-tags'][i] = up['dist-tags'][i];
+        }
+        if (i === 'latest' && local['dist-tags'][i] === up['dist-tags'][i]) {
           // if remote has more fresh package, we should borrow its readme
           local.readme = up.readme;
         }

--- a/test/unit/st_merge.js
+++ b/test/unit/st_merge.js
@@ -31,6 +31,23 @@ describe('Merge', function() {
     });
   });
 
+  it('dist-tags - staging', function() {
+    let x = {
+      versions: {},
+      // we've been locally publishing 1.1.x in preparation for the next
+      // public release
+      'dist-tags': {q:'1.1.10',w:'2.2.2'},
+    }
+    // 1.1.2 is the latest public release, but we want to continue testing
+    // against our local 1.1.10, which may end up published as 1.1.3 in the
+    // future
+    merge(x, {'dist-tags':{q:'1.1.2',w:'3.3.3',t:'4.4.4'}})
+    assert.deepEqual(x, {
+      versions: {},
+      'dist-tags': {q:'1.1.10',w:'3.3.3',t:'4.4.4'},
+    });
+  });
+
   it('semver_sort', function() {
     assert.deepEqual(semver_sort(['1.2.3', '1.2', '1.2.3a', '1.2.3c', '1.2.3-b']),
     ['1.2.3a',


### PR DESCRIPTION
If packages are being published to verdaccio as well as upstream to
npmjs.org, then when the cache is updated from npmjs.org it uses the
dist-tags from the upstream even if the locally published version is
actually newer. This makes it very difficult to use verdaccio as a
staging registry for testing out potential releases.

This change partially reverts a change in behaviour that was introduced
in #8 which caused a regression for the staging style workflow that was
supported by sinopia.

**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:
* [ ] The PR passes CI testing
-->

**Description:**

Replaces #80