### PR TITLE
Updated Dockerfile & added proper signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:8.1.2-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 RUN apk --no-cache add openssl && \
@@ -24,10 +24,12 @@ RUN addgroup -S verdaccio && adduser -S -g verdaccio verdaccio && \
 USER verdaccio
 
 ENV PORT 4873
+ENV PROTOCOL http
+
 EXPOSE $PORT
 
 VOLUME ["/verdaccio"]
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
-CMD $APPDIR/bin/verdaccio --config /verdaccio/conf/config.yaml
+CMD $APPDIR/bin/verdaccio --config /verdaccio/conf/config.yaml --listen $PROTOCOL://0.0.0.0:${PORT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,17 @@
-FROM node:6-alpine
+FROM node:alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
+
+RUN apk --no-cache add openssl && \
+    wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \
+    chmod +x /usr/local/bin/dumb-init && \
+    apk del openssl
 
 ENV APPDIR /usr/local/app
 
-RUN mkdir -p "$APPDIR"
 WORKDIR $APPDIR
+
 ADD . $APPDIR
+
 RUN npm install
 
 RUN mkdir -p /verdaccio/storage /verdaccio/conf
@@ -22,4 +28,6 @@ EXPOSE $PORT
 
 VOLUME ["/verdaccio"]
 
-CMD ["sh", "-c", "${APPDIR}/bin/verdaccio --config /verdaccio/conf/config.yaml --listen 0.0.0.0:${PORT}"]
+ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
+
+CMD $APPDIR/bin/verdaccio --config /verdaccio/conf/config.yaml


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR: Signal handling for stopping the container and not being able to use https with containers

<!--
Our bots should ensure:
* The PR passes CI testing
-->

**Description:**

Before this PR the stopsignal that the docker daemon was sending to verdaccio wasnt reaching the main program. Dumb-init makes sure that this happens. Also I've updated the dockerfile to use the latest alpine node image that is going to be the LTS version soon. There was also no way to listen on HTTPS protocol, so I've added the option to be able to do so