### PR TITLE
Default config shows how to enable anonymous access.

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -25,6 +25,8 @@ packages:
     publish: $authenticated
     proxy: npmjs
   '**':
+    # access: $all # Uncomment to allow all users to pull from cache
+    #              # (note: beware DOS potential for publicly exposed installs)
     proxy: npmjs
 logs:
   - {type: stdout, format: pretty, level: http}


### PR DESCRIPTION
It is probably generally desirable to expose the npmjs cache to all users, but including it as the default opens unwary users to DOS abuse. Include the how without actually doing it.

P.S. I needed this for v2.3.6, perhaps newer versions don't?

<!-- Before Pull Request check whether your commits follow this convention
https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines
-->

<!-- 
  If your Pull Request fix an issue don't forget to update the unit test and documentation in /wiki folder
  If your Pull Request deliver a new feature, please, provide examples and why such feature should be considered, this information is    important to document the Github changelog. Also try to increase documentation and create new unit/functional test.  
-->

<!-- Pick only one type, whether none apply, please suggest one, we might be included it by default -->
**Type:** bug / feature / documentation / unit test / build

The following has been addressed in the PR:

<!-- Remove the sections that your PR does not apply -->
*  There is a related issue
*  Unit or Functional tests are included in the PR

<!--
Our bots should ensure:
* The PR passes CI testing
-->

<!-- If there is no issue related with this PR just remove the following section -->
**Description:**

Resolves #???

<!-- We are glad your code is part of this community, thanks for your valuable time !! --> 
