### PR TITLE
fix: Add DATE and VERSION in search result

### DIFF
--- a/src/lib/storage/local/local-storage.js
+++ b/src/lib/storage/local/local-storage.js
@@ -688,9 +688,9 @@ class LocalStorage {
                   'bugs': version.bugs,
                   'license': version.license,
                   'time': {
-                    modified: item.time ? new Date(item.time).toISOString() : undefined,
+                    modified: item.time ? new Date(item.time).toISOString() : stats.mtime,
                   },
-                  'versions': {},
+                  'versions': {[latest]: "latest"},
                  });
               }
 

--- a/src/lib/storage/local/local-storage.js
+++ b/src/lib/storage/local/local-storage.js
@@ -690,7 +690,7 @@ class LocalStorage {
                   'time': {
                     modified: item.time ? new Date(item.time).toISOString() : stats.mtime,
                   },
-                  'versions': {[latest]: "latest"},
+                  'versions': {[latest]: 'latest'},
                  });
               }
 

--- a/test/functional/tags/preserve_tags.spec.js
+++ b/test/functional/tags/preserve_tags.spec.js
@@ -84,7 +84,9 @@ module.exports = function() {
             'time': {
               modified: '2014-10-02T07:07:51.000Z'
             },
-            'versions': {},
+            'versions': {
+              "0.0.0": "latest"
+            },
             'repository': {
               type: 'git', url: ''}
           });


### PR DESCRIPTION
	modified:   src/lib/storage/local/local-storage.js
	modified:   test/functional/tags/preserve_tags.spec.js

**Type:** bug

The following has been addressed in the PR:
This fixes the issue: ```npm search``` result doesn't contain DATE and VERSION information

Without this fix: ```npm search``` result's DATE and VERSION column is empty.  
With this fix: DATE column has the DATE that modified. VERSION column has the latest version.