### PR TITLE
Virtual `$scope` group to allow package scope groups (WIP)

### DIFF
--- a/test/functional/package/access.spec.js
+++ b/test/functional/package/access.spec.js
@@ -48,12 +48,15 @@ export default function(server) {
     const badCredentials = 'test:badpass';
     // test user is logged by default
     const validCredentials = 'test:test';
+    // another test user just for scope testing
+    const validScopeCredentials = 'test-only-scope:foobar';
 
     // defined on server1 configuration
     const testAccessOnly = 'test-access-only';
     const testPublishOnly = 'test-publish-only';
     const testOnlyTest = 'test-only-test';
     const testOnlyAuth = 'test-only-auth';
+    const testOnlyScope = '@test-only-scope/test-only-scope';
 
     // all are allowed to access
     checkAccess(validCredentials, testAccessOnly, true);
@@ -86,5 +89,13 @@ export default function(server) {
     checkPublish(validCredentials, testOnlyAuth, true);
     checkPublish(undefined, testOnlyAuth, false);
     checkPublish(badCredentials, testOnlyAuth, false);
+
+    // only authenticated users are allowed for their own scope
+    checkAccess(validScopeCredentials, testOnlyScope, true);
+    checkAccess(undefined, testOnlyScope, false);
+    checkAccess(badCredentials, testOnlyScope, false);
+    checkPublish(validScopeCredentials, testOnlyScope, true);
+    checkPublish(undefined, testOnlyScope, false);
+    checkPublish(badCredentials, testOnlyScope, false);
   });
 }

--- a/test/functional/store/config-1.yaml
+++ b/test/functional/store/config-1.yaml
@@ -1,6 +1,6 @@
 storage: ./test-storage
 
-max_users: 2
+max_users: 3
 
 web:
   enable: true
@@ -12,6 +12,9 @@ auth:
       test:
         name: test
         password: test
+      test-only-scope:
+        name: test-only-scope
+        password: foobar
 
 
 uplinks:
@@ -114,6 +117,11 @@ packages:
   'test-only-auth':
     allow_access: $authenticated
     allow_publish: $authenticated
+    storage: false
+
+  '@test-only-scope/*':
+    allow_access: $scope
+    allow_publish: $scope
     storage: false
 
   '*':


### PR DESCRIPTION
**Type:** feature

### Work in Progress

I opened pull request for hearing opinions and asking for help with the failing test cases.

The following has been addressed in the PR:

*  Add `$scope` (like `$authenticated`) virtual group support for replacing it with packages' scope (obviously for scoped packages only) to extend default auth functionalities
*  Simplify `allow_action` method by using (widely supported) `Array.prototype.some` instead of `Array.prototype.reduce`
*  Functional tests are included in the PR

<!--
Our bots should ensure:
* The PR passes CI testing
-->

<!-- If there is no issue related to this PR just remove the following section -->
**Description:**

This pr aims to add these two functionalities:

* Private organization

    Allow users with `myco` group to be able to access and publish packages to `@myco` scope (similar to private enabled organizations in npm)

    ```yaml
    packages:
      '@myco/*':
        allow_access: $scope
        allow_publish: $scope
    ```

* Public organization

    Allow users with `myorg` group to publish `@myorg` scope while everyone could access packages under that scope (similar to public orgs in npm).

    ```yaml
    packages:
      '@myorg/*':
        allow_access: $all
        allow_publish: $scope
    ```


### I need help with...

New tests I write fail, but I could not find the reason. I suspected `encodeURIComponent` encodes `@` sign [here](https://github.com/verdaccio/verdaccio/commit/96c9f459c18ecab0d57e28c9adf61c04926c5700#diff-04d07009857684ab352a0c726e6cc2c6R72) and behaves differently than the test [here](https://github.com/verdaccio/verdaccio/commit/a038b282ecbae92bbe8aef838554e1a1bb6f4ce3#diff-7d438d1d73482eeba9090e28b6725145R13). But using `server.request` directly in test did not work either. I will try to make tests work but would really appreciate any help!

Thank you for reading & reviewing.