### PR TITLE
docs: add verdaccio-profile-api plugin reference

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -126,6 +126,8 @@ modern verdaccio API and using the prefix as *verdaccio-xx-name*.
 
 * [verdaccio-audit](https://github.com/verdaccio/verdaccio-audit): verdaccio plugin for *npm audit* cli support (built-in) (compatible since 3.x)
 
+* [verdaccio-profile-api](https://github.com/ahoracek/verdaccio-profile-api): verdacci plugin for *npm profile* cli support and *npm profile set password* for *verdaccio-htpasswd* based authentificaton
+
 ### Storage Plugins
 
 (compatible since 3.x)


### PR DESCRIPTION
**Type:** docs
Add *verdacio-profile-api* plugin reference

The following has been addressed in the PR:

*  npm profile commands giving 404 error #392
*  No tests are included as it is a trivial documentation change

**Description:**
Referred plugin implements backend API for *npm profile* cli commands, including possibility to change password for *verdaccio-htpasswd* authentification
