### PR TITLE
Fix possible data loss upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ $ npm set ca null
 
 Now you can navigate to [http://localhost:4873/](http://localhost:4873/) where your local packages will be listed and can be searched.
 
+> Warning: Verdaccio current is not support PM2's cluster mode, run it with cluster mode may cause unknown behavior
+
 #### Beta
 
 If you are an adventurous developer you can use and install the latest beta version, this is a non stable version, I'd recommend only use for testing purporses.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "file-loader": "0.11.2",
     "flow-runtime": "0.13.0",
     "friendly-errors-webpack-plugin": "1.6.1",
+    "fs-extra": "4.0.1",
     "github-markdown-css": "2.8.0",
     "html-webpack-plugin": "2.29.0",
     "in-publish": "2.0.0",

--- a/src/lib/storage/local/local-data.js
+++ b/src/lib/storage/local/local-data.js
@@ -21,15 +21,13 @@ const logger = require('../../logger');
     try {
       dbFile = fs.readFileSync(this.path, 'utf8');
     } catch (err) {
-      if (err.code === 'ENOENT') { // Only recreate if file not found to prevent data loss
-        this.data = {list: []};
-      } else {
+      if (err.code !== 'ENOENT') { // Only recreate if file not found to prevent data loss
         logger.logger.error(
-          'Failed to read package database file, please check the error printed below and fix it manually:\n',
+          'Failed to read package database file, please check the error printed below:\n',
           `File Path: ${this.path}\n\n`,
           err
         );
-        throw new Error('Package database file unreachable');
+        this.locked = true; // Prevent any write action, wait admin to check what happened during startup
       }
     }
 
@@ -37,33 +35,39 @@ const logger = require('../../logger');
       try {
         this.data = JSON.parse(dbFile);
       } catch(err) {
-        logger.logger.error(err);
-        throw new Error(`Package database file corrupted (invalid JSON), please fix it manually.\nFile Path: ${this.path}`);
+        logger.logger.error(`Package database file corrupted (invalid JSON), please check the error printed below.\nFile Path: ${this.path}`, err);
+        this.locked = true;
       }
+    }
+
+    if (!this.data) {
+      this.data = {list: []};
     }
   }
 
   /**
    * Add a new element.
    * @param {*} name
+   * @return {Error|*}
    */
   add(name) {
     if (this.data.list.indexOf(name) === -1) {
       this.data.list.push(name);
-      this.sync();
+      return this.sync();
     }
   }
 
   /**
    * Remove an element from the database.
    * @param {*} name
+   * @return {Error|*}
    */
   remove(name) {
     const i = this.data.list.indexOf(name);
     if (i !== -1) {
       this.data.list.splice(i, 1);
     }
-    this.sync();
+    return this.sync();
   }
 
   /**
@@ -76,8 +80,14 @@ const logger = require('../../logger');
 
   /**
    * Syncronize {create} database whether does not exist.
+   * @return {Error|*}
    */
   sync() {
+    if (this.locked) {
+      logger.logger.error('Database is locked, please check error message printed during startup to prevent data loss.');
+      return new Error('Verdaccio database is locked, please contact your administrator to checkout logs during verdaccio startup.');
+    }
+
     // Uses sync to prevent ugly race condition
     try {
       require('mkdirp').sync(Path.dirname(this.path));
@@ -85,7 +95,11 @@ const logger = require('../../logger');
       // perhaps a logger instance?
       /* eslint no-empty:off */
     }
-    fs.writeFileSync(this.path, JSON.stringify(this.data));
+    try {
+      fs.writeFileSync(this.path, JSON.stringify(this.data));
+    } catch (err) {
+      return err;
+    }
   }
 
 }

--- a/src/lib/storage/local/local-data.js
+++ b/src/lib/storage/local/local-data.js
@@ -33,11 +33,13 @@ const logger = require('../../logger');
       }
     }
 
-    try {
-      this.data = JSON.parse(dbFile);
-    } catch(err) {
-      logger.logger.error(err);
-      throw new Error(`Package database file corrupted (invalid JSON), please fix it manually.\nFile Path: ${this.path}`);
+    if (dbFile) {
+      try {
+        this.data = JSON.parse(dbFile);
+      } catch(err) {
+        logger.logger.error(err);
+        throw new Error(`Package database file corrupted (invalid JSON), please fix it manually.\nFile Path: ${this.path}`);
+      }
     }
   }
 

--- a/src/lib/storage/local/local-data.js
+++ b/src/lib/storage/local/local-data.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const Path = require('path');
+const logger = require('../../logger');
 
 /**
  * Handle local database.
@@ -15,10 +16,28 @@ const Path = require('path');
    */
    constructor(path) {
     this.path = path;
+    let dbFile;
+
     try {
-      this.data = JSON.parse(fs.readFileSync(this.path, 'utf8'));
-    } catch(_) {
-      this.data = {list: []};
+      dbFile = fs.readFileSync(this.path, 'utf8');
+    } catch (err) {
+      if (err.code === 'ENOENT') { // Only recreate if file not found to prevent data loss
+        this.data = {list: []};
+      } else {
+        logger.logger.error(
+          'Failed to read package database file, please check the error printed below and fix it manually:\n',
+          `File Path: ${this.path}\n\n`,
+          err
+        );
+        throw new Error('Package database file unreachable');
+      }
+    }
+
+    try {
+      this.data = JSON.parse(dbFile);
+    } catch(err) {
+      logger.logger.error(err);
+      throw new Error(`Package database file corrupted (invalid JSON), please fix it manually.\nFile Path: ${this.path}`);
     }
   }
 

--- a/src/lib/storage/local/local-storage.js
+++ b/src/lib/storage/local/local-storage.js
@@ -119,6 +119,12 @@ class LocalStorage {
       }
       this._normalizePackage(data);
 
+      let removeFailed = this.localList.remove(name);
+      if (removeFailed) {
+        // This will happen when database is locked
+        return callback(this.utils.ErrorCode.get422(removeFailed.message));
+      }
+
       storage.unlink(pkgFileName, function(err) {
         if (err) {
           return callback(err);
@@ -145,7 +151,6 @@ class LocalStorage {
         });
       });
     });
-    this.localList.remove(name);
   }
 
   /**
@@ -296,7 +301,12 @@ class LocalStorage {
 
       data.versions[version] = metadata;
       this.utils.tag_version(data, version, tag);
-      this.localList.add(name);
+
+      let addFailed = this.localList.add(name);
+      if (addFailed) {
+        return cb(this.utils.ErrorCode.get422(addFailed.message));
+      }
+
       cb();
     }, callback);
   }

--- a/test/unit/local-data.spec.js
+++ b/test/unit/local-data.spec.js
@@ -4,32 +4,76 @@ const assert = require('assert');
 const LocalData = require('../../src/lib/storage/local/local-data');
 const path = require('path');
 const _ = require('lodash');
+const fs = require('fs-extra');
 
 
 describe('Local Database', function() {
 
+  const buildCorruptedPath = () => path.join(__dirname, './partials/storage/verdaccio-corrupted.db.json');
+  const buildValidDbPath = () => path.join(__dirname, './partials/storage/verdaccio.db.json');
 
   describe('reading database', () => {
 
-    const buildCorruptedPath = () => path.join(__dirname, './partials/storage/verdaccio-corrupted.db.json');
-
     it('should return empty database on read corrupted database', () => {
-      const config = new LocalData(buildCorruptedPath());
-      assert(_.isEmpty(config.data.list));
+      const dataLocal = new LocalData(buildCorruptedPath());
+
+      assert(_.isEmpty(dataLocal.data.list));
     });
 
     it('should return a database on read valid database', () => {
-      const config = new LocalData(path.join(__dirname, './partials/storage/verdaccio.db.json'));
-      assert(_.isEmpty(config.data.list) === false);
+      const dataLocal = new LocalData(buildValidDbPath());
+
+      assert(_.isEmpty(dataLocal.data.list) === false);
     });
 
     it('should fails on sync a corrupted database', () => {
-      const config = new LocalData(buildCorruptedPath());
-      const error = config.sync();
+      const dataLocal = new LocalData(buildCorruptedPath());
+      const error = dataLocal.sync();
 
       assert(_.isError(error));
       assert(error.message.match(/locked/));
+      assert(dataLocal.locked);
     });
+
+  });
+
+  describe('add/remove packages to database', () => {
+    it('should add a new package to local database', () => {
+      const dataLocal = new LocalData(buildCorruptedPath());
+      assert(_.isEmpty(dataLocal.data.list));
+      dataLocal.add('package1');
+      assert(!_.isEmpty(dataLocal.data.list));
+    });
+
+    it('should remove a new package to local database', () => {
+      const dataLocal = new LocalData(buildCorruptedPath());
+      const pkgName = 'package1';
+
+      assert(_.isEmpty(dataLocal.data.list));
+      dataLocal.add(pkgName);
+      dataLocal.remove(pkgName);
+      assert(_.isEmpty(dataLocal.data.list));
+    });
+  });
+
+  describe('sync packages to database', () => {
+    beforeEach(function() {
+      this.newDb = path.join(__dirname, './test-storage/verdaccio.temp.db.json');
+      fs.copySync(buildValidDbPath(), this.newDb);
+    });
+
+    it('should check sync packages', function() {
+      const localData1 = new LocalData(this.newDb);
+
+      localData1.add('package1');
+
+      const localData2 = new LocalData(this.newDb);
+
+      assert(_.isEmpty(localData2.data.list) === false);
+      assert(localData2.data.list.length === 2);
+
+    });
+
 
   });
 

--- a/test/unit/local-data.spec.js
+++ b/test/unit/local-data.spec.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert');
+const LocalData = require('../../src/lib/storage/local/local-data');
+const path = require('path');
+const _ = require('lodash');
+
+
+describe('Local Database', function() {
+
+
+  describe('reading database', () => {
+
+    const buildCorruptedPath = () => path.join(__dirname, './partials/storage/verdaccio-corrupted.db.json');
+
+    it('should return empty database on read corrupted database', () => {
+      const config = new LocalData(buildCorruptedPath());
+      assert(_.isEmpty(config.data.list));
+    });
+
+    it('should return a database on read valid database', () => {
+      const config = new LocalData(path.join(__dirname, './partials/storage/verdaccio.db.json'));
+      assert(_.isEmpty(config.data.list) === false);
+    });
+
+    it('should fails on sync a corrupted database', () => {
+      const config = new LocalData(buildCorruptedPath());
+      const error = config.sync();
+
+      assert(_.isError(error));
+      assert(error.message.match(/locked/));
+    });
+
+  });
+
+});
+

--- a/test/unit/partials/storage/verdaccio-corrupted.db.json
+++ b/test/unit/partials/storage/verdaccio-corrupted.db.json
@@ -1,0 +1,1 @@
+{"list"[],"secret":"14705eeaed167749990dafa07f908d2a9504bfdb0f6ca4102eed5acba0bc9076"}

--- a/test/unit/partials/storage/verdaccio.db.json
+++ b/test/unit/partials/storage/verdaccio.db.json
@@ -1,0 +1,1 @@
+{"list":["@verdaccio/test"],"secret":"48cd053de97d4ef34aea4f1efb902334442bea1e735df5fdc9424c986a281b3d"}

--- a/wiki/cli.md
+++ b/wiki/cli.md
@@ -18,6 +18,8 @@ or if you use `yarn`
 $ yarn add global verdaccio
 ```
 
+> Warning: Verdaccio current is not support PM2's cluster mode, run it with cluster mode may cause unknown behavior
+
 ## Commands
 
 ```bash

--- a/yarn.lock
+++ b/yarn.lock
@@ -2910,7 +2910,7 @@ fs-access@^1.0.0:
 
 fs-extra@4.0.1:
   version "4.0.1"
-  resolved "http://localhost:5555/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
@@ -3859,7 +3859,7 @@ json5@^0.5.0, json5@^0.5.1:
 
 jsonfile@^3.0.0:
   version "3.0.1"
-  resolved "http://localhost:5555/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -6670,7 +6670,7 @@ uniqs@^2.0.0:
 
 universalify@^0.1.0:
   version "0.1.1"
-  resolved "http://localhost:5555/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
+  resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unix-crypt-td-js@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2908,6 +2908,14 @@ fs-access@^1.0.0:
   dependencies:
     null-check "^1.0.0"
 
+fs-extra@4.0.1:
+  version "4.0.1"
+  resolved "http://localhost:5555/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^3.0.0"
+    universalify "^0.1.0"
+
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
@@ -3136,7 +3144,7 @@ globule@^1.0.0:
     lodash "~4.17.4"
     minimatch "~3.0.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "4.1.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3848,6 +3856,12 @@ json3@3.3.2, json3@^3.3.2:
 json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
+
+jsonfile@^3.0.0:
+  version "3.0.1"
+  resolved "http://localhost:5555/jsonfile/-/jsonfile-3.0.1.tgz#a5ecc6f65f53f662c4415c7675a0331d0992ec66"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonfilter@^1.1.2:
   version "1.1.2"
@@ -6653,6 +6667,10 @@ uniqid@^4.0.0:
 uniqs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
+
+universalify@^0.1.0:
+  version "0.1.1"
+  resolved "http://localhost:5555/universalify/-/universalify-0.1.1.tgz#fa71badd4437af4c148841e3b3b165f9e9e590b7"
 
 unix-crypt-td-js@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
**Type:** feature

**Description:**
Author: @Meeeeow 
Follow up of #300

- Throw error when the error code is not ENOENT during reading package database file to prevent possible data loss
- Add warning about PM2 cluster mode to docs
- **new**: Add unit test for locking feature

**Result**

If for any reason the database is corrupted, the user will see that message. It won't be able to publish packages.

```bash
➜ npm publish                                 
npm ERR! publish Failed PUT 422
npm ERR! code E422
npm ERR! Verdaccio database is locked, please contact your administrator to checkout logs during verdaccio startup. : npm-test-hello-world

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/user/.npm/_logs/2017-08-25T18_24_48_546Z-debug.log
````


Resolves #??? ==> @Meeeeow could you fill this part?
