### PR TITLE
Update IAuthWebUI flow types

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -13,7 +13,7 @@ import {getMatchedPackagesSpec} from './config-utils';
 import type {Config, Logger, Callback, IPluginAuth, RemoteUser} from '@verdaccio/types';
 import type {$Response, NextFunction} from 'express';
 import type {$RequestExtend, JWTPayload} from '../../types';
-import type {IAuth} from '../../types';
+import type {IAuth, IUser} from '../../types';
 
 
 const LoggerApi = require('./logger');
@@ -283,7 +283,7 @@ class Auth implements IAuth {
     };
   }
 
-  issueUIjwt(user: any, expiresIn: string) {
+  issueUIjwt(user: IUser, expiresIn: string) {
     const {name, real_groups} = user;
     const payload: JWTPayload = {
       user: name,

--- a/types/index.js
+++ b/types/index.js
@@ -57,9 +57,13 @@ export type $ResponseExtend = $Response & {cookies?: any}
 export type $NextFunctionVer = NextFunction & mixed;
 export type $SidebarPackage = Package & {latest: mixed}
 
+export interface IUser {
+  real_groups: Array<string>;
+  name: string;
+}
 
 interface IAuthWebUI {
-  issueUIjwt(user: string, time: string): string;
+  issueUIjwt(user: IUser, time: string): string;
 }
 
 interface IAuthMiddleware {


### PR DESCRIPTION
**Type:**

flow types

**Description:**

The [flow types](https://github.com/verdaccio/verdaccio/blob/master/types/index.js#L62) suggest that `issueUIjwt` accepts the user as a `string`.
The [implementation](https://github.com/verdaccio/verdaccio/blob/533ea45b70020babbc53c88c01fb684035549cac/src/lib/auth.js#L287), however, expects an `object` with `name` and `real_groups` properties.

**Context:**

As a plugin author, this fell on my feet, because I passed in the user as string after looking at the flow types. 

If passed in correctly, [username access filters](https://github.com/verdaccio/verdaccio/blob/master/conf/full.yaml#L83) work out of the box, otherwise, the username is undefined and only the default groups work.

**Important Note:**
I've never used flow and I've just inferred the syntax from looking at the code.