### PR TITLE
Fix typo at config wiki (uplinks section)

### DIFF
--- a/wiki/config.md
+++ b/wiki/config.md
@@ -61,7 +61,7 @@ web:
   logo: logo.png
 ```
 
-### Upkinks
+### Uplinks
 
 Uplinks is the ability of the system to fetch packages from remote registries when those packages are not available locally. For more information about this section read the [uplinks page](uplinks.md).
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

<!-- Remove the sections that your PR does not apply -->
<!--
Our bots should ensure:
* The PR passes CI testing
-->

**Description:**

Just fix typo at wiki
