### PR TITLE
feat: Package version gets send to plugin

### DIFF
--- a/src/api/endpoint/api/search.js
+++ b/src/api/endpoint/api/search.js
@@ -57,7 +57,7 @@ export default function(route, auth, storage) {
     stream.on('data', function each(pkg) {
       processing_pkgs++;
 
-      auth.allow_access(pkg.name, req.remote_user, function(err, allowed) {
+      auth.allow_access({packageName: pkg.name}, req.remote_user, function(err, allowed) {
         processing_pkgs--;
 
         if (err) {

--- a/src/api/middleware.js
+++ b/src/api/middleware.js
@@ -101,12 +101,13 @@ export function allow(auth: IAuth) {
   return function(action: string) {
     return function(req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer) {
       req.pause();
-      let packageName = req.params.package;
-      if (req.params.scope) {
-        packageName = `@${req.params.scope}/${packageName}`;
+      const pkg = {};
+      pkg.packageName = req.params.scope?`@${req.params.scope}/${req.params.package}`:req.params.package;
+      if (req.params.filename && /.+-(\d.+)\.tgz/.test(req.params.filename)) {
+        pkg.packageVersion = req.params.filename.match(/.+-(\d.+)\.tgz/)[1];
       }
       // $FlowFixMe
-      auth['allow_' + action](packageName, req.remote_user, function(error, allowed) {
+      auth['allow_' + action](pkg, req.remote_user, function(error, allowed) {
         req.resume();
         if (error) {
           next(error);

--- a/src/api/web/endpoint/package.js
+++ b/src/api/web/endpoint/package.js
@@ -18,7 +18,7 @@ function addPackageWebApi(route: Router, storage: IStorageHandler, auth: IAuth) 
 
   const checkAllow = (name, remoteUser) => new Promise((resolve, reject) => {
     try {
-      auth.allow_access(name, remoteUser, (err, allowed) => {
+      auth.allow_access({packageName: name}, remoteUser, (err, allowed) => {
         if (err) {
           resolve(false);
         } else {

--- a/src/api/web/endpoint/search.js
+++ b/src/api/web/endpoint/search.js
@@ -16,7 +16,7 @@ function addSearchWebApi(route: Router, storage: IStorageHandler, auth: IAuth) {
         name: results[i].ref,
         callback: (err, entry) => {
           if (!err && entry) {
-            auth.allow_access(entry.name, req.remote_user, function(err, allowed) {
+            auth.allow_access({packageName: entry.name}, req.remote_user, function(err, allowed) {
               if (err || !allowed) {
                 return;
               }

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -10,7 +10,7 @@ import {getDefaultPlugins} from './auth-utils';
 
 import {getMatchedPackagesSpec} from './config-utils';
 
-import type {Config, Logger, Callback, IPluginAuth, RemoteUser} from '@verdaccio/types';
+import type {Config, Logger, Callback, IPluginAuth, RemoteUser, AuthPluginPackage} from '@verdaccio/types';
 import type {$Response, NextFunction} from 'express';
 import type {$RequestExtend, JWTPayload} from '../../types';
 import type {IAuth} from '../../types';
@@ -118,7 +118,7 @@ class Auth implements IAuth {
   /**
    * Allow user to access a package.
    */
-  allow_access({packageName, packageVersion}: any, user: RemoteUser, callback: Callback) {
+  allow_access({packageName, packageVersion}: AuthPluginPackage, user: RemoteUser, callback: Callback) {
     let plugins = this.plugins.slice(0);
     // $FlowFixMe
     let pkg = Object.assign({name: packageName, version: packageVersion}, getMatchedPackagesSpec(packageName, this.config.packages));
@@ -147,7 +147,7 @@ class Auth implements IAuth {
   /**
    * Allow user to publish a package.
    */
-  allow_publish({packageName, packageVersion}: any, user: string, callback: Callback) {
+  allow_publish({packageName, packageVersion}: AuthPluginPackage, user: string, callback: Callback) {
     let plugins = this.plugins.slice(0);
     // $FlowFixMe
     let pkg = Object.assign({name: packageName, version: packageVersion}, getMatchedPackagesSpec(packageName, this.config.packages));

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -118,10 +118,10 @@ class Auth implements IAuth {
   /**
    * Allow user to access a package.
    */
-  allow_access(packageName: string, user: RemoteUser, callback: Callback) {
+  allow_access({packageName, packageVersion}: any, user: RemoteUser, callback: Callback) {
     let plugins = this.plugins.slice(0);
     // $FlowFixMe
-    let pkg = Object.assign({name: packageName}, getMatchedPackagesSpec(packageName, this.config.packages));
+    let pkg = Object.assign({name: packageName, version: packageVersion}, getMatchedPackagesSpec(packageName, this.config.packages));
 
     (function next() {
       const plugin = plugins.shift();
@@ -147,10 +147,10 @@ class Auth implements IAuth {
   /**
    * Allow user to publish a package.
    */
-  allow_publish(packageName: string, user: string, callback: Callback) {
+  allow_publish({packageName, packageVersion}: any, user: string, callback: Callback) {
     let plugins = this.plugins.slice(0);
     // $FlowFixMe
-    let pkg = Object.assign({name: packageName}, getMatchedPackagesSpec(packageName, this.config.packages));
+    let pkg = Object.assign({name: packageName, version: packageVersion}, getMatchedPackagesSpec(packageName, this.config.packages));
 
     (function next() {
       const plugin = plugins.shift();

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -547,6 +547,16 @@ export function buildToken(type: string, token: string) {
   return `${_.capitalize(type)} ${token}`;
 }
 
+/**
+ * return package version from tarball name
+ * @param {String} name
+ * @returns {String}
+ */
+export function getVersionFromTarball(name: string) {
+  // $FlowFixMe
+  return /.+-(\d.+)\.tgz/.test(name) ? name.match(/.+-(\d.+)\.tgz/)[1] : undefined;
+}
+
 export {
   addGravatarSupport,
   deleteProperties,

--- a/test/flow/plugins/middleware/example.middleware.plugin.js
+++ b/test/flow/plugins/middleware/example.middleware.plugin.js
@@ -24,7 +24,7 @@ export default class ExampleMiddlewarePlugin implements IPluginMiddleware {
 			name: 'test'
 		};
 		auth.authenticate('user', 'password', () => {});
-		auth.allow_access('packageName', remoteUser, () => {});
+		auth.allow_access({packageName: 'packageName'}, remoteUser, () => {});
 		auth.add_user('user', 'password', () => {});
 		auth.aesEncrypt(new Buffer('pass'));
 		// storage

--- a/test/unit/api/utils.spec.js
+++ b/test/unit/api/utils.spec.js
@@ -7,7 +7,8 @@ import {
   validateName as validate,
   convertDistRemoteToLocalTarballUrls,
   parseReadme,
-  addGravatarSupport
+  addGravatarSupport,
+  getVersionFromTarball
 } from '../../../src/lib/utils';
 import Logger, { setup } from '../../../src/lib/logger';
 import { readFile } from '../../functional/lib/test.utils';
@@ -125,6 +126,19 @@ describe('Utilities', () => {
         buildURI(host, '1.0.1')
       );
     });
+
+    test('getVersionFromTarball', () => {
+      const simpleName = 'test-name-4.2.12.tgz'
+      const complexName = 'test-5.6.4-beta.2.tgz'
+      const otherComplexName = 'test-3.5.0-6.tgz'
+      expect(getVersionFromTarball(simpleName)).toEqual('4.2.12')
+      expect(getVersionFromTarball(complexName)).toEqual('5.6.4-beta.2')
+      expect(getVersionFromTarball(otherComplexName)).toEqual('3.5.0-6')
+    })
+
+    test('getVersionFromTarball should don\'n fall at incorrect tarball name', () => {
+      expect(getVersionFromTarball('incorrectName')).toBeUndefined()
+    })
   });
 
   describe('parseReadme', () => {


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:** feature

The following has been addressed in the PR:

*  Related issues #226 #810 #818 #1156
*  Unit tests are included in the PR

**Description:**
In some cases new versions of package must be inaccessible. For doing this verdaccio must send version accessible package to plugins. So I modified `src/api/middleware.js` for it to do this.
npm sends request with version number only when downloads tarball, then I parse version only in this type of request, and send version to plugins.
Also, it was necessary to add new type `AuthPluginPackage`

Example package object from plugin
```js
{ 
  name: '@test/test',
  version: '5.0.11',
  access: [ '$all' ],
  publish: [],
  proxy: [] 
}
``` 
<!-- Resolves #??? -->
