### PR TITLE
ci: use CircleCI workspaces to share data among steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,8 @@ aliases:
   - &yarn_cache_key
     yarn-sha-{{ checksum "yarn.lock" }}
   - &restore_repo
-    restore_cache:
-      keys:
-        - *repo_key
+    attach_workspace:
+      at: ~/verdaccio
   - &ignore_non_dev_branches
     filters:
       tags:
@@ -54,7 +53,6 @@ jobs:
     <<: *defaults
     <<: *default_executor
     steps:
-      - *restore_repo
       - checkout
       - restore_cache:
           key: *base_config_key
@@ -88,10 +86,10 @@ jobs:
             - ~/.yarn
             - ~/.cache/yarn
             - node_modules
-      - save_cache:
-          key: *repo_key
+      - persist_to_workspace:
+          root: ~/verdaccio
           paths:
-            - ~/verdaccio
+            - ./*
 
   test_node6:
     <<: *defaults
@@ -153,6 +151,8 @@ jobs:
     <<: *default_executor
     steps:
       - *restore_repo
+      - restore_cache:
+          key: *base_config_key
       - run:
           name: Test size
           command: yarn test:size


### PR DESCRIPTION
**Type:** ci

The following has been addressed in the PR: Fix CircleCI to allow execution in PRs correctly

*  There is a related issue? No
*  Unit or Functional tests are included in the PR: No

**Description:**  We need to use CircleCI workspaces to share data in the workflow among steps and not use cache for that:
- The **cache** is used to share data between workflow executions, e.g, the workflow execution of this PR is not the same as latest master execution or another PR execution. Some good things to put in cache are packages installed (`node_modules`) or config files like `.npmrc`, as they won't change in short time.
- The **workspace** is used to share data between steps, for example, step prepare will make the installation of packages and build some part of the project, that later we need in other steps (like test_e2e), but this data will be dropped when the workflow ends. It's important to say that the workspace will not be removed immediatly, because it is used to re-run some steps (e.g, test failed due to internal error with container filesystem and not related with test suite) 


<!-- Resolves #??? -->
