### PR TITLE
add verdaccio-github-oauth

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -121,6 +121,7 @@ modern verdaccio API and using the prefix as *verdaccio-xx-name*.
 * [verdaccio-active-directory](https://github.com/nowhammies/verdaccio-activedirectory): Active Directory authentication plugin for verdaccio
 * [verdaccio-gitlab](https://github.com/bufferoverflow/verdaccio-gitlab): use GitLab Personal Access Token to authenticate
 * [verdaccio-htpasswd](https://github.com/verdaccio/verdaccio-htpasswd): Auth based on htpasswd file plugin (built-in) for verdaccio
+* [verdaccio-github-oauth](https://github.com/aroundus-inc/verdaccio-github-oauth): Github oauth authentication plugin for verdaccio.
 
 ### Middleware Plugins
 


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** documentation

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**
You can use `sinopia-github-oauth` with verdaccio but it throws an error because of missing `Auth.prototype.aes_encrypt` in verdaccio which exists in sinopia. So I published fixed version [verdaccio-github-oauth](https://www.npmjs.com/package/verdaccio-github-oauth). I already applied this to company's private verdaccio repository @aroundus-inc and working well.

- Error log
```plain
 fatal--- uncaught exception, please report this
TypeError: auth.aes_encrypt is not a function
    at IncomingMessage.<anonymous> (/usr/local/app/node_modules/sinopia-github-oauth/index.js:143:30)
    at IncomingMessage.emit (events.js:187:15)
    at IncomingMessage.EventEmitter.emit (domain.js:442:20)
    at endReadableNT (_stream_readable.js:1090:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

<!-- Resolves #??? -->
