### PR TITLE
fix: Authentication Plugins / plugin[method] is not a function (add_user method)

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -98,7 +98,7 @@ class Auth implements IAuth {
       if (_.isFunction(plugin[method]) === false) {
         method = 'add_user';
       }
-      if (_.isFunction[method] === false) {
+      if (_.isFunction(plugin[method]) === false) {
         next();
       } else {
         // p.add_user() execution


### PR DESCRIPTION
As `_.isFunction[method]` returns always `undefined` the following condition is never fulfilled:
```
      if (_.isFunction[method] === false) {
```

This leads to errors like
```
TypeError: plugin[method] is not a function
```

it should be like this imho
```
      if (_.isFunction(plugin[method]) === false) {
```

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

 Resolves #849 https://github.com/Alexandre-io/verdaccio-ldap/issues/43
