### PR TITLE
fix: remove useless secureProtocol option

### DIFF
--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -133,8 +133,7 @@ function displayHTTPSWarning(storageLocation) {
 function handleHTTPS(app, configPath, config) {
   try {
     let httpsOptions = {
-      secureProtocol: 'SSLv23_method', // disable insecure SSLv2 and SSLv3
-      secureOptions: constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_SSLv3,
+      secureOptions: constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_SSLv3, // disable insecure SSLv2 and SSLv3
     };
 
     if (config.https.pfx) {


### PR DESCRIPTION
Why we specified `secureProtocol: 'SSLv23_method'` here?
The comment after the code said `"disable insecure SSLv2 and SSLv3"`, but that was what the code next line do: `secureOptions: constants.SSL_OP_NO_SSLv2 | constants.SSL_OP_NO_SSLv3,`.

The default value of `secureProtocol` is [`SSLv23_method` in Node.JS 8 LTS](https://nodejs.org/docs/latest-v8.x/api/tls.html#tls_tls_createsecurecontext_options), but [none and use minVersion in Node.JS 10 LTS](https://nodejs.org/docs/latest-v10.x/api/tls.html#tls_tls_createsecurecontext_options).

`SSLv23_method` was in the OpenSSL manual version 1.0.2, but removed in the version 1.1.0. So it may not works in Node.JS 10.

I think we should remove this line to use the default value of Node.JS.