### PR TITLE
Add default column and fix typo

### DIFF
--- a/wiki/notifications.md
+++ b/wiki/notifications.md
@@ -45,11 +45,11 @@ notify:
 
 ## Configuration
 
-Property | Type | Required | Support | Description 
---- | --- | --- | --- | --- 
-method| string | No | all | HTTP verb
-packagePattern| string | No | all | Only run this notification if the package name matches the regular
-headers| array/object | Yes | all | If this endpoint requires specific headers, set them here as an array of key: value objects.
-endpoint| string | Yes | all | set the URL endpoint for this call
-content| string | Yes | all | any Handlebar expressions  
+Property | Type | Required | Support | Default | Description 
+--- | --- | --- | --- | --- | ---
+method| string | No | all |  | HTTP verb
+packagePattern| string | No | all |  | Only run this notification if the package name matches the regular expression
+headers| array/object | Yes | all |  | If this endpoint requires specific headers, set them here as an array of key: value objects.
+endpoint| string | Yes | all |  | set the URL endpoint for this call
+content| string | Yes | all |  | any Handlebar expressions  
 


### PR DESCRIPTION
**Type:** 

documentation

**Description:**

Just saw this while reading your docs:

1. It would be nice to have the default value for optional parameters (but I don't know what the values are and will leave it up to the maintainers to update them in this file).

2. Also fixes a small typo.

Keep up the great work !
