### PR TITLE
feat: local-data cluster support

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "stylelint": "7.13.0",
     "stylelint-config-standard": "16.0.0",
     "stylelint-webpack-plugin": "0.8.0",
+    "touch": "^3.1.0",
     "url-loader": "0.5.8",
     "webpack": "3.2.0",
     "webpack-dev-server": "2.5.0",

--- a/src/lib/search.js
+++ b/src/lib/search.js
@@ -13,6 +13,13 @@ class Search {
    * Constructor.
    */
   constructor() {
+    this.createIndex();
+  }
+
+  /**
+   * Creates an empty search index.
+   */
+  createIndex() {
     this.index = lunr(function() {
       this.field('name', {boost: 10});
       this.field('description', {boost: 4});
@@ -60,6 +67,7 @@ class Search {
    * Force a reindex.
    */
   reindex() {
+    this.createIndex();
     let self = this;
     this.storage.get_local(function(err, packages) {
       if (err) throw err; // that function shouldn't produce any
@@ -77,6 +85,9 @@ class Search {
   configureStorage(storage) {
     this.storage = storage;
     this.reindex();
+    this.storage.localStorage.localList.on('data', (data) => {
+      this.reindex();
+    });
   }
 }
 

--- a/src/lib/storage/local/local-storage.js
+++ b/src/lib/storage/local/local-storage.js
@@ -49,6 +49,11 @@ class LocalStorage {
     this.config = config;
     this.utils = utils;
     this.localList = new LocalData(this._buildStoragePath(this.config));
+    this.localList.on('data', (data) => {
+      if (_.isNil(data) === false) {
+        data.secret = this.config.checkSecretKey(data.secret);
+      }
+    });
     this.logger = logger.child({sub: 'fs'});
   }
 

--- a/test/unit/local-data.spec.js
+++ b/test/unit/local-data.spec.js
@@ -5,6 +5,7 @@ const LocalData = require('../../src/lib/storage/local/local-data');
 const path = require('path');
 const _ = require('lodash');
 const fs = require('fs-extra');
+const touch = require('touch');
 
 
 describe('Local Database', function() {
@@ -34,6 +35,18 @@ describe('Local Database', function() {
       assert(error.message.match(/locked/));
       assert(dataLocal.locked);
     });
+
+    it('should emit an event when database file is touched', (done) => {
+      const dataPath = buildValidDbPath();
+      const dataLocal = new LocalData(dataPath);
+      dataLocal.on('data', (data) => {
+        assert(_.isEmpty(data.list) === false);
+        assert(_.isNil(data.secret) === false);
+        assert(_.isEqual(data, dataLocal.data));
+        done();
+      });
+      touch.sync(dataPath);
+    }).timeout(LocalData.DEFAULT_WATCH_POLL_INTERVAL + 100);
 
   });
 

--- a/test/unit/search.spec.js
+++ b/test/unit/search.spec.js
@@ -1,6 +1,8 @@
 'use strict';
 
-let assert = require('assert');
+const touch = require('touch');
+const assert = require('assert');
+const LocalData = require('../../src/lib/storage/local/local-data');
 let Search = require('../../src/lib/search');
 let Storage = require('../../src/lib/storage');
 let config_hash = require('./partials/config');
@@ -62,4 +64,24 @@ describe('search', function() {
 		result = Search.query('test6');
 		assert(result.length === 0);
 	});
+
+	it('should reindex when database file is touched', (done) => {
+		let item = {
+			name: 'test6',
+			description: 'description',
+			_npmUser: {
+				name: 'test_user',
+			},
+		};
+		Search.add(item);
+		let result = Search.query('test6');
+		assert(result.length === 1);
+		Search.storage.localStorage.localList.on('data', (data) => {
+			// The index should have been rebuilt.
+			let result = Search.query('test6');
+			assert(result.length === 0);
+			done();
+		});
+		touch.sync(config_hash.storage);
+	}).timeout(LocalData.DEFAULT_WATCH_POLL_INTERVAL + 100);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4754,7 +4754,7 @@ nopt@^4.0.1:
 
 nopt@~1.0.10:
   version "1.0.10"
-  resolved "http://npm.bdu.rocks/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  resolved "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
   dependencies:
     abbrev "1"
 
@@ -6799,7 +6799,7 @@ toposort@^1.0.0:
 
 touch@^3.1.0:
   version "3.1.0"
-  resolved "http://npm.bdu.rocks/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  resolved "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
   dependencies:
     nopt "~1.0.10"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4752,6 +4752,12 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+nopt@~1.0.10:
+  version "1.0.10"
+  resolved "http://npm.bdu.rocks/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  dependencies:
+    abbrev "1"
+
 normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5:
   version "2.4.0"
   resolved "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
@@ -6790,6 +6796,12 @@ topo@1.x.x:
 toposort@^1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz#f02cd8a74bd8be2fc0e98611c3bacb95a171869c"
+
+touch@^3.1.0:
+  version "3.1.0"
+  resolved "http://npm.bdu.rocks/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
+  dependencies:
+    nopt "~1.0.10"
 
 tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* There is a related open PR in Sinopia: https://github.com/rlidwka/sinopia/pull/271
*  Unit or Functional tests are included in the PR

**Description:**
* The _CLUSTER_ support for `local-storage` when multiple Verdaccio nodes (or containers) share a common File System mount.
* Introduces the `data` event emitted by a storage.
* Refreshes the LocalData list and Search index when underlying local (FS) database is changed by another process (by consuming the `data` event).
* Tested with:
  * Docker,
  * PM2,
  * Custom setup - 2 VMs with GPFS.

* Verdaccio version `3.x.x` - I can prepare separated PR, when there will be an interest to have this functionality.