### PR TITLE
Filter packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@commitlint/config-conventional": "7.5.0",
     "@octokit/rest": "16.25.0",
     "@verdaccio/babel-preset": "0.1.0",
-    "@verdaccio/types": "5.0.0-beta.4",
+    "@verdaccio/types": "5.0.2",
     "codecov": "3.3.0",
     "cross-env": "5.2.0",
     "eslint": "5.16.0",

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -17,7 +17,7 @@ import { setupUpLinks, updateVersionsHiddenUpLink } from './uplink-util';
 import { mergeVersions } from './metadata-utils';
 import { ErrorCode, normalizeDistTags, validateMetadata, isObject } from './utils';
 import type { IStorage, IProxy, IStorageHandler, ProxyList, StringValue, IGetPackageOptions, ISyncUplinks } from '../../types';
-import type { Versions, Package, Config, MergeTags, Version, DistFile, Callback, Logger } from '@verdaccio/types';
+import type { Versions, Package, Config, MergeTags, Version, DistFile, Callback, Logger, IPluginStorageFilter } from '@verdaccio/types';
 import type { IReadTarball, IUploadTarball } from '@verdaccio/streams';
 import { hasProxyTo } from './config-utils';
 import { logger } from '../lib/logger';
@@ -27,6 +27,7 @@ class Storage implements IStorageHandler {
   config: Config;
   logger: Logger;
   uplinks: ProxyList;
+  filters: Array<IPluginStorageFilter>;
 
   constructor(config: Config) {
     this.config = config;
@@ -34,7 +35,8 @@ class Storage implements IStorageHandler {
     this.logger = logger.child();
   }
 
-  init(config: Config) {
+  init(config: Config, filters: Array<IPluginStorageFilter> = []) {
+    this.filters = filters;
     this.localStorage = new LocalStorage(this.config, logger);
 
     return this.localStorage.getSecret(config);
@@ -503,11 +505,24 @@ class Storage implements IStorageHandler {
           return callback(null, packageInfo);
         }
 
-        self.localStorage.updateVersions(name, packageInfo, function(err, packageJsonLocal: Package) {
+        self.localStorage.updateVersions(name, packageInfo, async (err, packageJsonLocal: Package) => {
           if (err) {
             return callback(err);
           }
-          return callback(null, packageJsonLocal, upLinksErrors);
+          // Any error here will cause a 404, like an uplink error. This is likely the right thing to do
+          // as a broken filter is a security risk.
+          const filterErrors = [];
+          // This MUST be done serially and not in parallel as they modify packageJsonLocal
+          for (const filter of self.filters) {
+            try {
+              // These filters can assume it's save to modify packageJsonLocal and return it directly for
+              // performance (i.e. need not be pure)
+              packageJsonLocal = await filter.filter_metadata(packageJsonLocal);
+            } catch (err) {
+              filterErrors.push(err);
+            }
+          }
+          callback(null, packageJsonLocal, _.concat(upLinksErrors, filterErrors));
         });
       }
     );

--- a/test/unit/api/api.spec.js
+++ b/test/unit/api/api.spec.js
@@ -42,6 +42,12 @@ describe('endpoint unit test', () => {
             file: './test-storage-api-spec/.htpasswd'
           }
         },
+        filters: {
+          '../partials/plugin/filter': {
+            pkg: 'npm_test',
+            version: '2.0.0'
+          }
+        },
         storage: store,
         self_path: store,
         uplinks: {
@@ -373,6 +379,37 @@ describe('endpoint unit test', () => {
 
         request(app)
           .get('/@verdaccio/not-found')
+          .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HTTP_STATUS.NOT_FOUND)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+            done();
+          });
+      });
+
+      test('be able to filter packages', (done) => {
+        request(app)
+          .get('/npm_test')
+          .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HTTP_STATUS.OK)
+          .end(function(err, res) {
+            if (err) {
+              return done(err);
+            }
+            // Filter out 2.0.0
+            expect(Object.keys(res.body.versions)).toEqual(['1.0.0']);
+            done();
+          });
+      });
+
+      test('should not found when a filter fails', (done) => {
+        request(app)
+           // Filter errors look like other uplink errors
+          .get('/trigger-filter-failure')
           .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
           .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
           .expect(HTTP_STATUS.NOT_FOUND)

--- a/test/unit/partials/mock-store/npm_test/package.json
+++ b/test/unit/partials/mock-store/npm_test/package.json
@@ -1,0 +1,87 @@
+{
+  "_id": "npm_test",
+  "name": "npm_test",
+  "description": "",
+  "dist-tags": {
+    "latest": "1.0.0"
+  },
+  "versions": {
+    "1.0.0": {
+      "name": "npm_test",
+      "version": "1.0.0",
+      "description": "",
+      "main": "index.js",
+      "dependencies": {
+        "test": "^1.4.0"
+      },
+      "devDependencies": {
+
+      },
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "keywords": [
+
+      ],
+      "author": "",
+      "license": "ISC",
+      "readme": "ERROR: No README data found!",
+      "_id": "npm_test@1.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+
+      },
+      "dist": {
+        "integrity": "sha512-tfzM1OFjWwg2d2Wke\/DV6icjeTZUVOZYLkbf8wmONRSAgMovL\/F+zyI24OhTtWyOXd1Kbj2YUMBvLpmpAjv8zg==",
+        "shasum": "3e4e6bd5097b295e520b947c9be3259a9509a673",
+        "tarball": "http:\/\/localhost:4873\/npm_test\/-\/npm_test-1.0.0.tgz"
+      }
+    },
+    "2.0.0": {
+      "name": "npm_test",
+      "version": "2.0.0",
+      "description": "",
+      "main": "index.js",
+      "dependencies": {
+        "test": "^2.4.0"
+      },
+      "devDependencies": {
+
+      },
+      "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+      },
+      "keywords": [
+
+      ],
+      "author": "",
+      "license": "ISC",
+      "readme": "ERROR: No README data found!",
+      "_id": "npm_test@2.0.0",
+      "_npmVersion": "5.5.1",
+      "_nodeVersion": "9.3.0",
+      "_npmUser": {
+
+      },
+      "dist": {
+        "integrity": "sha512-tzzM1OFjWwg2d2Wke\/DV6icjeTZUVOZYLkbf8wmONRSAgMovL\/F+zyI24OhTtWyOXd1Kbj2YUMBvLpmpAjv8zg==",
+        "shasum": "3a4e6bd5097b295e520b947c9be3259a9509a673",
+        "tarball": "http:\/\/localhost:4873\/npm_test\/-\/npm_test-2.0.0.tgz"
+      }
+    }
+  },
+  "readme": "ERROR: No README data found!",
+  "_attachments": {
+    "npm_test-1.0.0.tgz": {
+      "content_type": "application\/octet-stream",
+      "data": "H4sIAAAAAAAAE+2ST08CMRDFOe+nmPTAyawt7ELCVT149ihqmu4gI9I2bUGM4bvbbhGM4eYmxmR\/l6bvtW+mf6xUK\/mMlzaP5Ys3etAxnPNJVcE5PVHV0RPjkairsZiK0YALUU+mMOBdN3KOjQ\/SxVZ+m5PPAsfxn\/BRADAt18hmwDxpY0k+BfSBXSRni86T0ckUJS95Vhv0ypENByeLa0ntjHSDu\/iPvpZajIJWhD66qRwcC6Xlj6KsYm7U94cN2+sfe7KRS34LabuMCaiWBubsxjnjZqANJAO8RUULwmbOYDgE3FEAcSqzwvc345oUd\/\/QKnITlsadzvNKCrVv7+X27ooV++Kv36qnp6enSz4B8bhKUwAIAAA=",
+      "length": 281
+    },
+    "npm_test-2.0.0.tgz": {
+      "content_type": "application\/octet-stream",
+      "data": "H4sIAAAAAAAAE+2ST08CMRDFOe+nmPTAyawt7ELCVT149ihqmu4gI9I2bUGM4bvbbhGM4eYmxmR\/l6bvtW+mf6xUK\/mMlzaP5Ys3etAxnPNJVcE5PVHV0RPjkairsZiK0YALUU+mMOBdN3KOjQ\/SxVZ+m5PPAsfxn\/BRADAt18hmwDxpY0k+BfSBXSRni86T0ckUJS95Vhv0ypENByeLa0ntjHSDu\/iPvpZajIJWhD66qRwcC6Xlj6KsYm7U94cN2+sfe7KRS34LabuMCaiWBubsxjnjZqANJAO8RUULwmbOYDgE3FEAcSqzwvc345oUd\/\/QKnITlsadzvNKCrVv7+X27ooV++Kv36qnp6enSz4B8bhKUwAIAAA=",
+      "length": 281
+    }
+  }
+}

--- a/test/unit/partials/plugin/filter.js
+++ b/test/unit/partials/plugin/filter.js
@@ -1,0 +1,24 @@
+class FilterPlugin {
+  constructor(config) {
+    this._config = config;
+  }
+
+  filter_metadata(pkg) {
+    return new Promise((resolve) => {
+        // We use this to test what happens when a filter rejects
+        if(pkg.name === 'trigger-filter-failure') {
+          reject(new Error('Example filter failure'));
+          return;
+        }
+        // Example filter that removes a single blocked package
+        if (this._config.pkg === pkg.name) {
+          // In reality, we also want to remove references in attachments and dist-tags, etc. This is just a POC
+          delete pkg.versions[this._config.version];
+        }
+        resolve(pkg);
+      }
+    );
+  }
+}
+
+exports.default = FilterPlugin;


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:

*  There is a related issue? #818
*  Unit or Functional tests are included in the PR: Not yet, WIP

**Description:** Add a plugin that can filter all packages before being returned. This
enables blocking at the verdaccio level.

The general idea here is that we can have filters that do any type of thing we want. We can have whitelist or blacklist, temporal, keyword,  CVE-based etc. This WIP includes a blacklist filter which allows for one to update it and instantly block packages. This is useful if you want to block something before npm does and stops clients from being able to download it

The riskiest part of this change is what to do with changing `dist-tags`. Any downgrade could be a breaking change, but we need to guess something. Since we don't know what a tag (e.g. `latest`) was at previously, we guess the closest one that is semver smaller. This is better than not blocking or having a tag IMO, but is a serious risk. The example implementation allows for the user to set an exact replacement version.


Add a plugin that can filter all package metadata before being returned.

**This enables the blocking of packages from verdaccio.**

`IPluginStorageFilter` are loaded like other plugins from the config.
Verdaccio will look for plugins in `config.filters` and pass this to
storage.init. 

This is the same design as other plugins and will be
dynamically found with the same rules. These plugins must implement
a `filter_metadata` method, which is called serially (in the order
loaded from the config) for every metadata request. 

It gets a **current copy of a package metadata and may choose to modify it as required**.
For example, **this may be used to block a bad version of a package or
add a time delay from when new packages can be used from your
registry**. Errors in a filter will cause a 404, similar to upLinkErrors
as it is not safe to recover gracefully from them. 

Note: *When version is removed, be careful about updating tags*.

Resolves #818
