### PR TITLE
Add packagePatternFlags to Notifications doc

### DIFF
--- a/wiki/notifications.md
+++ b/wiki/notifications.md
@@ -49,6 +49,7 @@ Property | Type | Required | Support | Default | Description
 --- | --- | --- | --- | --- | ---
 method| string | No | all |  | HTTP verb
 packagePattern| string | No | all |  | Only run this notification if the package name matches the regular expression
+packagePatternFlags| string | No |   | Any flags to be used with the regular expression
 headers| array/object | Yes | all |  | If this endpoint requires specific headers, set them here as an array of key: value objects.
 endpoint| string | Yes | all |  | set the URL endpoint for this call
 content| string | Yes | all |  | any Handlebar expressions  


### PR DESCRIPTION
**Type:** documentation

The following has been addressed in the PR:

* `packagePatternFlags` config option for `notify:` wasn't documented, but is in the [full example config file](https://github.com/verdaccio/verdaccio/blob/master/conf/full.yaml)
* This ports the comment from that file to the relevant wiki doc
