### PR TITLE
Fix auth process to check against username also and not just groups

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -66,7 +66,7 @@ class Auth {
     const allow_action = function(action) {
       return function(user, pkg, cb) {
         let ok = pkg[action].reduce(function(prev, curr) {
-          if (user.groups.indexOf(curr) !== -1) return true;
+          if (user.name === curr || user.groups.indexOf(curr) !== -1) return true;
           return prev;
         }, false);
 


### PR DESCRIPTION
**Type:** bug

**Description:**

When using some authentication plugins other than htpasswd (we're using [sinopia-github-oauth](https://github.com/soundtrackyourbrand/sinopia-github-oauth)) user gets `403` if package publish/access config is setup to use username. I.e.:

    packages:
        '**':
            access: $authenticated
            publish: aszmyd

Is not working as authentication is checking this `publish` field against user groups only. But because my user object looks like this:

    { 
        name: 'aszmyd',
        groups: [ 'org', '$all', '$authenticated', '@all', '@authenticated', 'all' ],
        real_groups: [ 'org' ] 
     }

And the current check fails. 

My PR is fixing this by changing the way authentication checks `publish`/`access` configurations - now it checks also against `user.name` and not just `user.groups`
