### PR TITLE
Now we can mount plugins directory for Docker (also for non-docker).

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ To run the docker container:
 docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio
 ```
 
+You can mount directories for the config, storage, local_storage and plugins, for ex:
+
+```bash
+docker run -it --rm --name verdaccio -p 4873:4873 \
+  -v /<path to verdaccio directory>/conf:/verdaccio/conf \
+  -v /<path to verdaccio directory>/storage:/verdaccio/storage \
+  -v /<path to verdaccio directory>/local_storage:/verdaccio/local_storage \
+  -v /<path to verdaccio directory>/plugins:/verdaccio/plugins \
+  verdaccio/verdaccio
+```
+
 #### Using docker-compose
 
 1. Get the latest version of [docker-compose](https://github.com/docker/compose).
@@ -162,6 +173,10 @@ Misc stuff:
 - Searching (npm search) - **supported** (cli / browser)
 - Starring (npm star, npm unstar) - not supported, doesn't make sense in private registry
 - Ping (npm ping) - **supported** 
+
+## Plugins
+
+Plugins has to be stored under plugins directory, according to `config.yaml` file
 
 ## Storage
 

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -8,6 +8,8 @@
 
 # path to a directory with all packages
 storage: ./storage
+# path to a directory with plugins to include
+plugins: ./plugins
 
 auth:
   htpasswd:

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -12,6 +12,8 @@
 
 # path to a directory with all packages
 storage: /verdaccio/storage
+# path to a directory with plugins to include
+plugins: /verdaccio/plugins
 
 auth:
   htpasswd:

--- a/conf/full.yaml
+++ b/conf/full.yaml
@@ -1,5 +1,7 @@
 # path to a directory with all packages
 storage: ./storage
+# path to a directory with plugins to include
+plugins: ./plugins
 
 # a list of users
 #

--- a/lib/plugin-loader.js
+++ b/lib/plugin-loader.js
@@ -36,6 +36,19 @@ function load_plugins(config, plugin_configs, params, sanity_check) {
     // try local plugins first
     plugin = try_load(Path.resolve(__dirname + '/plugins', p));
 
+    if (plugin === null && config.plugins) {
+      plugin = try_load(Path.resolve(config.plugins, p));
+
+      // npm package
+      if (plugin === null && p.match(/^[^\.\/]/)) {
+        plugin = try_load(Path.resolve(config.plugins, `verdaccio-${p}`));
+        // compatibility for old sinopia plugins
+        if (!plugin) {
+          plugin = try_load(Path.resolve(config.plugins, `sinopia-${p}`));
+        }
+      }
+    }
+
     // npm package
     if (plugin === null && p.match(/^[^\.\/]/)) {
       plugin = try_load(`verdaccio-${p}`);

--- a/wiki/plugins.md
+++ b/wiki/plugins.md
@@ -1,5 +1,9 @@
 This is a pre release of plugins compatible with **Verdaccio**.
 
+## Plugins mount
+
+Plugins has to be stored under plugins directory, according to `config.yaml` file
+
 ## Sinopia Legacy Plugins
 
 * [sinopia-npm](https://www.npmjs.com/package/sinopia-npm): auth plugin for sinopia supporting an npm registry.


### PR DESCRIPTION
**Type:** feature

**Description:**

Since user that are using Docker image are not able to add plugins, this feature will let them mount plugins directory.
This feature is really mandatory for Docker users of this project.