### PR TITLE
Fixed bug with Maximum call stack size exceeded on packages web API.

### DIFF
--- a/src/api/web/api.js
+++ b/src/api/web/api.js
@@ -45,11 +45,13 @@ module.exports = function(config, auth, storage) {
         packages,
         function(pkg, cb) {
           auth.allow_access(pkg.name, req.remote_user, function(err, allowed) {
-            if (err) {
-              cb(null, false);
-            } else {
-              cb(err, allowed);
-            }
+            async.setImmediate(function() {
+              if (err) {
+                cb(null, false);
+              } else {
+                cb(err, allowed);
+              }
+            });
           });
         },
         function(err, packages) {

--- a/src/api/web/api.js
+++ b/src/api/web/api.js
@@ -45,7 +45,7 @@ module.exports = function(config, auth, storage) {
         packages,
         function(pkg, cb) {
           auth.allow_access(pkg.name, req.remote_user, function(err, allowed) {
-            async.setImmediate(function() {
+            setImmediate(function() {
               if (err) {
                 cb(null, false);
               } else {


### PR DESCRIPTION
**Type:** bug

**Description:**
Fixes bug when accessing Verdaccio throught web browser it show loading and no published packages are shown. This is caused because Verdaccio have published more than 500 packages and call stack size is exceeded.