### PR TITLE
fix: allow do not include storage if uses a storage plugin

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -91,9 +91,7 @@ class Config {
     // some weird shell scripts are valid yaml files parsed as string
     assert.equal(typeof(config), 'object', 'CONFIG: it doesn\'t look like a valid config file');
 
-    assert(self.storage, 'CONFIG: storage path not defined');
-
-     // sanity check for strategic config properties
+    // sanity check for strategic config properties
     strategicConfigProps.forEach(function(x) {
       if (self[x] == null) self[x] = {};
       assert(Utils.isObject(self[x]), `CONFIG: bad "${x}" value (object expected)`);

--- a/src/lib/local-storage.js
+++ b/src/lib/local-storage.js
@@ -842,6 +842,7 @@ class LocalStorage implements IStorage {
     const Storage = this._loadStorePlugin();
 
     if (_.isNil(Storage)) {
+      assert(this.config.storage, 'CONFIG: storage path not defined');
       return new LocalDatabase(this.config, logger);
     } else {
       return Storage;

--- a/test/e2e/config/config-protected-e2e.yaml
+++ b/test/e2e/config/config-protected-e2e.yaml
@@ -1,4 +1,3 @@
-# this is useless yet since we use a custom storage, just ignore it
 web:
   enable: true
   title: verdaccio-server-protected-e2e

--- a/test/e2e/config/config-protected-e2e.yaml
+++ b/test/e2e/config/config-protected-e2e.yaml
@@ -1,6 +1,4 @@
 # this is useless yet since we use a custom storage, just ignore it
-storage: ./store-e2e
-
 web:
   enable: true
   title: verdaccio-server-protected-e2e

--- a/test/e2e/config/config-scoped-e2e.yaml
+++ b/test/e2e/config/config-scoped-e2e.yaml
@@ -1,4 +1,3 @@
-# this is useless yet since we use a custom storage, just ignore it
 web:
   enable: true
   title: verdaccio-server-e2e

--- a/test/e2e/config/config-scoped-e2e.yaml
+++ b/test/e2e/config/config-scoped-e2e.yaml
@@ -1,6 +1,4 @@
 # this is useless yet since we use a custom storage, just ignore it
-storage: ./store-e2e
-
 web:
   enable: true
   title: verdaccio-server-e2e


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** bug


**Description:**
In situations when we use storage plugins, `storage` property is not mandatory to be added. 

```
....
# path to a directory with all packages
# storage: /Users/user/.local/share/verdaccio/storage
auth:
  htpasswd:
    file: ./htpasswd
    # Maximum amount of users allowed to register, defaults to "+inf".
    # You can set this to -1 to disable registration.
    max_users: 100
store:
  memory:
    limit: 10
....
```

Resolves #673 
