### PR TITLE
fix: remove useless warning ignoring tag

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -155,10 +155,6 @@ function tagVersion(data: Package, version: string, tag: StringValue) {
         return true;
       }
     }
-    Logger.logger.warn({ver: version, tag: tag}, 'ignoring bad version @{ver} in @{tag}');
-    if (tag && data[DIST_TAGS][tag]) {
-      delete data[DIST_TAGS][tag];
-    }
   }
   return false;
 }


### PR DESCRIPTION
**Type:** bug

**Description:**
The snippet removed does not have any impact and should be removed

 Resolves #702
