### PR TITLE
docs: Fix typos in plugins.md

### DIFF
--- a/wiki/plugins.md
+++ b/wiki/plugins.md
@@ -1,6 +1,6 @@
 # Plugins
 
-Verdaccio is an plugabble aplication. Currently supports multiple plugins only for [Auhtentification](auth.md) but there are plans to [improve the plugin system](https://github.com/verdaccio/verdaccio/issues/169). If you are intested to develop your own plugin, read the [development](development.md) section.
+Verdaccio is an plugabble aplication. Currently supports multiple plugins only for [Authentication](auth.md) but there are plans to [improve the plugin system](https://github.com/verdaccio/verdaccio/issues/169). If you are interested to develop your own plugin, read the [development](development.md) section.
 
 ## Usage
 


### PR DESCRIPTION
**Type:** documentation

The following has been addressed in the PR:
2 typos are fixed in `plugins.md`