### PR TITLE
feat: use PrismJS to highlight README code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "normalize.css": "8.0.0",
     "optimize-css-assets-webpack-plugin": "5.0.0",
     "ora": "1.4.0",
+    "prismjs": "1.15.0",
     "prop-types": "15.6.1",
     "puppeteer": "1.1.1",
     "react": "16.4.2",

--- a/src/webui/modules/detail/SyntaxHighlighter.js
+++ b/src/webui/modules/detail/SyntaxHighlighter.js
@@ -1,0 +1,37 @@
+import Prism from 'prismjs/components/prism-core';
+
+import 'prismjs/themes/prism.css';
+
+// NOTE: import order is important
+import 'prismjs/components/prism-clike';
+
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-css-extras';
+import 'prismjs/components/prism-less';
+import 'prismjs/components/prism-sass';
+import 'prismjs/components/prism-scss';
+
+import 'prismjs/components/prism-markup';
+import 'prismjs/components/prism-markup-templating';
+
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-jsx';
+import 'prismjs/components/prism-tsx';
+import 'prismjs/components/prism-flow';
+
+import 'prismjs/components/prism-json';
+import 'prismjs/components/prism-yaml';
+
+import 'prismjs/components/prism-markdown';
+
+import 'prismjs/components/prism-sql';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-git';
+import 'prismjs/components/prism-graphql';
+
+module.exports = {
+  highlightAll: function() {
+    Prism.highlightAll();
+  }
+};

--- a/src/webui/modules/detail/index.jsx
+++ b/src/webui/modules/detail/index.jsx
@@ -2,6 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {Loading} from 'element-react';
 import isEmpty from 'lodash/isEmpty';
+import SyntaxHighlighter from './SyntaxHighlighter';
 
 import PackageDetail from '../../components/PackageDetail';
 import NotFound from '../../components/NotFound';
@@ -33,6 +34,7 @@ export default class Detail extends Component {
 
   async componentDidMount() {
     await this.loadPackageInfo(this.packageName);
+    SyntaxHighlighter.highlightAll();
   }
 
   componentDidUpdate(newProps) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,6 +2201,14 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
+clipboard@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/clipboard/-/clipboard-2.0.1.tgz#a12481e1c13d8a50f5f036b0560fe5d16d74e46a"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -3118,6 +3126,10 @@ del@^3.0.0:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -4513,6 +4525,12 @@ gonzales-pe@4.2.3:
   resolved "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz#41091703625433285e0aee3aa47829fc1fbeb6f2"
   dependencies:
     minimist "1.1.x"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.4:
   version "4.1.11"
@@ -8049,6 +8067,12 @@ prettycli@^1.4.3:
   dependencies:
     chalk "2.1.0"
 
+prismjs@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.npmjs.org/prismjs/-/prismjs-1.15.0.tgz#8801d332e472091ba8def94976c8877ad60398d9"
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.npmjs.org/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -8955,6 +8979,10 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+
 selfsigned@^1.9.1:
   version "1.10.3"
   resolved "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz#d628ecf9e3735f84e8bafba936b3cf85bea43823"
@@ -9798,6 +9826,10 @@ timers-browserify@^2.0.4:
 timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
+
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
**Type: Feature**

The following has been addressed in the PR:

*  Related issue: https://github.com/verdaccio/verdaccio/issues/281

**Description:**

Resolves #281

This PR uses PrismJS to apply syntax highlighting to code blocks in README.md files.

As this is a web / UI change there is no simple way to unit test the change. Any suggestions are welcome!
