### PR TITLE
use light version of syntax highlighter

### DIFF
--- a/src/webui/src/components/Help/index.js
+++ b/src/webui/src/components/Help/index.js
@@ -1,9 +1,12 @@
 
 import React from 'react';
-import SyntaxHighlighter from 'react-syntax-highlighter/dist/index';
+import SyntaxHighlighter, {registerLanguage} from 'react-syntax-highlighter/dist/light';
 import sunburst from 'react-syntax-highlighter/src/styles/sunburst';
+import js from 'react-syntax-highlighter/dist/languages/javascript';
 
 import classes from './help.scss';
+
+registerLanguage('javascript', js);
 
 const Help = () => {
     return (


### PR DESCRIPTION
The following has been addressed in the PR:

Uses light version of react syntax highlighter to remove 820kb from bundle size for client 
before:
<img width="650" alt="screen shot 2017-07-22 at 10 26 24 pm" src="https://user-images.githubusercontent.com/8263298/28495986-2921c84e-6f2d-11e7-913d-391e63e39bc6.png">
after:
<img width="700" alt="screen shot 2017-07-22 at 10 25 07 pm" src="https://user-images.githubusercontent.com/8263298/28495988-364b59c2-6f2d-11e7-8767-78e9056667d8.png">



