### PR TITLE
Remove non-relevant capitalization on package name

### DIFF
--- a/src/webui/src/components/PackageDetail/packageDetail.scss
+++ b/src/webui/src/components/PackageDetail/packageDetail.scss
@@ -5,7 +5,6 @@
     font-size: 26px;
     color: $primary-color;
     border-bottom: 1px solid $border-color;
-    text-transform: capitalize;
     font-weight: 600;
     margin: 0 0 40px;
     padding-bottom: 5px;


### PR DESCRIPTION
__Description:__

The package name shown on the top of the package detail page is probably the best and more natural way for copying and reusing (e.g. in a `npm install`). However the point is that it's capitalized makes its use less relevant.

Resolves https://github.com/verdaccio/verdaccio/issues/583