### PR TITLE
fix: configure fetch to send cookies

### DIFF
--- a/src/webui/utils/api.js
+++ b/src/webui/utils/api.js
@@ -26,6 +26,7 @@ class API {
 
       return fetch(url, {
         method,
+        credentials: 'same-origin',
         ...options
       }).then(handleErrors);
     }


### PR DESCRIPTION

**Type: fix**

The following has been addressed in the PR:

*  Send cookies when using fetch

**Description:**

Previously, when __XMLHttpRequest__ was used, cookies were sent when getting _/-/verdaccio/logo_ and _/-/verdaccio/packages_

After switching to __fetch__ in sha fef7ee75e8a02dc3a6017b70dcb62dabf9183e0f cookies are no longer sent.

This commit configures fetch in the webui to send cookies to the same domain.

> The "same-origin" value makes fetch behave similarly to
> XMLHttpRequest with regards to cookies.
> https://github.com/github/fetch#sending-cookies

**Why cookies?**
I have a proxy in front of Verdaccio that handles authentication (using redirection to Azure AD). It sets a cookie at the end of authentication process. In versions prior to `3.0.0-beta.5` this worked well, but with beta 5 it broke, as the cookie wasn't sent for _/-/verdaccio/logo_ and _/-/verdaccio/packages_ resulting in the proxy issuing a `302` to redirect to the login page. 