### PR TITLE
docs: Add a notification example for Google Hangouts Chat

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -10,7 +10,7 @@ commands.
 
 ## Usage
 
-An example with a **hipchat** hook:
+An example with a **HipChat** and **Google Hangouts Chat** hook:
 
 #### Single notification
 
@@ -26,23 +26,16 @@ notify:
 
 ```yaml
 notify:
-  'example-package-1'
+  'example-google-chat':
+    method: POST
+    headers: [{'Content-Type': 'application/json'}]
+    endpoint: https://chat.googleapis.com/v1/spaces/AAAAB_TcJYs/messages?key=myKey&token=myToken
+    content: '{"text":"New package published: `{{ name }}{{#each versions}} v{{version}}{{/each}}`"}'
+  'example-hipchat':
      method: POST
      headers: [{'Content-Type': 'application/json'}]
      endpoint: https://usagge.hipchat.com/v2/room/3729485/notification?auth_token=mySecretToken
      content: '{"color":"green","message":"New package published: * {{ name }}*","notify":true,"message_format":"text"}'
-  'example-package-2'
-     method: POST
-     headers: [{'Content-Type': 'application/json'}]
-     endpoint: https://usagge.hipchat.com/v2/room/3729485/notification?auth_token=mySecretToken
-     content: '{"color":"green","message":"New package published: * {{ name }}*","notify":true,"message_format":"text"}'
-  'example-package-3'
-     method: POST
-     headers: [{'Content-Type': 'application/json'}]
-     endpoint: https://usagge.hipchat.com/v2/room/3729485/notification?auth_token=mySecretToken
-     content: '{"color":"green","message":"New package published: * {{ name }}*","notify":true,"message_format":"text"}'
-
-
 ```
 
 ## Configuration
@@ -54,5 +47,4 @@ packagePattern| string | No | all |  | Only run this notification if the package
 packagePatternFlags| string | No | all |   | Any flags to be used with the regular expression
 headers| array/object | Yes | all |  | If this endpoint requires specific headers, set them here as an array of key: value objects.
 endpoint| string | Yes | all |  | set the URL endpoint for this call
-content| string | Yes | all |  | any Handlebar expressions
-
+content| string | Yes | all |  | any [handlebar](https://handlebarsjs.com/) expressions


### PR DESCRIPTION
Being a user of Google Hangouts Chat, I would have be happy to find an example of configuration.

Message format reference : https://developers.google.com/hangouts/chat/reference/message-formats/

This is what the notification looks like:
![image](https://user-images.githubusercontent.com/400034/40472225-208cff1c-5f39-11e8-8670-2b64ad167415.png)

This also fixes the multi-notification example by adding missing `:`