### PR TITLE
build: allow publish from continous integration tool

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,3 +29,13 @@ test:
     - nvm alias default 8
     - yarn run test:ci
     - yarn run coverage:publish
+deployment:
+  production:
+    tag: /(v)?[0-9]+(\.[0-9]+)*/
+    commands:
+      - ./scripts/publish.sh
+general:
+  branches:
+    ignore:
+      - gh-pages # list of branches to ignore
+      - /release\/.*/ # or ignore regexes

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Get the last tag from GitHub
+lastTag=$(git describe --tags $(git rev-list --tags --max-count=1))
+
+# Print it to the console for verification
+echo "Bumping version to new tag: ${lastTag}"
+
+# Bump the version
+npm --no-git-tag-version version $lastTag
+
+# Publish to NPM
+npm publish


### PR DESCRIPTION
**Type:** feature

**Description:**

To avoid future incidents, we will deploy automatically from `circleci` after push a new `git tag`

Resolves #367 
