### PR TITLE
Fix spelling of authentication in plugins doc

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -22,7 +22,7 @@ registry=http://localhost:5555/
 
 #### Anonymous publish
 
-`verdaccio`allows you to enable anonymous publish, to achieve that you will need to set up correctly your [packages acces](packages.md).
+`verdaccio`allows you to enable anonymous publish, to achieve that you will need to set up correctly your [packages access](packages.md).
 
 Eg:
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -37,7 +37,7 @@ As is described [on issue #212](https://github.com/verdaccio/verdaccio/issues/21
 
 ## Default htpasswd
 
-In order to simplify the setup, `verdaccio` use a build-in plugin based on `htpasswd`.
+In order to simplify the setup, `verdaccio` use a built-in plugin based on `htpasswd`.
 
 ```yaml
 auth:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,7 +3,7 @@ id: plugins
 title: "Plugins"
 ---
 
-Verdaccio is an plugabble aplication. It can be extended in many ways, either new authentifications methods, adding 
+Verdaccio is an plugabble aplication. It can be extended in many ways, either new authentication methods, adding 
 endpoints or using a custom storage.
  
 > If you are interested to develop your own plugin, read the [development](development.md) section.


### PR DESCRIPTION
**Type:**
documentation

**Description:**
Fix spelling of authentication in plugins doc