### PR TITLE
refactor: add node api to launch verdaccio programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 [![downloads badge](http://img.shields.io/npm/dm/verdaccio.svg)](https://www.npmjs.org/package/verdaccio)
 [![Gitter chat](https://badges.gitter.im/verdaccio/questions.png)](https://gitter.im/verdaccio/)
 [![Crowdin](https://d322cqt584bo4o.cloudfront.net/verdaccio/localized.svg)](https://crowdin.com/project/verdaccio)
-[![dependencies Status](https://david-dm.org/verdaccio/verdaccio/status.svg)](https://david-dm.org/verdaccio/verdaccio)
+[![dependencies Status](https://david-dm.org/verdaccio/verdaccio/status.svg)](https://david-dm.org/verdaccio/verdaccio)[![codecov](https://codecov.io/gh/verdaccio/verdaccio/branch/master/graph/badge.svg)](https://codecov.io/gh/verdaccio/verdaccio)
+
 
 <p align="center"><img src="https://firebasestorage.googleapis.com/v0/b/jotadeveloper-website.appspot.com/o/verdaccio_long_video2.gif?alt=media&token=4d20cad1-f700-4803-be14-4b641c651b41"></p>
 

--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,7 @@ test:
     - yarn run test
     - nvm alias default 9
     - yarn run test
+    - yarn run coverage:publish
     - echo "machine github.com login verdacciobot password $GITHUB_TOKEN" > ~/.netrc
     - cd website && yarn install && GIT_USER=verdacciobot USE_SSH=false yarn run publish-gh-pages
 deployment:

--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -1,0 +1,21 @@
+---
+id: node-api
+title: "Node API"
+---
+
+Verdaccio can be invoqued programmatically.
+
+## Usage
+
+#### Programmatically
+
+```js
+ import startServer from 'verdaccio';	
+
+ startServer(configJsonFormat, 6000, store, '1.0.0', 'verdaccio',
+    (webServer, addrs, pkgName, pkgVersion) => {
+		webServer.listen(addr.port || addr.path, addr.host, () => {
+			console.log('verdaccio running');
+		});
+  });
+```

--- a/index.js
+++ b/index.js
@@ -1,9 +1,1 @@
-module.exports = require('./src/api/index');
-
-/** package
-{ "name": "verdaccio",
-  "version": "0.0.0",
-  "dependencies": {"js-yaml": "*"},
-  "scripts": {"postinstall": "js-yaml package.yaml > package.json ; npm install"}
-}
-**/
+export {default as startVerdaccio} from './build/index';

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git://github.com/verdaccio/verdaccio"
   },
-  "main": "index.js",
+  "main": "build/index.js",
   "bin": {
     "verdaccio": "./bin/verdaccio"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,5 @@
+// @flow
+
+import {startVerdaccio} from './lib/bootstrap';
+
+export default startVerdaccio;

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -21,7 +21,7 @@ const logger = require('./logger');
     - localhost:5557
     @return {Array}
  */
-function getListListenAddresses(argListen, configListen) {
+export function getListListenAddresses(argListen, configListen) {
   // command line || config file || default
   let addresses;
   if (argListen) {
@@ -62,13 +62,6 @@ function startVerdaccio(config, cliListen, configPath, pkgVersion, pkgName, call
     throw new Error('config file must be an object');
   }
 
-  if (!config.self_path) {
-    config.self_path = Path.resolve(configPath);
-  }
-  if (!config.https) {
-    config.https = {enable: false};
-  }
-
   const app = server(config);
   const addresses = getListListenAddresses(cliListen, config.listen);
 
@@ -97,9 +90,9 @@ function unlinkAddressPath(addr) {
   }
 }
 
-function displayHTTPSWarning(configPath) {
+function displayHTTPSWarning(storageLocation) {
   const resolveConfigPath = function(file) {
-    return Path.resolve(Path.dirname(configPath), file);
+    return Path.resolve(Path.dirname(storageLocation), file);
   };
 
   logger.logger.fatal([
@@ -115,7 +108,7 @@ function displayHTTPSWarning(configPath) {
     ' $ openssl x509 -req -in ' + resolveConfigPath('verdaccio-csr.pem') +
     ' -signkey ' + resolveConfigPath('verdaccio-key.pem') + ' -out ' + resolveConfigPath('verdaccio-cert.pem'),
     '',
-    'And then add to config file (' + configPath + '):',
+    'And then add to config file (' + storageLocation + '):',
     '  https:',
     '    key: verdaccio-key.pem',
     '    cert: verdaccio-cert.pem',

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -3,6 +3,7 @@
 /* eslint no-sync:0 */
 /* eslint no-empty:0 */
 
+import path from 'path';
 import {startVerdaccio, listenDefaultCallback} from './bootstrap';
 import findConfigFile from './config-path';
 
@@ -49,6 +50,13 @@ try {
   configPathLocation = findConfigFile(commander.config);
   verdaccioConfiguration = Utils.parseConfigFile(configPathLocation);
   process.title = verdaccioConfiguration.web && verdaccioConfiguration.web.title || 'verdaccio';
+
+  if (!verdaccioConfiguration.self_path) {
+    verdaccioConfiguration.self_path = path.resolve(configPathLocation);
+  }
+  if (!verdaccioConfiguration.https) {
+    verdaccioConfiguration.https = {enable: false};
+  }
 
   logger.logger.warn({file: configPathLocation}, 'config file  - @{file}');
 } catch (err) {

--- a/test/unit/basic_system.spec.js
+++ b/test/unit/basic_system.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const express = require('express');
 const request = require('request');
 const rimraf = require('rimraf');
-const verdaccio = require('../../');
+const verdaccio = require('../../src/api/index');
 const config = require('./partials/config');
 
 const app = express();

--- a/test/unit/cli.spec.js
+++ b/test/unit/cli.spec.js
@@ -1,0 +1,60 @@
+import startServer from '../../src';
+import {getListListenAddresses} from '../../src/lib/bootstrap';
+import config from './partials/config';
+import path from 'path';
+import _ from 'lodash';
+
+require('../../src/lib/logger').setup([]);
+
+describe('startServer via API', () => {
+
+  describe('startServer launcher', () => {
+    test('should provide all server data', (done) => {
+      const store = path.join(__dirname, 'partials/store');
+
+      startServer(config, 6000, store, '1.0.0', 'verdaccio-test',
+        (webServer, addrs, pkgName, pkgVersion) => {
+          expect(webServer).toBeDefined();
+          expect(addrs).toBeDefined();
+          expect(addrs.proto).toBe('http');
+          expect(addrs.host).toBe('localhost');
+          expect(addrs.port).toBe('6000');
+          expect(pkgName).toBeDefined();
+          expect(pkgVersion).toBeDefined();
+          expect(pkgVersion).toBe('1.0.0');
+          expect(pkgName).toBe('verdaccio-test');
+          done();
+      });
+    });
+
+    test('should fails if config is missing', () => {
+      expect(() => { return startServer() }).toThrow('config file must be an object');
+    });
+
+  });
+
+  describe('getListListenAddresses test', () => {
+    test('should return by default 4873', () => {
+      const addrs = getListListenAddresses()[0];
+
+      expect(addrs.proto).toBe('http');
+      expect(addrs.host).toBe('localhost');
+      expect(addrs.port).toBe('4873');
+    });
+
+    test('should return a list of address and no cli argument provided', () => {
+      const addrs = getListListenAddresses(null, ['1000', '2000']);
+
+      expect(_.isArray(addrs)).toBeTruthy();
+    });
+
+    test('should return an address and no cli argument provided', () => {
+      const addrs = getListListenAddresses(null, '1000');
+
+      expect(_.isArray(addrs)).toBeTruthy();
+    });
+
+
+  });
+
+});

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -33,7 +33,8 @@
       "build",
       "contributing",
       "source-code",
-      "unit-testing"
+      "unit-testing",
+      "node-api"
     ],
     "Guides": ["protect-your-dependencies"]
   }


### PR DESCRIPTION
Verdaccio can be invoqued programmatically.

## Usage

#### Programmatically

```js
 import startServer from 'verdaccio';	

 startServer(configJsonFormat, 6000, store, '1.0.0', 'verdaccio',
    (webServer, addrs, pkgName, pkgVersion) => {
		webServer.listen(addr.port || addr.path, addr.host, () => {
			console.log('verdaccio running');
		});
  });
```
