### PR TITLE
chore: fix docker build behind a corporate proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:10.3-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
-RUN apk --no-cache add openssl && \
+RUN apk --no-cache add wget openssl && \
     wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64 && \
     chmod +x /usr/local/bin/dumb-init && \
     apk del openssl && \


### PR DESCRIPTION
installs full-fledged wget in alpine, so that it honors proxy
environment variables

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type: build**

The following has been addressed in the PR:

*  There is a related issue? No
*  Unit or Functional tests are included in the PR: Same as existing

**Description:**
When building docker behind a corporate proxy, and having proxy environment variables setup, the build cannot be completed because the wget version included in busybox does not honor the envvars. This PR adds the full-fledged wget command that does use the variables when downloading.

This will apply when e.g. a config like this is applied in `.docker/config.json`:
```
     "proxies":
     {
         "default":
         {
             "httpProxy": "...",
             "httpsProxy": "...",
             "noProxy": "..."
         }
     }
```
<!-- Resolves #??? -->
