### PR TITLE
add travis as secon ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+sudo: false
+node_js:
+  - 'lts/boron'
+  - 'lts/carbon'
+  - 'lts/*'
+script:
+  - npm install
+  - echo commitlint-travis
+  - npm run pre:ci
+  - npm run test


### PR DESCRIPTION
this is based on !470 and adds travis-ci using npm instead of yarn, so we can check npm and yarn with ci