### PR TITLE
fix: adds webpack banner plugin to tag bundles with version (#784)

### DIFF
--- a/tools/getPackageJson.js
+++ b/tools/getPackageJson.js
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * A module to get package informations from package.json
+ * @module getPackageJson
+ * @param {...string} keys from package.json if no arguments passed it returns package.json content as object
+ * @returns {object} with given keys or content of package.json as object
+ */
+
+/**
+ * Returns package info
+ */
+const getPackageJson = function(...args) {
+  const packageJSON = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json')));
+  if (!args.length) {
+    return packageJSON;
+  }
+  return args.reduce((out, key) => {
+    out[key] = packageJSON[key];
+    return out;
+  }, {});
+};
+
+module.exports = getPackageJson;

--- a/tools/getPackageVersion.js
+++ b/tools/getPackageVersion.js
@@ -1,9 +1,0 @@
-import fs from 'fs';
-import path from 'path';
-
-export default function getPackageVersion() {
-  let packageJSON = JSON.parse(fs.readFileSync(path.join(__dirname, '../package.json')));
-
-  return packageJSON.version;
-}
-

--- a/tools/webpack.dev.config.babel.js
+++ b/tools/webpack.dev.config.babel.js
@@ -4,7 +4,7 @@ import FriendlyErrorsPlugin from 'friendly-errors-webpack-plugin';
 import baseConfig from './webpack.config';
 import env from '../src/config/env';
 import StyleLintPlugin from 'stylelint-webpack-plugin';
-import getPackageVersion from './getPackageVersion';
+import getPackageJson from './getPackageJson';
 
 export default {
   ...baseConfig,
@@ -31,7 +31,7 @@ export default {
   plugins: [
     new webpack.DefinePlugin({
       __DEBUG__: true,
-      __APP_VERSION__: `"${getPackageVersion()}"`,
+      __APP_VERSION__: `"${getPackageJson('version')}"`,
     }),
     new HTMLWebpackPlugin({
       title: 'Verdaccio',

--- a/tools/webpack.prod.config.babel.js
+++ b/tools/webpack.prod.config.babel.js
@@ -7,7 +7,21 @@ const baseConfig = require('./webpack.config');
 const env = require('../src/config/env');
 const _ = require('lodash');
 const merge = require('webpack-merge');
-import getPackageVersion from './getPackageVersion';
+const getPackageJson = require('./getPackageJson');
+
+const {
+  version,
+  name,
+  license,
+} = getPackageJson('version', 'name', 'license');
+
+const banner = `
+    Name: [name]
+    Generated on: ${Date.now()}
+    Package: ${name}
+    Version: v${version}
+    License: ${license}
+    `;
 
 const prodConf = {
   mode: 'production',
@@ -24,7 +38,7 @@ const prodConf = {
     new webpack.DefinePlugin({
       __DEBUG__: false,
       'process.env.NODE_ENV': '"production"',
-      __APP_VERSION__: `"${getPackageVersion()}"`,
+      __APP_VERSION__: `"${version}"`,
     }),
     new MiniCssExtractPlugin({
       filename: 'style.[contenthash].css',
@@ -38,6 +52,7 @@ const prodConf = {
       debug: false,
       inject: true,
     }),
+    new webpack.BannerPlugin(banner),
   ],
 
   optimization: {
@@ -55,6 +70,6 @@ prodConf.module.rules = baseConfig.module.rules
     Array.isArray(loader.use) && loader.use.find((v) => /css/.test(v.loader.split('-')[0]))
   ).forEach((loader) => {
     loader.use = [MiniCssExtractPlugin.loader].concat(_.tail(loader.use));
-});
+  });
 
 module.exports = merge(baseConfig, prodConf);


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** good first issue

**Description:**  Added webpack banner plugin to tag bundles with current version for web ui production build (yarn run build:webui).
e.g. 
```javascript
/*!
 * 
 *     Name: 1
 *     Generated on: 1529912145630
 *     Package: verdaccio
 *     Version: v3.2.0
 *     License: MIT
 *     
 */
```  

Resolves #784 
