### PR TITLE
feat: check for minimum node.js version on start

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "js-string-escape": "1.0.1",
     "js-yaml": "3.12.0",
     "jsonwebtoken": "8.3.0",
-    "lint-staged": "7.2.0",
     "lockfile": "1.0.4",
     "lodash": "4.17.10",
     "lunr-mutable-indexes": "2.3.1",
@@ -51,7 +50,8 @@
     "request": "2.87.0",
     "semver": "5.5.0",
     "verdaccio-audit": "0.2.0",
-    "verdaccio-htpasswd": "0.2.2"
+    "verdaccio-htpasswd": "0.2.2",
+    "verror": "1.10.0"
   },
   "devDependencies": {
     "@commitlint/cli": "7.0.0",
@@ -84,6 +84,7 @@
     "codecov": "3.0.4",
     "cross-env": "5.1.4",
     "css-loader": "0.28.10",
+    "lint-staged": "7.2.0",
     "element-theme-default": "1.4.13",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",

--- a/src/api/web/index.js
+++ b/src/api/web/index.js
@@ -1,14 +1,29 @@
-import express from 'express';
 import _ from 'lodash';
 import fs from 'fs';
-import Search from '../../lib/search';
+import path from 'path';
+import VError from 'verror';
+import chalk from 'chalk';
+import express from 'express';
+
 import * as Utils from '../../lib/utils';
+import Search from '../../lib/search';
 import {HTTP_STATUS, WEB_TITLE} from '../../lib/constants';
 
 const {securityIframe} = require('../middleware');
 /* eslint new-cap:off */
 const env = require('../../config/env');
-const template = fs.readFileSync(`${env.DIST_PATH}/index.html`).toString();
+const templatePath = path.join(env.DIST_PATH, '/index.html');
+const existTemplate = fs.existsSync(templatePath);
+
+if (!existTemplate) {
+ const err = new VError('missing file: "%s", run `yarn build:webui`', templatePath);
+ /* eslint no-console:off */
+  console.error(chalk.red(err.message));
+ /* eslint no-console:off */
+  process.exit(2);
+}
+
+const template = fs.readFileSync(templatePath).toString();
 const spliceURL = require('../../utils/string').spliceURL;
 
 module.exports = function(config, auth, storage) {

--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -4,20 +4,23 @@
 /* eslint no-empty:0 */
 
 import path from 'path';
+import semver from 'semver';
+import chalk from 'chalk';
 import {startVerdaccio, listenDefaultCallback} from './bootstrap';
 import findConfigFile from './config-path';
 
 if (process.getuid && process.getuid() === 0) {
-  global.console.error('Verdaccio doesn\'t need superuser privileges. Don\'t run it under root.');
+  global.console.warn(chalk.bgYellow('Verdaccio doesn\'t need superuser privileges. Don\'t run it under root.'));
+}
+
+const MIN_NODE_VERSION = '6.9.0';
+
+if (semver.satisfies(process.version, `>=${MIN_NODE_VERSION}`) === false) {
+ global.console.error(chalk.bgRed(`Verdaccio requires at least Node.js ${MIN_NODE_VERSION} or higher, please upgrade your Node.js distribution`));
+ process.exit(1);
 }
 
 process.title = 'verdaccio';
-
-try {
-  // for debugging memory leaks
-  // totally optional
-  require('heapdump');
-} catch (err) { }
 
 const logger = require('./logger');
 logger.setup(); // default setup


### PR DESCRIPTION
**Type:** feature

**Description:**
To avoid mistake on usage, we stop execution whether Node.js is less as defined in the package.

For testing
```
nvm install 6.8.0
```
run
```
➜ verdaccio
Verdaccio requires at least Node.js 6.9.0 or higher, please upgrade your Node.js distribution
```

* It redoes `vscode` launch debugging configuration
* add `"verror": "1.10.0"`
* `"lint-staged"` was as `dependency` ⚠️, now is a  `devDependency` 

