### PR TITLE
Fix top link url in example docker.yaml

### DIFF
--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -4,7 +4,7 @@
 #
 # Do not configure host and port under `listen` in this file
 # as it will be ignored when using docker.
-# see https://github.com/verdaccio/verdaccio/blob/master/wiki/docker.md#docker-and-custom-port-configuration
+# see https://verdaccio.org/docs/en/docker#docker-and-custom-port-configuration
 #
 # Look here for more config file examples:
 # https://github.com/verdaccio/verdaccio/tree/master/conf


### PR DESCRIPTION
**Type:** fix

**Description:**
The URL given in the docker.yaml file points to a non-existent URL. I updated the link to point to the official docs page/section.
