### PR TITLE
Update glibc package signing key URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk --no-cache add wget openssl && \
     apk del openssl && \
     apk --no-cache add ca-certificates wget && \
     apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python && \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-glibc/master/sgerrand.rsa.pub && \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
     apk add glibc-2.25-r0.apk
 


### PR DESCRIPTION
The URL used for the sgerrand.rsa.pub pubkey is returning a 404.  Updated to new URL.

See related: https://gitlab.com/gitlab-org/gitlab-ci-yml/merge_requests/185/diffs