### PR TITLE
fix: fix docker build failure due breaking changes in yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ADD . $APPDIR
 ENV NODE_ENV=production
 
 RUN npm config set registry http://registry.npmjs.org/ && \
-    npm install -g -s --no-progress yarn --pure-lockfile && \
+    npm install -g -s --no-progress yarn@0.28.4 --pure-lockfile && \
     yarn install --production=false && \
     yarn run build:webui && \
     yarn cache clean && \


### PR DESCRIPTION
**Type:** bug

Docker build fails with Yarn `1.x` breaks the build. This PR set `v0.28.4` as fixed version