### PR TITLE
Match shell title with web title

### DIFF
--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -64,6 +64,8 @@ try {
   process.exit(1);
 }
 
+process.title = config.web && config.web.title || 'verdaccio'
+
 afterConfigLoad();
 
 /**

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -64,7 +64,7 @@ try {
   process.exit(1);
 }
 
-process.title = config.web && config.web.title || 'verdaccio'
+process.title = config.web && config.web.title || 'verdaccio';
 
 afterConfigLoad();
 


### PR DESCRIPTION
<!-- Before Pull Request check whether your commits follow this convention
https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines
-->


<!-- Pick only one type, whether none apply, please suggest one, we might be included it by default -->
**Type:** feature 

The following has been addressed in the PR:

<!-- Remove the sections that your PR does not apply -->
just an initiative...

<!--
Our bots should ensure:
* The PR passes CI testing
-->

<!-- If there is no issue related with this PR just remove the following section -->
**Description:**

I'm using verdaccio to evaluate CI tools and publish tools.
I'm running few instances to mimic different registries of different scopes.
I found that the config supports `config.web.title` - which is propagated to the web-ui.
I decided to propose to match the `process.title` with `config.web.title` so I can track which of the instances was hit as part of the processes


<!-- We are glad your code is part of this community, thanks for your valuable time !! --> 
