### PR TITLE
chore(ci): fix test and functional test execution in same command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,9 @@ jobs:
       - *restore_repo
       - run:
           name: Test with Node 8
-          command: yarn test
-          command: yarn test:functional
+          command: |
+            yarn test
+            yarn test:functional
 
   test_node9:
     <<: *defaults
@@ -119,8 +120,9 @@ jobs:
       - *restore_repo
       - run:
           name: Test with Node 9
-          command: yarn test
-          command: yarn test:functional
+          command: |
+            yarn test
+            yarn test:functional
       - save_cache:
           key: *coverage_key
           paths:
@@ -133,8 +135,9 @@ jobs:
       - *restore_repo
       - run:
           name: Test with Node 10
-          command: yarn run test
-          command: yarn test:functional
+          command: |
+            yarn run test
+            yarn test:functional
 
   test_e2e:
     <<: *defaults


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** chore

The following has been addressed in the PR:

*  There is a related issue? Part of #612
*  This PR does not include Unit or Functional tests

**Description:** There was a problem when we chaining the execution of tests and functional tests, duplicating `command` in a single `run`. With this, CircleCI takes the last `command` found as the command to perform, ignoring any other before. That is because YAML treat them as object keys (Js simile) and override every occurence before.

The syntax to chain several commands is:

```yaml
- run:
    name: 'Name of the step'
    command: |
      echo 'first command'
      echo 'second command'
      # ...
      echo 'Nth command' 
```

<!-- Resolves #612 -->
