### PR TITLE
enable verdaccio behind a https nginx proxy

### DIFF
--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -45,7 +45,7 @@ module.exports = function(config, auth, storage) {
     template = Handlebars.compile(fs.readFileSync(require.resolve('./GUI/index.hbs'), 'utf8'));
   }
   app.get('/', function(req, res, next) {
-    let proto = req.get('X-Forwarded-Proto') || req.protocol
+    let proto = req.get('X-Forwarded-Proto') || req.protocol;
     let base = Utils.combineBaseUrl(proto, req.get('host'), config.url_prefix);
     res.setHeader('Content-Type', 'text/html');
 

--- a/lib/index-web.js
+++ b/lib/index-web.js
@@ -45,7 +45,8 @@ module.exports = function(config, auth, storage) {
     template = Handlebars.compile(fs.readFileSync(require.resolve('./GUI/index.hbs'), 'utf8'));
   }
   app.get('/', function(req, res, next) {
-    let base = Utils.combineBaseUrl(req.protocol, req.get('host'), config.url_prefix);
+    let proto = req.get('X-Forwarded-Proto') || req.protocol
+    let base = Utils.combineBaseUrl(proto, req.get('host'), config.url_prefix);
     res.setHeader('Content-Type', 'text/html');
 
     storage.get_local(function(err, packages) {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

Static sources were fetched using http when verdaccio was running behind a https nginx reverse proxy, failing. Now they are fetched using https, succeeding.

* [ ] There is a related issue
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:
* [ ] The PR passes CI testing
-->

**Description:**

Resolves #???