### PR TITLE
docs: add link to  Circle CI 2.0 npm docs

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -3,12 +3,12 @@ id: ci
 title: "Continuous Integration"
 ---
 
-You may use verdaccio with continuous integration while login or publish. When 
-using NPM to install a private module in a continuous integration environment 
-for the first time, a brick wall is quickly hit. The NPM login command is 
-designed to be used interactively. This causes an issue in CI, scripts, etc. 
+You may use verdaccio with continuous integration while login or publish. When
+using NPM to install a private module in a continuous integration environment
+for the first time, a brick wall is quickly hit. The NPM login command is
+designed to be used interactively. This causes an issue in CI, scripts, etc.
 Here’s how to use NPM login different continuous integration platforms.
 
 - [Travis CI](https://remysharp.com/2015/10/26/using-travis-with-private-npm-deps)
-- [Circle CI 1.0](https://circleci.com/docs/1.0/npm-login/)
+- [Circle CI 1.0](https://circleci.com/docs/1.0/npm-login/) or [Circle CI 2.0](https://circleci.com/docs/2.0/deployment-integrations/#npm)
 - [Gitlab CI](https://www.exclamationlabs.com/blog/continuous-deployment-to-npm-using-gitlab-ci/)


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** CI Documentation


**Description:**

Circle CI will sunset it's 1.0 builds on 31 August 2018 in favour of the 2.0 builds
<!-- Resolves #??? -->
