### PR TITLE
fix: missing properties for default matcher #981

### DIFF
--- a/src/lib/config-utils.js
+++ b/src/lib/config-utils.js
@@ -107,7 +107,7 @@ export function normalisePackageAccess(packages: PackageList): PackageList {
   const normalizedPkgs: PackageList = {...packages};
   // add a default rule for all packages to make writing plugins easier
   if (_.isNil(normalizedPkgs['**'])) {
-    normalizedPkgs['**'] = {};
+    normalizedPkgs['**'] = {access: [], publish: []};
   }
 
   for (let pkg in packages) {

--- a/test/unit/api/config-utils.spec.js
+++ b/test/unit/api/config-utils.spec.js
@@ -1,6 +1,7 @@
 // @flow
 
 import path from 'path';
+import _ from 'lodash';
 import {spliceURL}  from '../../../src/utils/string';
 import {parseConfigFile} from '../../../src/lib/utils';
 import {
@@ -125,12 +126,14 @@ describe('Config Utilities', () => {
       const scoped = access[`${PACKAGE_ACCESS.SCOPE}`];
       expect(scoped).toBeUndefined();
 
-      // ** should be added by default
+      // ** should be added by default **
       const all = access[`${PACKAGE_ACCESS.ALL}`];
       expect(all).toBeDefined();
 
-      expect(all.access).toBeUndefined();
-      expect(all.publish).toBeUndefined();
+      expect(all.access).toBeDefined();
+      expect(_.isArray(all.access)).toBeTruthy();
+      expect(all.publish).toBeDefined();
+      expect(_.isArray(all.publish)).toBeTruthy();
 
     });
   });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

*  There is a related issue? yes
*  Unit or Functional tests are included in the PR ye

**Description:**

Wrong migration on refactoring was causing this.

Resolves #981 

⚠️ I'd like to ship this ASAP
