### PR TITLE
packageInfo : child components' methods gives undefined in api call

### DIFF
--- a/src/webui/src/components/PackageSidebar/index.jsx
+++ b/src/webui/src/components/PackageSidebar/index.jsx
@@ -47,13 +47,13 @@ export default class PackageSidebar extends React.Component {
   render() {
     let {packageMeta} = this.state;
 
-    return (
-      <aside>
+    return packageMeta ?
+      (<aside>
         <LastSync packageMeta={packageMeta} />
         <Maintainers packageMeta={packageMeta} />
         <Dependencies packageMeta={packageMeta} />
         {/* Package management module? Help us implement it! */}
-      </aside>
-    );
+      </aside>):
+      (<aside>Loading package information...</aside>);
   }
 }

--- a/src/webui/src/components/PackageSidebar/modules/LastSync/index.jsx
+++ b/src/webui/src/components/PackageSidebar/modules/LastSync/index.jsx
@@ -6,12 +6,10 @@ import classes from './style.scss';
 
 export default class LastSync extends React.Component {
   static propTypes = {
-    packageMeta: PropTypes.object
+    packageMeta: PropTypes.object.isRequired
   };
 
   get lastUpdate() {
-    if (!this.props.packageMeta) return 'Loading...';
-
     let lastUpdate = 0;
     Object.keys(this.props.packageMeta._uplinks).forEach((upLinkName) => {
       const status = this.props.packageMeta._uplinks[upLinkName];
@@ -25,8 +23,6 @@ export default class LastSync extends React.Component {
   }
 
   get recentReleases() {
-    if (!this.props.packageMeta) return [];
-
     let recentReleases = Object.keys(this.props.packageMeta.time).map((version) => {
       return {
         version,


### PR DESCRIPTION
<!-- Before Pull Request check whether your commits follow this convention
https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines
-->

<!-- 
  If your Pull Request fix an issue don't forget to update the unit test and documentation in /wiki folder
  If your Pull Request deliver a new feature, please, provide examples and why such feature should be considered, this information is    important to document the Github changelog. Also try to increase documentation and create new unit/functional test.  
-->

<!-- Pick only one type, whether none apply, please suggest one, we might be included it by default -->
**Type:** bug

The following has been addressed in the PR:

<!-- Remove the sections that your PR does not apply -->
*  There is a related issue
*  Unit or Functional tests are included in the PR

<!--
Our bots should ensure:
* The PR passes CI testing
-->

<!-- If there is no issue related with this PR just remove the following section -->
**Description:**
Package components loading before API call resolves.

It fixes the following thing:
- author function returns `undefined` on the first load. I found this writing test cases.
https://github.com/verdaccio/verdaccio/blob/704253a08d5db5209baabffb92caf7d88d2183e3/src/webui/src/components/PackageSidebar/modules/Maintainers/index.jsx#L21
- removes loading statement.
https://github.com/verdaccio/verdaccio/blob/704253a08d5db5209baabffb92caf7d88d2183e3/src/webui/src/components/PackageSidebar/modules/LastSync/index.jsx#L13



<!-- We are glad your code is part of this community, thanks for your valuable time !! --> 
