### PR TITLE
Amend proxy instructions for Apache

### DIFF
--- a/wiki/reverse-proxy.md
+++ b/wiki/reverse-proxy.md
@@ -34,8 +34,8 @@ Apache virtual server configuration
         ProxyRequests           Off
         ProxyPreserveHost       On
         AllowEncodedSlashes     NoDecode
-        ProxyPass               /       http://127.0.0.1:4873/ nocanon
-        ProxyPassReverse        /       http://127.0.0.1:4873/
+        ProxyPass               /       http://127.0.0.1:4873 nocanon
+        ProxyPassReverse        /       http://127.0.0.1:4873
     </VirtualHost>
     </IfModule>
 ````


### PR DESCRIPTION
Hi.
I had issues regarding to resources when accessing Verdaccio through Apache proxy.
I found out that removing ending slashes at `ProxyPass` and `ProxyPassReverse` settings solved it.
I also set Verdaccio's config `url_prefix` to match the proxy location.
Hope it helps.

**Type:** bug / documentation