### PR TITLE
feat: support for npm audit fix #689

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ Verdaccio aims to support all features of a standard npm client that make sense 
 - Starring (npm star, npm unstar) - not supported, doesn't make sense in private registry
 - Ping (npm ping) - **supported**
 
+### Security
+
+- npm audit - **supported**
+
 ## FAQ / Contact / Troubleshoot
 
 If you have any issue you can try the following options, do no desist to ask or check our issues database, perhaps someone has asked already what you are looking for.

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -43,6 +43,11 @@ packages:
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs
 
+# To use `npm audit` comment out the following section
+#middlewares:
+#  audit:
+#    enabled: true
+
 # log settings
 logs:
   - {type: stdout, format: pretty, level: http}

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -43,7 +43,7 @@ packages:
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs
 
-# To use `npm audit` comment out the following section
+# To use `npm audit` uncomment the following section
 #middlewares:
 #  audit:
 #    enabled: true

--- a/conf/full.yaml
+++ b/conf/full.yaml
@@ -16,6 +16,11 @@ auth:
     # You can set this to -1 to disable registration.
     #max_users: 1000
 
+# Experimental built-in middlewares
+#middlewares:
+#  audit:
+#    enabled: true
+
 # a list of other known repositories we can talk to
 uplinks:
   npmjs:

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "pkginfo": "0.4.1",
     "request": "2.85.0",
     "semver": "5.5.0",
+    "verdaccio-audit": "0.0.3",
     "verdaccio-htpasswd": "0.2.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1658,6 +1658,21 @@ body-parser@1.18.2:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
+body-parser@1.18.3:
+  version "1.18.3"
+  resolved "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "~1.6.3"
+    iconv-lite "0.4.23"
+    on-finished "~2.3.0"
+    qs "6.5.2"
+    raw-body "2.3.3"
+    type-is "~1.6.16"
+
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"
@@ -4761,7 +4776,7 @@ http-errors@1.6.2:
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
 
-http-errors@1.6.3, http-errors@~1.6.2:
+http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
   version "1.6.3"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
   dependencies:
@@ -4835,7 +4850,7 @@ iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
-iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.23, iconv-lite@^0.4.17, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
   dependencies:
@@ -8026,7 +8041,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@^6.5.1, qs@~6.5.1:
+qs@6.5.2, qs@^6.5.1, qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
@@ -8122,6 +8137,15 @@ raw-body@2.3.2:
     bytes "3.0.0"
     http-errors "1.6.2"
     iconv-lite "0.4.19"
+    unpipe "1.0.0"
+
+raw-body@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz#1b324ece6b5706e153855bc1148c65bb7f6ea0c3"
+  dependencies:
+    bytes "3.0.0"
+    http-errors "1.6.3"
+    iconv-lite "0.4.23"
     unpipe "1.0.0"
 
 rc@^1.1.7:
@@ -8544,6 +8568,32 @@ request@2, request@2.85.0, request@^2.81.0, request@^2.83.0:
     qs "~6.5.1"
     safe-buffer "^5.1.1"
     stringstream "~0.0.5"
+    tough-cookie "~2.3.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.1.0"
+
+request@2.86.0:
+  version "2.86.0"
+  resolved "https://registry.npmjs.org/request/-/request-2.86.0.tgz#2b9497f449b0a32654c081a5cf426bbfb5bf5b69"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.6.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.1"
+    forever-agent "~0.6.1"
+    form-data "~2.3.1"
+    har-validator "~5.0.3"
+    hawk "~6.0.2"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.17"
+    oauth-sign "~0.8.2"
+    performance-now "^2.1.0"
+    qs "~6.5.1"
+    safe-buffer "^5.1.1"
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
@@ -10084,6 +10134,15 @@ vary@^1, vary@~1.1.2:
 vendors@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
+
+verdaccio-audit@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.npmjs.org/verdaccio-audit/-/verdaccio-audit-0.0.3.tgz#d7743b02286f845d5b84b4400a84769660a13223"
+  dependencies:
+    body-parser "1.18.3"
+    compression "1.7.2"
+    express "4.16.3"
+    request "2.86.0"
 
 verdaccio-auth-memory@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
**Type:** feature

**Description:**

This PR allow a built-in usage of `npm audit` command via verdaccio.

### Installation
```
npm install --global verdaccio@beta    
npm install --global verdaccio-audit
```

### Usage
To enable it you need to add this to your configuration file.
```
middlewares:
  audit:
    enabled: true
```

## Run

```
➜ verdaccio
 warn --- config file  - /Users/user/.config/verdaccio/config.yaml
 warn --- Plugin successfully loaded: htpasswd
 warn --- Plugin successfully loaded: audit
```

Note: **It's gonna be built-in in next beta but  disabled by default.**

Resolves #689 

Project: https://github.com/verdaccio/verdaccio-audit

track clients issues here: 
* yarn (https://github.com/yarnpkg/yarn/issues/5808)
* pnpm (https://github.com/pnpm/pnpm/issues/1153)