### PR TITLE
chore(ci): fix publish step execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ aliases:
         - *repo_key
   - &ignore_branches
     filters:
+      tags:
+        only: /.*/
       branches:
         ignore:
           - gh-pages
@@ -166,7 +168,7 @@ jobs:
             yarn install
             GIT_USER=verdacciobot USE_SSH=false yarn run publish-gh-pages
 
-  deploy:
+  publish_package:
     <<: *defaults
     <<: *default_executor
     steps:
@@ -219,12 +221,13 @@ workflows:
             - test_node10
             - test_e2e
           <<: *ignore_branches
-      - deploy:
+      - publish_package:
           requires:
             - coverage
             - publish_gh_pages
           filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /(v)?[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore:
+                - /.*/


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** chore

The following has been addressed in the PR: 

*  There is a related issue? Part of #612 
*  This PR does not include Unit or Functional tests

**Description:**

This PR is a fix over https://github.com/verdaccio/verdaccio/pull/738 and https://github.com/verdaccio/verdaccio/pull/747. With this fix, we can trigger CircleCI execution on tag push events correctly. For more details on the solution, look at  https://github.com/verdaccio/verdaccio/issues/612#issuecomment-396517868

<!-- Resolves #612  -->
