### PR TITLE
Removes dist-tag put and delete endpoint

### DIFF
--- a/src/api/endpoint/api/dist-tags.js
+++ b/src/api/endpoint/api/dist-tags.js
@@ -69,26 +69,4 @@ module.exports = function(route, auth, storage) {
         return next({ok: 'tags updated'});
       });
     });
-
-  route.put('/-/package/:package/dist-tags', can('publish'), media(mime.lookup('json')), expect_json,
-    function(req, res, next) {
-      storage.replace_tags(req.params.package, req.body, function(err) {
-        if (err) {
-          return next(err);
-        }
-        res.status(201);
-        return next({ok: 'tags updated'});
-      });
-    });
-
-  route.delete('/-/package/:package/dist-tags', can('publish'), media(mime.lookup('json')),
-    function(req, res, next) {
-      storage.replace_tags(req.params.package, {}, function(err) {
-        if (err) {
-          return next(err);
-        }
-        res.status(201);
-        return next({ok: 'tags removed'});
-      });
-    });
 };

--- a/test/functional/tags/tags.js
+++ b/test/functional/tags/tags.js
@@ -155,7 +155,7 @@ module.exports = function() {
             latest: '1.1.0',
             "quux": "0.1.0"
           };
-
+          
           assert.deepEqual(body, expected);
         });
       });


### PR DESCRIPTION
**Type:** improvement

The following has been addressed in the PR:

<!-- Remove the sections that your PR does not apply -->
*  There is a related issue
*  Unit or Functional tests are included in the PR

<!--
Our bots should ensure:
* The PR passes CI testing
-->

**Description:**

Resolves #288 


I have removed set() method endpoint. 

https://github.com/npm/npm-registry-client/blob/c03a77aba3e86e191b4025e34da47afb452c684a/lib/dist-tags/set.js#L33