### PR TITLE
fix(docs): clarify usage of uplink auth property

### DIFF
--- a/docs/uplinks.md
+++ b/docs/uplinks.md
@@ -34,11 +34,46 @@ maxage | string | No |10m | all | limit maximun failure request | 2m
 fail_timeout | string | No |10m | all | defines max time when a request becomes a failure | 5m
 max_fails | number | No |2 | all | limit maximun failure request | 2
 cache | boolean | No |[true,false] | >= 2.1 | avoid cache tarballs | true
-auth | list | No | type: [bearer], [token: "token",token_env: [true,\<get name process.env\>]]  | >= 2.5 | assigns the header 'Authorization' see: http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules | disabled
+auth | list | No | see below  | >= 2.5 | assigns the header 'Authorization' see: http://blog.npmjs.org/post/118393368555/deploying-with-npm-private-modules | disabled
 headers | list | No | authorization: "Bearer SecretJWToken==" | all | list of custom headers for the uplink | disabled
 strict_ssl |boolean | No | [true,false] | >= 3.0 | If true, requires SSL certificates be valid. | true
 
-> The `auth` property allows you to use a auth token via an environment variable, [clik here for an example](https://github.com/verdaccio/verdaccio/releases/tag/v2.5.0). 
+The `auth` property allows you to use an auth token with an uplink. Using the default environment variable:
+
+```yaml
+uplinks:
+  private:
+    url: https://private-registry.domain.com/registry
+    auth:
+      type: bearer
+      token_env: true # defaults to `process.env['NPM_TOKEN']`   
+```
+
+or via a specified environment variable: 
+
+```yaml
+uplinks:
+  private:
+    url: https://private-registry.domain.com/registry
+    auth:
+      type: bearer
+      token_env: FOO_TOKEN
+```
+
+`token_env: FOO_TOKEN `internally will use `process.env['FOO_TOKEN']`
+
+or by directly specifying a token:
+
+```yaml
+uplinks:
+  private:
+    url: https://private-registry.domain.com/registry
+    auth:
+      type: bearer
+      token: "token"
+```
+
+> Note: `token` has priority over `token_env`
 
 ### You Must know
 


### PR DESCRIPTION
**Description:**

Resolves #693 - **Uplink Auth Usage Documentation Is Wrong**

Adapted the guidance from @juanpicado [here](https://github.com/verdaccio/verdaccio/issues/693#issuecomment-388911933) to build out more concrete examples of how to use the `auth` property with an uplink.

* Informs users to "see below "when looking at the `auth` property in the configuration table. I find it too dificult to understand at a glance if these options are mutually exclusive. 

* Creates separate examples for each of the token options, genericized from my original issue and @juanpicado's guidance to not refer to artifactory directly. No need to mention a specific solution.

* Removes the need to refer to [the 2.5.0 release](https://github.com/verdaccio/verdaccio/releases/tag/v2.5.0), which incidentally does seem to have been updated since I originally reported the issue (thanks!). That should help future users finding that.

* Excludes `basic` as a type, per the documentation on this page. The guidance from @juanpicado included this, as does the release notes of 2.5.0. If we want to add that back in, please let me know.

* I had to submit this change using the GitHub editor interface because I could not build the site on two different Windows machines. Hopefully it looks okay to you.

Cheers!

