### PR TITLE
feat: Add basic package infos and resource links to sidebar.

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -36,6 +36,11 @@ notify:
      headers: [{'Content-Type': 'application/json'}]
      endpoint: https://usagge.hipchat.com/v2/room/3729485/notification?auth_token=mySecretToken
      content: '{"color":"green","message":"New package published: * {{ name }}*","notify":true,"message_format":"text"}'
+  'example-stride':
+     method: POST
+     headers: [{'Content-Type': 'application/json'}, {'authorization': 'Bearer secretToken'}]
+     endpoint: https://api.atlassian.com/site/{cloudId}/conversation/{conversationId}/message
+     content: '{"body": {"version": 1,"type": "doc","content": [{"type": "paragraph","content": [{"type": "text","text": "New package published: * {{ name }}* Publisher name: * {{ publisher.name }}"}]}]}}'     
 ```
 
 ### Publisher information

--- a/src/webui/src/components/PackageSidebar/index.jsx
+++ b/src/webui/src/components/PackageSidebar/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import LastSync from './modules/LastSync';
 import Maintainers from './modules/Maintainers';
 import Dependencies from './modules/Dependencies';
+import Infos from './modules/Infos';
 
 import API from '../../../utils/api';
 
@@ -53,6 +54,7 @@ export default class PackageSidebar extends React.Component {
     return packageMeta ?
       (<aside className="sidebar-info">
         <LastSync packageMeta={packageMeta} />
+        <Infos packageMeta={packageMeta} />
         <Maintainers packageMeta={packageMeta} />
         <Dependencies packageMeta={packageMeta} />
         {/* Package management module? Help us implement it! */}

--- a/src/webui/src/components/PackageSidebar/modules/Infos/index.jsx
+++ b/src/webui/src/components/PackageSidebar/modules/Infos/index.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import get from 'lodash/get';
+import Module from '../../Module';
+
+import classes from './style.scss';
+
+export default class Infos extends React.Component {
+  static propTypes = {
+    packageMeta: PropTypes.object.isRequired
+  };
+
+  get infos() {
+    const homepage = this.normalizeInfo(get(this, 'props.packageMeta.latest.homepage', null));
+    const repo = this.normalizeInfo(get(this, 'props.packageMeta.latest.repository', null));
+    const license = get(this, 'props.packageMeta.latest.license', 'N/A');
+
+    return {homepage, repo, license};
+  }
+
+  normalizeInfo(infoObj) {
+    if (typeof infoObj === 'string') {
+      return {url: infoObj};
+    } else if (infoObj === null) {
+      return {url: ''};
+    }
+
+    infoObj.url = infoObj.url.replace(/^git\+/, '');
+
+    return infoObj;
+  }
+
+  render() {
+    const infos = this.infos;
+
+    if (!infos.homepage.url && !infos.repo.url && infos.license === 'N/A') {
+      return '';
+    }
+
+    return (
+      <Module
+        title="Infos"
+        className={classes.infosModule}
+      >
+        <ul>
+          {infos.homepage.url &&
+            <li><span>Homepage</span><a href={infos.homepage.url} target="_blank">{infos.homepage.url}</a></li>
+          }
+
+          {infos.repo.url &&
+            <li><span>Repository</span><a href={infos.repo.url} target="_blank">{infos.repo.url}</a></li>
+          }
+
+          {infos.license &&
+            <li><span>License</span><span>{infos.license}</span></li>
+          }
+        </ul>
+      </Module>
+    );
+  }
+}

--- a/src/webui/src/components/PackageSidebar/modules/Infos/index.jsx
+++ b/src/webui/src/components/PackageSidebar/modules/Infos/index.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import Module from '../../Module';
+import isString from 'lodash/isString';
+import isNil from 'lodash/isNil';
 
 import classes from './style.scss';
 
@@ -19,21 +21,25 @@ export default class Infos extends React.Component {
   }
 
   normalizeInfo(infoObj) {
-    if (typeof infoObj === 'string') {
+    if (isString(infoObj)) {
       return {url: infoObj};
-    } else if (infoObj === null) {
+    } else if (isNil(infoObj)) {
       return {url: ''};
     }
 
-    infoObj.url = infoObj.url.replace(/^git\+/, '');
+    infoObj.url = this.normalizeGitUrl(infoObj);
 
     return infoObj;
+  }
+
+  normalizeGitUrl(infoObj) {
+    return infoObj.url.replace(/^git\+/, '');
   }
 
   render() {
     const infos = this.infos;
 
-    if (!infos.homepage.url && !infos.repo.url && infos.license === 'N/A') {
+    if (infos.homepage.url === '' && infos.repo.url === '' && infos.license === 'N/A') {
       return '';
     }
 
@@ -43,19 +49,21 @@ export default class Infos extends React.Component {
         className={classes.infosModule}
       >
         <ul>
-          {infos.homepage.url &&
-            <li><span>Homepage</span><a href={infos.homepage.url} target="_blank">{infos.homepage.url}</a></li>
-          }
+          {infos.homepage.url && this.renderSection('Homepage', infos.homepage.url)}
 
-          {infos.repo.url &&
-            <li><span>Repository</span><a href={infos.repo.url} target="_blank">{infos.repo.url}</a></li>
-          }
+          {infos.repo.url && this.renderSection('Repository', infos.repo.url)}
 
           {infos.license &&
             <li><span>License</span><span>{infos.license}</span></li>
           }
         </ul>
       </Module>
+    );
+  }
+
+  renderSection(title, url) {
+    return (
+      <li><span>{title}</span><a href={url} target="_blank">{url}</a></li>
     );
   }
 }

--- a/src/webui/src/components/PackageSidebar/modules/Infos/style.scss
+++ b/src/webui/src/components/PackageSidebar/modules/Infos/style.scss
@@ -1,0 +1,22 @@
+@import '../../../../styles/variable';
+
+.infosModule {
+  li {
+    display: flex;
+    font-size: 14px;
+    line-height: 2;
+
+    a {
+      color: inherit;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      max-width: 150px;
+    }
+    
+    a:last-child,
+    span:last-child {
+      margin-left: auto;
+    }
+  }
+}

--- a/test/webui/components/PackageSidebar/__snapshots__/infos.spec.js.snap
+++ b/test/webui/components/PackageSidebar/__snapshots__/infos.spec.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<PackageSidebar /> : <Infos /> should load the Info component and match snapshot 1`] = `"<div class=\\"module infosModule\\"><h2 class=\\"moduleTitle\\">Infos</h2><div><ul><li><span>Homepage</span><a href=\\"https://github.com/verdaccio/verdaccio#readme\\" target=\\"_blank\\">https://github.com/verdaccio/verdaccio#readme</a></li><li><span>Repository</span><a href=\\"git://github.com/verdaccio/verdaccio.git\\" target=\\"_blank\\">git://github.com/verdaccio/verdaccio.git</a></li><li><span>License</span><span>WTFPL</span></li></ul></div></div>"`;

--- a/test/webui/components/PackageSidebar/infos.spec.js
+++ b/test/webui/components/PackageSidebar/infos.spec.js
@@ -1,5 +1,5 @@
 /**
- * LastSync component
+ * Infos component
  */
 
 import React from 'react';

--- a/test/webui/components/PackageSidebar/infos.spec.js
+++ b/test/webui/components/PackageSidebar/infos.spec.js
@@ -1,0 +1,29 @@
+/**
+ * LastSync component
+ */
+
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+import Infos from '../../../../src/webui/src/components/PackageSidebar/modules/Infos';
+import { packageMeta } from '../store/packageMeta';
+ 
+console.error = jest.fn();
+
+describe('<PackageSidebar /> : <Infos />', () => {
+  it('should load the component and check getter: info with package data', () => {
+    const wrapper = mount(<Infos packageMeta={packageMeta} />);
+    const instance = wrapper.instance();
+    const result = {
+      repo: { type: 'git', url: 'git://github.com/verdaccio/verdaccio.git' },
+      homepage: { url: 'https://github.com/verdaccio/verdaccio#readme' },
+      license: 'WTFPL'
+    };
+
+    expect(instance.infos).toEqual(result);
+  });
+
+  it('should load the Info component and match snapshot', () => {
+    const wrapper = shallow(<Infos packageMeta={packageMeta} />);
+    expect(wrapper.html()).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
It's my very first time working with this kind of front end stack. From webpack to react, so I hope I didn't write too terrible code.

I've added a new module to the sidebar that shows a link to the package homepage, repository and license if available in the meta data.

It's a very basic implementation that probably doesn't catch a lot of the edge cases (especially in regards of the repository url), but maybe a starting point?

![auswahl_001](https://user-images.githubusercontent.com/11567985/41382334-02ee8b72-6f6c-11e8-80cb-37803275b3b5.jpg)


<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

<!-- Resolves #??? -->
