### PR TITLE
fix: Remove accept header that seems cause issues #285 #289 

### DIFF
--- a/src/lib/storage/up-storage.js
+++ b/src/lib/storage/up-storage.js
@@ -17,9 +17,7 @@ const encode = function(thing) {
 
 const jsonContentType = 'application/json';
 
-const contenTypeAccept = [
-  `${jsonContentType} q=0.8, */*`,
-].join(', ');
+const contenTypeAccept = `${jsonContentType} q=0.8, */*`;
 
 /**
  * Just a helper (`config[key] || default` doesn't work because of zeroes)

--- a/src/lib/storage/up-storage.js
+++ b/src/lib/storage/up-storage.js
@@ -18,8 +18,6 @@ const encode = function(thing) {
 const jsonContentType = 'application/json';
 
 const contenTypeAccept = [
-  'application/octet-stream',
-  'application/vnd.npm.install-v1+json; q=1.0',
   `${jsonContentType} q=0.8, */*`,
 ].join(', ');
 


### PR DESCRIPTION
**Type:** bug

**Description:**

Issues #285 #289 seems to be affected by the use of.

`Accept: application/vnd.npm.install-v1+json; q=1.0`

Also makes fails the `npm search` command

Resolves #285 
