### PR TITLE
docs: fix typo/grammar

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -48,7 +48,7 @@ auth:
 
 #### Multiple Auth plugins
 
-This is tecnically possible, the plugins order becames important, the the credentials will resolved in order.
+This is tecnically possible, making the plugin order important, as the credentials will be resolved in order.
 
 ```yaml
 auth:


### PR DESCRIPTION
**Type:**

The following has been addressed in the PR: typo/grammar in docs

*  There is a related issue? no
*  Unit or Functional tests are included in the PR? n/a

**Description:**

The sentence wasn't proper grammar (and still isn't quite, but it's definitely closer) and also had a couple typos in it (double 'the', becames, etc.).
