### PR TITLE
Using the env path in the systemd service

### DIFF
--- a/systemd/verdaccio.service
+++ b/systemd/verdaccio.service
@@ -5,7 +5,7 @@ Description=verdaccio Service
 Type=simple
 User=verdaccio
 WorkingDirectory=/home/verdaccio
-ExecStart=/usr/local/lib/npm/bin/verdaccio
+ExecStart=/usr/bin/env verdaccio
 ExecStop=/usr/bin/bash -c "kill $(ps -ef | grep ^verdacc+ | awk {'print $2'})"
 
 [Install]


### PR DESCRIPTION
**Type:** improvement

The following has been addressed in the PR:
* The problem discussed in issue #396 