### PR TITLE
Feature remove node4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ See in detail each of these [use cases](https://github.com/verdaccio/verdaccio/t
 
 ### Prerequisites
 
-* Node.js >= 4.6.1
+* Node.js >= `2.x` (4.6.1) | `3.x` (6.12.0)
 * `npm` or `yarn`
 
 Installation and starting (application will create default config in config.yaml you can edit later)

--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,7 @@ dependencies:
         curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
       fi
     - nvm install 6
+    - nvm install 9
 
   cache_directories:
     - ~/.yarn
@@ -25,6 +26,8 @@ test:
     - nvm alias default 6
     - yarn run test
     - nvm alias default 8
+    - yarn run test
+    - nvm alias default 9
     - yarn run test
 deployment:
   production:

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "build:docker:rpi": "docker build -f Dockerfile.rpi -t verdaccio:rpi ."
   },
   "engines": {
-    "node": ">=4.6.1",
+    "node": ">=6.12.0",
     "npm": ">=3"
   },
   "preferGlobal": true,

--- a/wiki/install.md
+++ b/wiki/install.md
@@ -4,21 +4,20 @@ Verdaccio is a multiplatform web application, to install you need at least some 
 
 #### Prerequisites
 
-* Node higher than **4.6.1**
+* Node higher than (2.x **4.6.1**) | (3.x **6.12.0)
 * npm or yarn
-
 
 ## Installing the CLI
 
 `Verdaccio` must be install globaly using any of the most modern
 
-Using `npm` 
+Using `npm`
 
 ```bash
 npm install -g verdaccio
 
 ```
-or using `yarn` 
+or using `yarn`
 
 ```bash
 yarn global add verdaccio


### PR DESCRIPTION
**Type:** feature 

Node 4 LTS support ends on April 2018, Verdaccio `3.x` won't support officially anymore less than Node6.

This PR also add Node9 support on circleci.
