### PR TITLE
refactor: Awshanks/assertfixes

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -122,6 +122,7 @@ modern verdaccio API and using the prefix as *verdaccio-xx-name*.
 * [verdaccio-ldap](https://www.npmjs.com/package/verdaccio-ldap): LDAP auth plugin for verdaccio.
 * [verdaccio-active-directory](https://github.com/nowhammies/verdaccio-activedirectory): Active Directory authentication plugin for verdaccio
 * [verdaccio-gitlab](https://github.com/bufferoverflow/verdaccio-gitlab): use GitLab Personal Access Token to authenticate
+* [verdaccio-gitlab-ci](https://github.com/lab360-ch/verdaccio-gitlab-ci): Enable GitLab CI to authenticate against verdaccio.
 * [verdaccio-htpasswd](https://github.com/verdaccio/verdaccio-htpasswd): Auth based on htpasswd file plugin (built-in) for verdaccio
 * [verdaccio-github-oauth](https://github.com/aroundus-inc/verdaccio-github-oauth): Github oauth authentication plugin for verdaccio.
 * [verdaccio-github-oauth-ui](https://github.com/n4bb12/verdaccio-github-oauth-ui): GitHub OAuth plugin for the verdaccio login button.

--- a/test/functional/tags/tags.js
+++ b/test/functional/tags/tags.js
@@ -1,6 +1,5 @@
 
 import _ from 'lodash';
-import assert from 'assert';
 import {readFile} from '../lib/test.utils';
 
 const readTags = () => readFile('../fixtures/tags.json');
@@ -26,10 +25,10 @@ export default function(server, express) {
       return server.getPackage('testexp_tags')
                .status(200)
                .then(function(body) {
-                 assert(_.isObject(body.versions['1.1.0']));
+                 expect(_.isObject(body.versions['1.1.0'])).toBe(true);
                  // note: 5.4.3 is invalid tag, 0.1.3alpha is highest semver
-                 assert.equal(body['dist-tags'].latest, '1.1.0');
-                 assert.equal(body['dist-tags'].bad, null);
+                 expect(body['dist-tags'].latest).toEqual('1.1.0');
+                 expect(body['dist-tags'].bad).toEqual(undefined);
                });
     });
 
@@ -40,7 +39,7 @@ export default function(server, express) {
         return server.request({uri: '/testexp_tags/'+ver})
                  .status(200)
                  .then(function(body) {
-                   assert.equal(body.version, '0.1.1alpha');
+                   expect(body.version).toEqual('0.1.1alpha');
                  });
       });
     });
@@ -71,7 +70,7 @@ export default function(server, express) {
           latest: "1.1.0"
         };
 
-        assert.deepEqual(body, expected);
+        expect(body).toStrictEqual(expected);
       });
     });
 
@@ -94,7 +93,7 @@ export default function(server, express) {
             "quux": "0.1.0"
           };
 
-          assert.deepEqual(body, expected);
+          expect(body).toStrictEqual(expected);
         });
       });
     });
@@ -115,7 +114,7 @@ export default function(server, express) {
             latest: '1.1.0'
           };
 
-        assert.deepEqual(body, expected);
+          expect(body).toStrictEqual(expected);
         });
       });
     });
@@ -135,7 +134,7 @@ export default function(server, express) {
             foo: "0.1.3alpha"
           };
 
-          assert.deepEqual(body, expected);
+          expect(body).toStrictEqual(expected);
         });
       });
     });
@@ -154,7 +153,7 @@ export default function(server, express) {
             "quux": "0.1.0"
           };
 
-          assert.deepEqual(body, expected);
+          expect(body).toStrictEqual(expected);
         });
       });
     });


### PR DESCRIPTION
**Type:**

The following has been addressed in the PR:

remove all import assert from 'assert'; in favor of Jest matchers in testing in tags.js
