### PR TITLE
upgrade node to fix long standing socket timeout issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.7.0-alpine
+FROM node:8.9.0-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 RUN apk --no-cache add openssl && \


### PR DESCRIPTION
Type: bug

The following has been addressed in the PR: Sockets doesn't timeout before download is complete

Description: Socket timeouts on connections

This is a known nodejs issue which has been fixed on node 8.9.0

https://github.com/nodejs/node/pull/15791/commits
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V8.md#8.9.0

Anyone not running in docker should upgrade to node 8.9.0

Resolves #301
