### PR TITLE
fix: replace static endpoint in case of reverse proxy

### DIFF
--- a/tools/webpack.config.js
+++ b/tools/webpack.config.js
@@ -7,7 +7,7 @@ module.exports = {
   output: {
     path: `${env.APP_ROOT}/static/`,
     filename: '[name].[hash].js',
-    publicPath: '/-/static',
+    publicPath: 'ToReplaceByVerdaccio/-/static',
   },
 
   resolve: {


### PR DESCRIPTION
Pull request for issue 753.
https://github.com/verdaccio/verdaccio/issues/753

This will add the "ToReplaceByVerdaccio" back into the  /verdaccio/static/index.html on build.
proxy replacements are done bij the nodejs backend. see /verdaccio/src/api/web/index.js line 45

Screen shot of the 404 errors when using reverse proxy at this time.
![image](https://user-images.githubusercontent.com/4007585/41359596-22743b86-6f2b-11e8-9daa-a139d89ff521.png)
![image](https://user-images.githubusercontent.com/4007585/41359658-455b932e-6f2b-11e8-8ba8-8b5b93be3585.png)
