### PR TITLE
feat: check the min Node.js supported version on boot

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,55 +6,41 @@
 	"configurations": [
 		{
 			"type": "node",
-			"request": "attach",
-			"name": "Attach to Process",
-			"processId": "${command:PickProcess}",
-			"port": 5858
+			"request": "launch",
+			"name": "CLI Babel Registry",
+			"program": "${workspaceFolder}/debug/bootstrap.js",
+			"env": {
+				"BABEL_ENV": "registry"
+			},
+			"preLaunchTask": "npm: build:webui",
+			"console": "integratedTerminal"
 		},
 		{
-			"name": "Tests",
+			"name": "Unit Tests",
 			"type": "node",
 			"request": "launch",
 			"program": "${workspaceRoot}/node_modules/jest-cli/bin/jest.js",
 			"stopOnEntry": false,
-			"args": ["--runInBand"],
+			"args": ["--debug=true" ],
 			"cwd": "${workspaceRoot}",
 			"preLaunchTask": null,
 			"runtimeExecutable": null,
 			"runtimeArgs": [
-					"--nolazy"
+				"--nolazy"
 			],
 			"env": {
-					"NODE_ENV": "test"
+				"NODE_ENV": "test",
+				"TZ": "UTC"
 			},
-			"externalConsole": false,
-			"sourceMaps": false,
-			"outDir": null
+			"console": "integratedTerminal"
 		},
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Mocha Tests",
-			"stopOnEntry": false,
-      "runtimeExecutable": null,
-			"program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-			"args": [
-				"--no-timeouts",
-				"${workspaceRoot}/test/unit"
-			]
-		},
-		{
-			"type": "node",
-			"request": "launch",
-			"name": "Verdaccio",
-			"program": "${workspaceRoot}/bin/verdaccio"
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Process",
-			"address": "localhost",
-			"port": 5858
+			"name": "Verdaccio Compiled",
+			"preLaunchTask": "npm: code:build",
+			"program": "${workspaceRoot}/bin/verdaccio",
+			"console": "integratedTerminal"
 		}
 	]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="3.7.1"></a>
+## [3.7.1](https://github.com/verdaccio/verdaccio/compare/v3.7.0...v3.7.1) (2018-08-28)
+
+
+### Bug Fixes
+
+* login modal validation ([#958](https://github.com/verdaccio/verdaccio/issues/958)) ([9f78c31](https://github.com/verdaccio/verdaccio/commit/9f78c31))
+* ui change details issue in props update ([#959](https://github.com/verdaccio/verdaccio/issues/959)) ([#960](https://github.com/verdaccio/verdaccio/issues/960)) ([431e760](https://github.com/verdaccio/verdaccio/commit/431e760))
+
+
+
 <a name="3.7.0"></a>
 # [3.7.0](https://github.com/verdaccio/verdaccio/compare/v3.6.0...v3.7.0) (2018-08-25)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,7 +31,7 @@ Recently we have moved to modern techonologies as `React` and `element-react`. W
 
 ### I feel more confortable improving the stack
 
-Of course, we will be happy to help us improving the stack, you can upgrade dependencies as `eslint`, `stylelint`, `webpack`. You migt merely improve the `webpack` configuration would be great. Any suggestion is very welcome. Furthermore whether you have experience with **Yeoman** you might help us with the [verdaccio generator](https://github.com/verdaccio/generator-verdaccio-plugin).
+Of course, we will be happy to help us improving the stack, you can upgrade dependencies as `eslint`, `stylelint`, `webpack`. You might merely improve the `webpack` configuration would be great. Any suggestion is very welcome. Furthermore whether you have experience with **Yeoman** you might help us with the [verdaccio generator](https://github.com/verdaccio/generator-verdaccio-plugin).
 
 Here some ideas:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verdaccio",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Private npm repository server",
   "author": {
     "name": "Alex Kocharin",
@@ -36,7 +36,6 @@
     "js-string-escape": "1.0.1",
     "js-yaml": "3.12.0",
     "jsonwebtoken": "8.3.0",
-    "lint-staged": "7.2.0",
     "lockfile": "1.0.4",
     "lodash": "4.17.10",
     "lunr-mutable-indexes": "2.3.1",
@@ -48,7 +47,8 @@
     "request": "2.87.0",
     "semver": "5.5.0",
     "verdaccio-audit": "0.2.0",
-    "verdaccio-htpasswd": "0.2.2"
+    "verdaccio-htpasswd": "0.2.2",
+    "verror": "1.10.0"
   },
   "devDependencies": {
     "@commitlint/cli": "7.0.0",
@@ -98,6 +98,7 @@
     "file-loader": "1.1.11",
     "flow-bin": "0.77.0",
     "flow-runtime": "0.17.0",
+    "lint-staged": "7.2.0",
     "friendly-errors-webpack-plugin": "1.7.0",
     "github-markdown-css": "2.10.0",
     "html-webpack-plugin": "3.2.0",

--- a/src/api/web/index.js
+++ b/src/api/web/index.js
@@ -1,14 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+
 import express from 'express';
 import _ from 'lodash';
-import fs from 'fs';
 import Search from '../../lib/search';
 import * as Utils from '../../lib/utils';
 import {HTTP_STATUS, WEB_TITLE} from '../../lib/constants';
+import VError from 'verror';
+import chalk from 'chalk';
 
 const {securityIframe} = require('../middleware');
 /* eslint new-cap:off */
 const env = require('../../config/env');
-const template = fs.readFileSync(`${env.DIST_PATH}/index.html`).toString();
+const templatePath = path.join(env.DIST_PATH, '/index.html');
+const existTemplate = fs.existsSync(templatePath);
+
+if (!existTemplate) {
+  const err = new VError('missing file: "%s", run `yarn build:webui`', templatePath);
+  /* eslint no-console:off */
+  console.error(chalk.red(err.message));
+  /* eslint no-console:off */
+  process.exit(2);
+}
+
+const template = fs.readFileSync(templatePath).toString();
 const spliceURL = require('../../utils/string').spliceURL;
 
 module.exports = function(config, auth, storage) {

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -4,20 +4,23 @@
 /* eslint no-empty:0 */
 
 import path from 'path';
+import semver from 'semver';
+import chalk from 'chalk';
 import {startVerdaccio, listenDefaultCallback} from './bootstrap';
 import findConfigFile from './config-path';
 
 if (process.getuid && process.getuid() === 0) {
-  global.console.error('Verdaccio doesn\'t need superuser privileges. Don\'t run it under root.');
+  global.console.warn(chalk.bgYellow('Verdaccio doesn\'t need superuser privileges. Don\'t run it under root.'));
+}
+
+const MIN_NODE_VERSION = '6.9.0';
+
+if (semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`) === false) {
+  global.console.error(chalk.bgRed(`Verdaccio requires at least Node.js ${MIN_NODE_VERSION} or higher, please upgrade your Node.js distribution`));
+  process.exit(1);
 }
 
 process.title = 'verdaccio';
-
-try {
-  // for debugging memory leaks
-  // totally optional
-  require('heapdump');
-} catch (err) { }
 
 const logger = require('./logger');
 logger.setup(); // default setup


### PR DESCRIPTION
**Type:** feature

**Description:**
To avoid mistake on usage, we stop execution whether Node.js is less as defined in the package.

For testing
```
nvm install 6.8.0
```
run
```
➜ verdaccio
Verdaccio requires at least Node.js 6.9.0 or higher, please upgrade your Node.js distribution
```

* It redoes `vscode` launch debugging configuration
* add `"verror": "1.10.0"`
* `"lint-staged"` was as `dependency` ⚠️, now is a  `devDependency` 

