### PR TITLE
Update SSL documentation

### DIFF
--- a/wiki/ssl.md
+++ b/wiki/ssl.md
@@ -19,7 +19,7 @@ Once you update the listen and try to run verdaccio again will ask for certifica
  $ openssl x509 -req -in ~/.config/verdaccio/verdaccio-csr.pem -signkey ~/.config/verdaccio/verdaccio-key.pem -out ~/.config/verdaccio/verdaccio-cert.pem
  ````
  
-* Edit your config file `~/.config/verdaccio/config.yalm` an add the following section
+* Edit your config file `~/.config/verdaccio/config.yalm` an add the following section (more info on the `key`, `cert` and `ca` arguments on the [Node documentation](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options))
 
 ````
 https:
@@ -33,3 +33,8 @@ https:
 * Open the browser and load `https://your.domain.com:port/`
 
 This instructions are mostly valid under OSX and Linux, on Windows the paths will vary but, the steps are the same.
+
+## Docker
+If you are using the Docker image, you have to set the `PROTOCOL` environment variable to `https` as the `listen` argument is provided on the [Dockerfile](https://github.com/verdaccio/verdaccio/blob/master/Dockerfile#L43), and thus ignored from your config file.
+
+You can also set the `PORT` environment variable if you are using a different port than `4873`.


### PR DESCRIPTION
Hi,

**Type:** documentation

The following has been addressed in the PR:

<!-- Remove the sections that your PR does not apply -->
*  improve documentation for the SSL part

**Description:**

I had some troubles setting up SSL for my Verdaccio registry because document was not perfectly clear.
I made little improvements on the SSL wiki page by adding a section about Docker (`listen` config entry is ignored because it's already set on Dockerfile), and I also added a link to the Node documentation pointing at more documentation for the `ca`, `cert` and `key` options for the `https` entry on the configuration.

Hope it can help other people!