### PR TITLE
Don't exit if using https and pfx is enabled (#1061)

### DIFF
--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -81,7 +81,7 @@ function startVerdaccio(config: any,
       let webServer;
       if (addr.proto === 'https') {
         // https  must either have key cert and ca  or a pfx and (optionally) a passphrase
-      if (!config.https || !((config.https.key && config.https.cert && config.https.ca) || config.https.pfx)) {
+        if (!config.https || !((config.https.key && config.https.cert && config.https.ca) || config.https.pfx)) {
           displayHTTPSWarning(configPath);
         }
 

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -81,7 +81,7 @@ function startVerdaccio(config: any,
       let webServer;
       if (addr.proto === 'https') {
         // https  must either have key cert and ca  or a pfx and (optionally) a passphrase
-        if (!config.https || !config.https.key || !config.https.cert || !config.https.ca) {
+      if (!config.https || !((config.https.key && config.https.cert && config.https.ca) || config.https.pfx)) {
           displayHTTPSWarning(configPath);
         }
 


### PR DESCRIPTION
* Fixes #1061 

**Description:**
pfx config is now handled correctly and the process does not exits.
