### PR TITLE
fix: unpublish version does not remove it from timeline

### DIFF
--- a/src/lib/local-storage.js
+++ b/src/lib/local-storage.js
@@ -333,6 +333,7 @@ class LocalStorage implements IStorage {
           this.logger.info( {name: name, version: ver}, 'unpublishing @{name}@@{version}');
 
           delete jsonData.versions[ver];
+          delete jsonData.time[ver];
 
           for (let file in jsonData._attachments) {
             if (jsonData._attachments[file].version === ver) {


### PR DESCRIPTION
Unpublishing a specific module version does not remove that version from the local-storage (package.json) "time" object.
This results in the version still being shown in the webui right-pane "Last Sync".

Added delete of the time[ver] object when module version is removed.