### PR TITLE
chore: improve vscode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
 			"type": "node",
 			"request": "launch",
 			"name": "CLI Babel Registry",
+			"stopOnEntry": false,
 			"program": "${workspaceFolder}/debug/bootstrap.js",
 			"env": {
 				"BABEL_ENV": "registry"
@@ -21,9 +22,10 @@
 			"request": "launch",
 			"program": "${workspaceRoot}/node_modules/jest-cli/bin/jest.js",
 			"stopOnEntry": false,
-			"args": ["--debug=true" ],
+			"args": [
+				"--debug=true" ],
 			"cwd": "${workspaceRoot}",
-			"preLaunchTask": null,
+			"preLaunchTask": "pre-test",
 			"runtimeExecutable": null,
 			"runtimeArgs": [
 				"--nolazy"
@@ -33,6 +35,35 @@
 				"TZ": "UTC"
 			},
 			"console": "integratedTerminal"
+		},
+		{
+			"name": "Functional Tests",
+			"type": "node",
+			"request": "launch",
+			"program": "${workspaceRoot}/node_modules/.bin/jest",
+			"stopOnEntry": false,
+			"args": [
+				"--config",
+				"./test/jest.config.functional.js",
+				"--testPathPattern",
+				"./test/functional/index*",
+				"--debug=false",
+				"--verbose",
+				"--useStderr",
+				"--detectOpenHandles"],
+			"cwd": "${workspaceRoot}",
+			"env": {
+				"BABEL_ENV": "testOldEnv",
+				"VERDACCIO_DEBUG": "true",
+				"VERDACCIO_DEBUG_INJECT": "true",
+				"NODE_DEBUG": "TO_DEBUG_REQUEST_REMOVE_THIS_request"
+			},
+			"preLaunchTask": "pre-test",
+			"console": "integratedTerminal",
+			"runtimeExecutable": null,
+			"runtimeArgs": [
+				"--nolazy"
+			],
 		},
 		{
 			"type": "node",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,55 +6,41 @@
 	"configurations": [
 		{
 			"type": "node",
-			"request": "attach",
-			"name": "Attach to Process",
-			"processId": "${command:PickProcess}",
-			"port": 5858
+			"request": "launch",
+			"name": "CLI Babel Registry",
+			"program": "${workspaceFolder}/debug/bootstrap.js",
+			"env": {
+				"BABEL_ENV": "registry"
+			},
+			"preLaunchTask": "npm: build:webui",
+			"console": "integratedTerminal"
 		},
 		{
-			"name": "Tests",
+			"name": "Unit Tests",
 			"type": "node",
 			"request": "launch",
 			"program": "${workspaceRoot}/node_modules/jest-cli/bin/jest.js",
 			"stopOnEntry": false,
-			"args": ["--runInBand"],
+			"args": ["--debug=true" ],
 			"cwd": "${workspaceRoot}",
 			"preLaunchTask": null,
 			"runtimeExecutable": null,
 			"runtimeArgs": [
-					"--nolazy"
+				"--nolazy"
 			],
 			"env": {
-					"NODE_ENV": "test"
+				"NODE_ENV": "test",
+				"TZ": "UTC"
 			},
-			"externalConsole": false,
-			"sourceMaps": false,
-			"outDir": null
+			"console": "integratedTerminal"
 		},
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Mocha Tests",
-			"stopOnEntry": false,
-      "runtimeExecutable": null,
-			"program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-			"args": [
-				"--no-timeouts",
-				"${workspaceRoot}/test/unit"
-			]
-		},
-		{
-			"type": "node",
-			"request": "launch",
-			"name": "Verdaccio",
-			"program": "${workspaceRoot}/bin/verdaccio"
-		},
-		{
-			"type": "node",
-			"request": "attach",
-			"name": "Attach to Process",
-			"address": "localhost",
-			"port": 5858
+			"name": "Verdaccio Compiled",
+			"preLaunchTask": "npm: code:build",
+			"program": "${workspaceRoot}/bin/verdaccio",
+			"console": "integratedTerminal"
 		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "build:webui",
+			"problemMatcher": []
+		},
+		{
+			"type": "npm",
+			"script": "code:build",
+			"problemMatcher": []
+		},
+		{
+			"label": "pre-test",
+			"dependsOn": [
+					"npm: code:build",
+					"npm: test:clean"
+			]
+	}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
     "flow": "flow check",
     "pretest": "npm run code:build",
     "test": "npm run test:unit",
+    "test:clean": "npx jest --clearCache",
     "test:unit": "cross-env NODE_ENV=test BABEL_ENV=test TZ=UTC jest --config ./jest.config.js --maxWorkers 2",
     "test:functional": "cross-env NODE_ENV=testOldEnv jest --config ./test/jest.config.functional.js --testPathPattern ./test/functional/index*",
     "test:e2e": "cross-env BABEL_ENV=testOldEnv jest --config ./test/jest.config.e2e.js",

--- a/test/functional/lib/environment.js
+++ b/test/functional/lib/environment.js
@@ -77,6 +77,10 @@ class FunctionalEnvironment extends NodeEnvironment {
   async teardown() {
     await super.teardown();
     console.log(chalk.yellow('Teardown Test Environment.'));
+    if (!this.global.__SERVERS_PROCESS__) {
+      throw new Error("There are no servers to stop");
+    }
+
     // shutdown verdaccio
     for (let server of this.global.__SERVERS_PROCESS__) {
       server[0].stop();


### PR DESCRIPTION
**Description:**

It updates `launch.json` to provide built-in settings to help contributors to run `verdaccio` in dev mode.

There are 4 launchers

* CLI Babel Registry: runs the registry to compiles on the fly 
* Unit Test: Run unit testing with Jest in debug mode
* Unit Test: Run functional testing with Jest in debug mode
* Verdaccio compiled: transpile code and debug over the compiled code


![screen shot 2018-08-31 at 11 38 23 pm](https://user-images.githubusercontent.com/558752/44936916-ff8d5a00-ad76-11e8-8077-abf21623e2e7.png)
