### PR TITLE
Adding X-Forwarded-Proto header to docs

### DIFF
--- a/wiki/reverse-proxy.md
+++ b/wiki/reverse-proxy.md
@@ -66,6 +66,7 @@ location / {
     proxy_pass http://127.0.0.1:4873/;
     proxy_set_header Host            $host:$server_port;
     proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
 }
 ```
 For this case, `url_prefix` should NOT set in verdaccio config
@@ -78,6 +79,7 @@ location ~ ^/verdaccio/(.*)$ {
     proxy_pass http://127.0.0.1:4873/$1;
     proxy_set_header Host            $host:$server_port;
     proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
 }
 ```
 For this case, `url_prefix` should set to `/verdaccio/`


### PR DESCRIPTION
**Type:** docs

The following has been addressed in the PR:

<!-- Remove the sections that your PR does not apply -->
*  Addition to the reverse proxy wiki

<!--
Our bots should ensure:
* The PR passes CI testing
-->

**Description:**

The web ui code relies on [src/lib/utils.js#L319](https://github.com/verdaccio/verdaccio/blob/master/src/lib/utils.js#L319) to figure out the correct protocol for serving the assets (js, css, etc). Since it relies on the "X-Forwarded-Proto" header, I have updated the documentation to reflect this. Without this header, you get a mixed-content page when you are on https as the assets end up being served over http.
