### PR TITLE
ci: allow prereleases following Semver tagging spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ aliases:
   - &execute_on_release
     filters:
       tags:
-        only: /(v)?[0-9]+(\.[0-9]+)*/
+        only: /v?[0-9]+(\.[0-9]+)+([-+\.][0-9a-zA-Z]+)*/
       branches:
         ignore:
           - /.*/


### PR DESCRIPTION
**Type:** ci

The following has been addressed in the PR:

*  There is a related issue? Mentioned in comment: https://github.com/verdaccio/verdaccio/issues/1038#issuecomment-426413196
*  Unit or Functional tests are included in the PR: Not necessary

**Description:** Semantic Versioning 2.0.0 sets in paragraphs [9](https://semver.org/#spec-item-9) and [10](https://semver.org/#spec-item-10) how prereleases should be denoted. We have just translate that to Regex and verified in another repo that works correctly in our CI (currently CircleCI).
[Here is a sandbox](https://regex101.com/r/of3nST/3) where you can test the regex following that spec.
