### PR TITLE
Fixed grammar error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,6 @@ About the storage there is a running discussion [here](https://github.com/verdac
 - [shadow-npm](https://github.com/dominictarr/shadow-npm), [public service](http://shadow-npm.net/) - it uses the same code as npmjs.org + service is dead
 - [gemfury](http://www.gemfury.com/l/npm-registry) and others - those are closed-source cloud services, and I'm not in a mood to trust my private code to somebody (security through obscurity yeah!)
 - npm-registry-proxy, npm-delegate, npm-proxy - those are just proxies...
-- [nexus-repository-oss](https://www.sonatype.com/nexus-repository-oss) - Repository manager that handles more then just NPM dependencies
+- [nexus-repository-oss](https://www.sonatype.com/nexus-repository-oss) - Repository manager that handles more than just NPM dependencies
 - Is there something else?
 - [codebox-npm](https://github.com/craftship/codebox-npm) - Serverless private npm registry using


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

Grammar error in README.md has been fixed:
`More then just NPM dependencies -> More than just NPM ...`

<!--
Our bots should ensure:
* The PR passes CI testing
-->
