### PR TITLE
Fixed adding the verdaccio user into the group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN npm install
 RUN mkdir -p /verdaccio/storage /verdaccio/conf
 ADD conf/docker.yaml /verdaccio/conf/config.yaml
 
-RUN addgroup -S verdaccio && adduser -S -g verdaccio verdaccio && \
+RUN addgroup -S verdaccio && adduser -S -G verdaccio verdaccio && \
     chown -R verdaccio:verdaccio "$APPDIR" && \
     chown -R verdaccio:verdaccio /verdaccio
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR: There was a typo in the command creating the verdaccio user

<!--
Our bots should ensure:
* The PR passes CI testing
-->

**Description:** This exceptionally huge change makes it possible to use the image without chowning the whole volume in an init-container as mentioned in #238. :)

To be able to use it just make a change in your deployment file, add this to your [PodSpec](https://kubernetes.io/docs/api-reference/v1.6/#podspec-v1-core) (101 is the verdaccio group id)

```json
"securityContext": {
    "fsGroup": 101
}                        
```
Resolves #238 

**BUT**
There is still a problem while trying to use the image like this: 
`docker run -it -v ~/test:/verdaccio/storage verdaccio/verdaccio:latest`

I believe that it's a problem on [Docker side](https://github.com/moby/moby/issues/2259). 
