### PR TITLE
fix: Check if socket exists before removing

### DIFF
--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -172,7 +172,7 @@ function afterConfigLoad() {
       webServer = http.createServer(app);
     }
 
-    if (addr.path) {
+    if (addr.path && fs.existsSync(addr.path)) {
       fs.unlinkSync(addr.path);
     }
 


### PR DESCRIPTION
**Type:** Bug

Hello,
I want to apologize, but while fixing a bug on #373, i've managed to create another bug.

Removing the socket before a `listen` call will prevent `EADDRINUSE`, but blindly removing that file will throw an `EADDRINUSE ` error if the file does not exists.

This definitely fix errors while using unix sockets.
My sincere apologies.

Lucius.