### PR TITLE
Add verdaccio-gitlab-ci to authorization plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -122,6 +122,7 @@ modern verdaccio API and using the prefix as *verdaccio-xx-name*.
 * [verdaccio-ldap](https://www.npmjs.com/package/verdaccio-ldap): LDAP auth plugin for verdaccio.
 * [verdaccio-active-directory](https://github.com/nowhammies/verdaccio-activedirectory): Active Directory authentication plugin for verdaccio
 * [verdaccio-gitlab](https://github.com/bufferoverflow/verdaccio-gitlab): use GitLab Personal Access Token to authenticate
+* [verdaccio-gitlab-ci](https://github.com/lab360-ch/verdaccio-gitlab-ci): Enable GitLab CI to authenticate against verdaccio.
 * [verdaccio-htpasswd](https://github.com/verdaccio/verdaccio-htpasswd): Auth based on htpasswd file plugin (built-in) for verdaccio
 * [verdaccio-github-oauth](https://github.com/aroundus-inc/verdaccio-github-oauth): Github oauth authentication plugin for verdaccio.
 * [verdaccio-github-oauth-ui](https://github.com/n4bb12/verdaccio-github-oauth-ui): GitHub OAuth plugin for the verdaccio login button.


### PR DESCRIPTION

**Type:** Documentation

**Description:**

I stumbled across this auth plugin and tested it in my setup.

Adding to the list as suggested here:
https://github.com/bufferoverflow/verdaccio-gitlab/issues/4#issuecomment-425664401