### PR TITLE
Correct accept header set for registry requests.

### DIFF
--- a/src/lib/storage/up-storage.js
+++ b/src/lib/storage/up-storage.js
@@ -17,7 +17,7 @@ const encode = function(thing) {
 
 const jsonContentType = 'application/json';
 
-const contenTypeAccept = `${jsonContentType} q=0.8, */*`;
+const contenTypeAccept = `${jsonContentType}; q=0.8, */*`;
 
 /**
  * Just a helper (`config[key] || default` doesn't work because of zeroes)


### PR DESCRIPTION

**Type:** bug


**Description:**

A semicolon is required after media type in accept header when quality specification is made. Necessary for more pedantic servers such as JFrog's Artifactory.

Resolves #294 
