### PR TITLE
test: add scenarios where publish or access are missing

### DIFF
--- a/test/unit/api/config-utils.spec.js
+++ b/test/unit/api/config-utils.spec.js
@@ -60,7 +60,46 @@ describe('Config Utilities', () => {
       expect(all).toBeDefined();
     });
 
-    test('should test multi group', ()=> {
+    test('should define an empty publish array even if is not defined in packages', ()=> {
+      const {packages} = parseConfigFile(parseConfigurationFile('pkgs-basic-no-publish'));
+      const access = normalisePackageAccess(packages);
+
+      const scoped = access[`${PACKAGE_ACCESS.SCOPE}`];
+      const all = access[`${PACKAGE_ACCESS.ALL}`];
+      // publish must defined
+      expect(scoped.publish).toBeDefined();
+      expect(scoped.publish).toHaveLength(0);
+      expect(all.publish).toBeDefined();
+      expect(all.publish).toHaveLength(0);
+    });
+
+    test('should define an empty access array even if is not defined in packages', ()=> {
+      const {packages} = parseConfigFile(parseConfigurationFile('pkgs-basic-no-access'));
+      const access = normalisePackageAccess(packages);
+
+      const scoped = access[`${PACKAGE_ACCESS.SCOPE}`];
+      const all = access[`${PACKAGE_ACCESS.ALL}`];
+      // publish must defined
+      expect(scoped.access).toBeDefined();
+      expect(scoped.access).toHaveLength(0);
+      expect(all.access).toBeDefined();
+      expect(all.access).toHaveLength(0);
+    });
+
+    test('should define an empty proxy array even if is not defined in package', ()=> {
+      const {packages} = parseConfigFile(parseConfigurationFile('pkgs-basic-no-proxy'));
+      const access = normalisePackageAccess(packages);
+
+      const scoped = access[`${PACKAGE_ACCESS.SCOPE}`];
+      const all = access[`${PACKAGE_ACCESS.ALL}`];
+      // publish must defined
+      expect(scoped.proxy).toBeDefined();
+      expect(scoped.proxy).toHaveLength(0);
+      expect(all.proxy).toBeDefined();
+      expect(all.proxy).toHaveLength(0);
+    });
+
+    test('should test multi user group definition', ()=> {
       const {packages} = parseConfigFile(parseConfigurationFile('pkgs-multi-group'));
       const access = normalisePackageAccess(packages);
 
@@ -84,7 +123,7 @@ describe('Config Utilities', () => {
     });
 
 
-    test('should deprecated packages props', ()=> {
+    test('should normalize deprecated packages into the new ones (backward props compatible)', ()=> {
       const {packages} = parseConfigFile(parseConfigurationFile('deprecated-pkgs-basic'));
       const access = normalisePackageAccess(packages);
 

--- a/test/unit/partials/config/yaml/pkgs-basic-no-access.yaml
+++ b/test/unit/partials/config/yaml/pkgs-basic-no-access.yaml
@@ -1,0 +1,7 @@
+packages:
+  '@*/*':
+    publish: $all
+    proxy: npmjs
+  '**':
+    publish: $all
+    proxy: npmjs

--- a/test/unit/partials/config/yaml/pkgs-basic-no-proxy.yaml
+++ b/test/unit/partials/config/yaml/pkgs-basic-no-proxy.yaml
@@ -1,0 +1,7 @@
+packages:
+  '@*/*':
+    access: $all
+    publish: $all
+  '**':
+    access: $all
+    publish: $all

--- a/test/unit/partials/config/yaml/pkgs-basic-no-publish.yaml
+++ b/test/unit/partials/config/yaml/pkgs-basic-no-publish.yaml
@@ -1,0 +1,7 @@
+packages:
+  '@*/*':
+    access: $all
+    proxy: npmjs
+  '**':
+    access: $all
+    proxy: npmjs


### PR DESCRIPTION
**Description:**

It provides unit test scenarios where the configuration will normalize those props are missing as empty arrays.

In cases where `proxy`, `publish` or `access` props are missing. Eg:
```
packages:
  '@*/*':
    access: $all
  'foo':
  '**':
    access: $all
    publish: $all
```
The output wil be
```
packages:
  '@*/*':
    access: $all
    publish:
    proxy:
  'foo':
    access: 
    publish:
    proxy:
  '**':
    access: $all
    publish: $all
    proxy:
```

This unit test will confirm that we can remove the `?` for `allow_access`, `allow_proxy`, `allow_publish`,  `proxy`, `publish` or `access` on https://github.com/verdaccio/flow-types/blob/master/src/types.js#L167 types where those values are not optional, actually will exist in any case.