### PR TITLE
fix: support localTimeZone for logger `pretty-timestamped` format

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -6,6 +6,7 @@ const chalk = require('chalk');
 const Utils = require('./utils');
 const pkgJSON = require('../../package.json');
 const _ = require('lodash');
+const {format} = require('date-fns');
 
 /**
  * Match the level based on buyan severity scale
@@ -24,10 +25,6 @@ function getlvl(x) {
   }
 }
 
-function formatLocalISOString(date) {
-  const tzoffset = date.getTimezoneOffset() * 60000; // offset in milliseconds
-  return (new Date(date.getTime() - tzoffset)).toISOString().slice(0, -1);
-}
 /**
  * A RotatingFileStream that modifes the message first
  */
@@ -105,7 +102,7 @@ function setup(logs) {
       } else if (target.format === 'pretty-timestamped') {
         // making fake stream for pretty pritting
         stream.write = (obj) => {
-          destination.write(`${formatLocalISOString(obj.time)}${print(obj.level, obj.msg, obj, destinationIsTTY)}\n`);
+          destination.write(`[${format(obj.time, 'YYYY-MM-DD HH:mm:ss')}] ${print(obj.level, obj.msg, obj, destinationIsTTY)}\n`);
         };
       } else {
         stream.write = (obj) => {

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -24,6 +24,10 @@ function getlvl(x) {
   }
 }
 
+function formatLocalISOString(date) {
+  const tzoffset = date.getTimezoneOffset() * 60000; // offset in milliseconds
+  return (new Date(date.getTime() - tzoffset)).toISOString().slice(0, -1);
+}
 /**
  * A RotatingFileStream that modifes the message first
  */
@@ -101,7 +105,7 @@ function setup(logs) {
       } else if (target.format === 'pretty-timestamped') {
         // making fake stream for pretty pritting
         stream.write = (obj) => {
-          destination.write(`${obj.time.toISOString()}${print(obj.level, obj.msg, obj, destinationIsTTY)}\n`);
+          destination.write(`${formatLocalISOString(obj.time)}${print(obj.level, obj.msg, obj, destinationIsTTY)}\n`);
         };
       } else {
         stream.write = (obj) => {


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**
feature

The following has been addressed in the PR:

nothing.

**Description:**
I found that it would be ignore local timezone when set `pretty-timestamped`. Default use `Date().toISOString()`. Always i print the error time string in my log files.
I create a function to resolve it. Now it has the crollectly time string show.

<!-- Resolves #??? -->
