### PR TITLE
chore(ci): improve the workflow publishing doc only when releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ aliases:
     restore_cache:
       keys:
         - *repo_key
-  - &ignore_branches
+  - &ignore_non_dev_branches
     filters:
       tags:
         only: /.*/
@@ -41,6 +41,13 @@ aliases:
           - gh-pages
           - l10n_master
           - /release\/.*/
+  - &execute_on_release
+    filters:
+      tags:
+        only: /(v)?[0-9]+(\.[0-9]+)*/
+      branches:
+        ignore:
+          - /.*/
 
 jobs:
   prepare:
@@ -187,27 +194,27 @@ workflows:
   workflow:
     jobs:
       - prepare:
-          <<: *ignore_branches
+          <<: *ignore_non_dev_branches
       - test_node6:
           requires:
             - prepare
-          <<: *ignore_branches
+          <<: *ignore_non_dev_branches
       - test_node8:
           requires:
             - prepare
-          <<: *ignore_branches
+          <<: *ignore_non_dev_branches
       - test_node9:
           requires:
             - prepare
-          <<: *ignore_branches
+          <<: *ignore_non_dev_branches
       - test_node10:
           requires:
             - prepare
-          <<: *ignore_branches
+          <<: *ignore_non_dev_branches
       - test_e2e:
           requires:
             - prepare
-          <<: *ignore_branches
+          <<: *ignore_non_dev_branches
       - coverage:
           requires:
             - test_node6
@@ -215,7 +222,7 @@ workflows:
             - test_node9
             - test_node10
             - test_e2e
-          <<: *ignore_branches
+          <<: *ignore_non_dev_branches
       - publish_gh_pages:
           requires:
             - test_node6
@@ -223,14 +230,9 @@ workflows:
             - test_node9
             - test_node10
             - test_e2e
-          <<: *ignore_branches
+          <<: *execute_on_release
       - publish_package:
           requires:
             - coverage
             - publish_gh_pages
-          filters:
-            tags:
-              only: /(v)?[0-9]+(\.[0-9]+)*/
-            branches:
-              ignore:
-                - /.*/
+          <<: *execute_on_release


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** chore

The following has been addressed in the PR:

*  There is a related issue? Part of #612 
*  This PR does not include Unit or Functional tests

**Description:** In this PR, we improve the workflow by executing `publish_gh_pages` step only on release. Also, renamed `ignore_branches` constant to `ignore_not_dev_branches` to be more expressive.

As `publish_gh_pages` will not execute every time, we should unset the check on this step (as we did with release step).

<!-- Resolves #612 -->
