### PR TITLE
Let the Login Button Be Replaced with a Link to Support More Auth Flows

### DIFF
--- a/docs/dev-plugins.md
+++ b/docs/dev-plugins.md
@@ -3,13 +3,25 @@ id: dev-plugins
 title: "Developing Plugins"
 ---
 
-There are many ways to extend `verdaccio`, currently we support `authentication plugins`, `middleware plugins` (since `v2.7.0`) and `storage plugins` since (`v3.x`).
+There are many ways to extend `verdaccio`, currently we support [authentication plugins](#authentication-plugin), [middleware plugins](#middleware-plugin) (since `v2.7.0`) and [storage plugins](#storage-plugin) since (`v3.x`).
 
 ## Authentication Plugin
 
-This section will describe how it looks like a Verdaccio plugin in a ES5 way. Basically we have to return an object with a single method called `authenticate` that will recieve 3 arguments (`user, password, callback`). Once the authentication has been executed there is 2 options to give a response to `verdaccio`.
+This section describes how to make an authentication plugin in an ES5 way.
 
-### API
+There are two ways to create an authentication plugin:
+* Providing an object with a `authenticate` function to handle the username/password input to the login modal.
+* Providing an object with a `login_url` property to redirect the user to a different login page
+
+### `authenticate`
+
+The `authenticate` function takes three arguments:
+
+| Name     | Type     | Description  |
+| -------- | -------- | ------------ |
+| user     |`string`  | the username |
+| password |`string`  | the password |
+| callback |`function`| the callback |
 
 ```js
 function authenticate (user, password, callback) {
@@ -21,7 +33,7 @@ function authenticate (user, password, callback) {
 
 Either something bad happened or auth was unsuccessful.
 
-```
+```javascript
 callback(null, false)
 ```
 
@@ -32,9 +44,28 @@ The auth was successful.
 
 `groups` is an array of strings where the user is part of.
 
-```
+```javascript
  callback(null, groups);
 ```
+
+### `login_page`
+
+Instead of providing an `authenticate` function you can provide a `login_url` to send the user to when they click the login button.
+
+#### Using `login_page`
+
+Here's an example of using `login_page` in an authentication plugin:
+
+```javascript
+module.exports = {
+  // When the user clicks the login button they will be sent to /login_page
+  //
+  // The login_url is relative to the url_prefix in the config file, so if url_prefix is set to
+  // "http://foo.com/bar", then clicking the login button will send the user to http://foo.com/bar/login_page
+  login_url: '/login_page'
+};
+```
+
 
 ### Example
 
@@ -81,7 +112,7 @@ Where `htpasswd` is the sufix of the plugin name. eg: `verdaccio-htpasswd` and t
 ## Middleware Plugin
 
 Middleware plugins have the capability to modify the API layer, either adding new endpoints or intercepting requests.
- 
+
 > A pretty good example
 of middleware plugin is the [sinopia-github-oauth](https://github.com/soundtrackyourbrand/sinopia-github-oauth) and [verdaccio-audit](https://github.com/verdaccio/verdaccio-audit).
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@commitlint/cli": "6.1.3",
     "@commitlint/config-conventional": "6.1.3",
-    "@verdaccio/types": "3.4.2",
+    "@verdaccio/types": "3.5.1",
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",
     "babel-eslint": "8.2.2",

--- a/src/api/web/index.js
+++ b/src/api/web/index.js
@@ -41,9 +41,10 @@ module.exports = function(config, auth, storage) {
 
   router.get('/', function(req, res) {
     const base = Utils.combineBaseUrl(Utils.getWebProtocol(req), req.get('host'), config.url_prefix);
-    let webPage = template
+    const webPage = template
       .replace(/ToReplaceByVerdaccio/g, base)
-      .replace(/ToReplaceByTitle/g, _.get(config, 'web.title') ? config.web.title : WEB_TITLE);
+      .replace(/ToReplaceByTitle/g, _.get(config, 'web.title') ? config.web.title : WEB_TITLE)
+      .replace(/ToReplaceByLogin/g, auth.login_url ? `${base}/${auth.login_url.replace(/^\/+/, '')}` : '');
 
     res.setHeader('Content-Type', 'text/html');
 

--- a/src/webui/components/Header/index.js
+++ b/src/webui/components/Header/index.js
@@ -143,7 +143,11 @@ export default class Header extends React.Component {
         </div>
       );
     } else {
-      return <Button className={`${classes.headerButton} header-button-login`} onClick={ this.toggleLoginModal }>Login</Button>;
+      if (window.LOGIN_URL) {
+        return <a className={`${classes.headerButton} header-button-login el-button`} href={ window.LOGIN_URL }>Login</a>;
+      } else {
+        return <Button className={`${classes.headerButton} header-button-login`} onClick={ this.toggleLoginModal }>Login</Button>;
+      }
     }
   }
 

--- a/src/webui/components/Header/index.js
+++ b/src/webui/components/Header/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {Form, Button, Dialog, Input, Alert} from 'element-react';
 import isString from 'lodash/isString';
 import isNumber from 'lodash/isNumber';
@@ -15,6 +16,10 @@ import './logo.png';
 
 
 export default class Header extends React.Component {
+  static propTypes = {
+    loginUrl: PropTypes.string
+  }
+
   state = {
     showLogin: false,
     username: '',
@@ -143,8 +148,8 @@ export default class Header extends React.Component {
         </div>
       );
     } else {
-      if (window.LOGIN_URL) {
-        return <a className={`${classes.headerButton} header-button-login el-button`} href={ window.LOGIN_URL }>Login</a>;
+      if (this.props.loginUrl) {
+        return <a className={`${classes.headerButton} header-button-login el-button`} href={ this.props.loginUrl }>Login</a>;
       } else {
         return <Button className={`${classes.headerButton} header-button-login`} onClick={ this.toggleLoginModal }>Login</Button>;
       }

--- a/src/webui/router.js
+++ b/src/webui/router.js
@@ -12,7 +12,7 @@ const RouterApp = () => {
   return (
     <Router>
       <div className="page-full-height">
-        <Header/>
+        <Header loginUrl={window.LOGIN_URL}/>
         <div className="container">
           <Switch>
             <Route exact path="/(search/:keyword)?" component={ HomePage } />

--- a/src/webui/template/index.html
+++ b/src/webui/template/index.html
@@ -7,6 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>
         window.VERDACCIO_API_URL = '<%= htmlWebpackPlugin.options.verdaccioURL %>/-/verdaccio/';
+        window.LOGIN_URL = '<%= htmlWebpackPlugin.options.loginURL %>';
     </script>
 </head>
 <body class="body">

--- a/test/unit/webui/components/header.spec.js
+++ b/test/unit/webui/components/header.spec.js
@@ -3,6 +3,7 @@
  */
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import {Button} from 'element-react';
 import Header from '../../../../src/webui/components/Header';
 import { BrowserRouter } from 'react-router-dom';
 import storage from '../../../../src/webui/utils/storage';
@@ -42,6 +43,38 @@ describe('<Header /> component shallow', () => {
       expect(HeaderWrapper.state('logo'))
         .toEqual('http://localhost/-/static/logo.png');
     });
+  });
+
+  it('should use a <Button> for the login button when LOGIN_URL is empty', () => {
+    global.window.LOGIN_URL = ''
+
+    const wrapper = shallow(
+      <BrowserRouter>
+        <Header />
+      </BrowserRouter>
+    ).find(Header).dive();
+
+    expect(wrapper.find('.header-button-login').type()).toEqual(Button);
+
+    delete global.window.LOGIN_URL
+
+  });
+
+  it('should use an <a> for the login button when LOGIN_URL is not empty', () => {
+    const testUrl = 'https://foo.bar/quux'
+    global.window.LOGIN_URL = testUrl
+
+    const wrapper = shallow(
+      <BrowserRouter>
+        <Header />
+      </BrowserRouter>
+    ).find(Header).dive();
+
+    const ele = wrapper.find('.header-button-login')
+    expect(ele.type()).toEqual('a');
+    expect(ele.prop('href')).toEqual(testUrl);
+
+    delete global.window.LOGIN_URL
   });
 
   it('should toggleLogin modal', () => {

--- a/test/unit/webui/components/header.spec.js
+++ b/test/unit/webui/components/header.spec.js
@@ -46,35 +46,20 @@ describe('<Header /> component shallow', () => {
   });
 
   it('should use a <Button> for the login button when LOGIN_URL is empty', () => {
-    global.window.LOGIN_URL = ''
-
-    const wrapper = shallow(
-      <BrowserRouter>
-        <Header />
-      </BrowserRouter>
-    ).find(Header).dive();
-
-    expect(wrapper.find('.header-button-login').type()).toEqual(Button);
-
-    delete global.window.LOGIN_URL
-
+    expect(wrapper.find(Header).dive().find('.header-button-login').type()).toEqual(Button);
   });
 
   it('should use an <a> for the login button when LOGIN_URL is not empty', () => {
     const testUrl = 'https://foo.bar/quux'
-    global.window.LOGIN_URL = testUrl
-
     const wrapper = shallow(
       <BrowserRouter>
-        <Header />
+        <Header loginUrl={testUrl} />
       </BrowserRouter>
     ).find(Header).dive();
 
     const ele = wrapper.find('.header-button-login')
     expect(ele.type()).toEqual('a');
     expect(ele.prop('href')).toEqual(testUrl);
-
-    delete global.window.LOGIN_URL
   });
 
   it('should toggleLogin modal', () => {
@@ -113,7 +98,7 @@ describe('<Header /> component shallow', () => {
     const {handleSubmit} = HeaderWrapper.instance();
     const event = {preventDefault: () => {}}
     const spy = jest.spyOn(event, 'preventDefault');
-    
+
     HeaderWrapper.setState({ username: 'sam', password: '1234' });
 
     handleSubmit(event).then(() => {

--- a/tools/webpack.dev.config.babel.js
+++ b/tools/webpack.dev.config.babel.js
@@ -37,6 +37,7 @@ export default {
       title: 'Verdaccio',
       filename: 'index.html',
       verdaccioURL: '//localhost:4873',
+      loginURL: 'ToReplaceByLogin',
       template: `${env.SRC_ROOT}/webui/template/index.html`,
       debug: true,
       inject: true,

--- a/tools/webpack.prod.config.babel.js
+++ b/tools/webpack.prod.config.babel.js
@@ -48,6 +48,7 @@ const prodConf = {
       filename: 'index.html',
       favicon: `${env.SRC_ROOT}/webui/template/favicon.ico`,
       verdaccioURL: 'ToReplaceByVerdaccio',
+      loginURL: 'ToReplaceByLogin',
       template: `${env.SRC_ROOT}/webui/template/index.html`,
       debug: false,
       inject: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -234,9 +234,9 @@
   version "1.0.0"
   resolved "https://registry.npmjs.org/@verdaccio/streams/-/streams-1.0.0.tgz#d5d24c6747208728b9fd16b908e3932c3fb1f864"
 
-"@verdaccio/types@3.4.2":
-  version "3.4.2"
-  resolved "https://registry.npmjs.org/@verdaccio/types/-/types-3.4.2.tgz#e1b0952df73167428dbbe071663e72911df3404e"
+"@verdaccio/types@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.npmjs.org/@verdaccio/types/-/types-3.5.1.tgz#1ddfb6e4d12680e6689e1fb189e25377f9e606a6"
 
 "@webassemblyjs/ast@1.5.9":
   version "1.5.9"
@@ -7967,7 +7967,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2, request@2.85.0, request@^2.81.0, request@^2.83.0:
+request@2, request@^2.81.0, request@^2.83.0:
   version "2.85.0"
   resolved "https://registry.npmjs.org/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
   dependencies:


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** feature + unit tests

The following has been addressed in the PR:

*  Unit or Functional tests are included in the PR

**Description:**
This PR adds the ability for auth plugins to set a property which lets them override the default behavior of the login button and turn it into a link. The goal of this is to provide better support for OAuth, OpenID, SAML, etc.

Here's the changes in action:
![output](https://user-images.githubusercontent.com/5911086/43039123-e47fda00-8cf4-11e8-8c58-5e624dd7cd87.gif)

I'll put up a PR in [flow-types](https://github.com/verdaccio/flow-types) which can be merged concurrently with this PR to update `IPluginAuth`.