### PR TITLE
docs: changed chown uid to 100 for docker

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -63,7 +63,7 @@ V_PATH=/path/for/verdaccio; docker run -it --rm --name verdaccio -p 4873:4873 \
   -v $V_PATH/storage:/verdaccio/storage \
   verdaccio/verdaccio
 ```
->Note: Verdaccio runs as a non-root user (uid=101, gid=101) inside the container, if you use bind mount to override default, you need to make sure the mount directory is assigned to the right user. In above example, you need to run `sudo chown -R 101:101 /opt/verdaccio` otherwise you will get permission errors at runtime. [Use docker volume](https://docs.docker.com/storage/volumes/) is recommended over using bind mount.
+>Note: Verdaccio runs as a non-root user (uid=100, gid=101) inside the container, if you use bind mount to override default, you need to make sure the mount directory is assigned to the right user. In above example, you need to run `sudo chown -R 100:101 /opt/verdaccio` otherwise you will get permission errors at runtime. [Use docker volume](https://docs.docker.com/storage/volumes/) is recommended over using bind mount.
 
 ### Docker and custom port configuration
 Any `host:port` configured in `conf/config.yaml` under `listen` is currently ignored when using docker.


### PR DESCRIPTION
**Type: documentation**

The following has been addressed in the PR:

*  This relates to issue #336
*  No tests are included as it is a trivial documentation change

**Description:**

May not resolve #336, but that issue culminates in a discussion around how the user ID should be 100 and the group ID should be 101. This is contrast to the documentation which says both the user ID and group ID should be 101, but this does not appear to work.

The documentation already makes clear that using bind mount is not the best approach (`docker volume` is) and this PR does not detract from that, but hopefully does make things easier for people who are not able to use `docker volumes` (e.g. people on docker versions <=1.8).