### PR TITLE
Unlink socket before listening

### DIFF
--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -172,6 +172,10 @@ function afterConfigLoad() {
       webServer = http.createServer(app);
     }
 
+    if (addr.path) {
+      fs.unlinkSync(addr.path);
+    }
+
     webServer
       .listen(addr.port || addr.path, addr.host)
       .on('error', function(err) {


### PR DESCRIPTION
# **Type:** Bug

**Description - Also described at #372:**
This is a default behavior of the operation system, after the process has quit it's sockets will remain on disk.

The solution is to just remove the file before trying to use it again, preventing any **EADDRINUSE** error


Resolves #372
