### PR TITLE
refactor: replaces componentWillMount with componentDidMount

### DIFF
--- a/src/webui/src/components/Header/index.js
+++ b/src/webui/src/components/Header/index.js
@@ -43,7 +43,7 @@ export default class Header extends React.Component {
     });
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.loadLogo();
   }
 


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:
In some places in our code base, I found that we are using componentWillMount for API calls and setting the state. It is better to stop using this because it is an anti-pattern. It will be deprecated in newer react versions.

For api calls use use componentDidMount

Current Issue : facebook/react#7671 (comment)

React docs also states that to use class constructor for initialization.

Docs: https://reactjs.org/docs/react-component.html#unsafe_componentwillmount

**Description:**
- Replace `componentWillMount` with `componentDidMount`

<!-- Resolves #??? -->
