### PR TITLE
docs: document package regex syntax

### DIFF
--- a/docs/packages.md
+++ b/docs/packages.md
@@ -134,7 +134,7 @@ Be **aware that the order of your packages definitions is important and always u
 
 ### Configuration
 
-You can define mutiple `packages` and each of them must have an unique `Regex`.
+You can define mutiple `packages` and each of them must have an unique `Regex`. The syntax is based on [minimatch glob expressions](https://github.com/isaacs/minimatch).
 
 Property | Type | Required | Example | Support | Description
 --- | --- | --- | --- | --- | ---


### PR DESCRIPTION
make explicit the syntax used in the package configuration directives by
linking to the minimatch npm package used for the implementation

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** docs

The following has been addressed in the PR:

*  There is a related issue?
No
*  Unit or Functional tests are included in the PR
Unneeded

**Description:**
See commit message
<!-- Resolves #??? -->
