### PR TITLE
fix reference to htpasswd plugin in auth docs

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -37,7 +37,10 @@ As is described [on issue #212](https://github.com/verdaccio/verdaccio/issues/21
 
 ## Default htpasswd
 
-In order to simplify the setup, `verdaccio` use a build-in plugin based on `htpasswd`.
+In order to simplify the setup, `verdaccio` use a plugin based on `htpasswd`.
+As of version v3.0.0-beta.x an [external plugin](https://github.com/verdaccio/verdaccio-htpasswd)
+is used by default. The v2.x version of this package still contains the
+built-in version of this plugin.
 
 ```yaml
 auth:


### PR DESCRIPTION
**Type:**
documentation

**Description:**
Fix reference to htpasswd plugin in auth docs.