### PR TITLE
Remove unused parameters from processBody method invocation

### DIFF
--- a/src/lib/up-storage.js
+++ b/src/lib/up-storage.js
@@ -141,7 +141,7 @@ class ProxyStorage implements IProxy {
       let error;
       const responseLength = err ? 0 : body.length;
       // $FlowFixMe
-      processBody(err, body);
+      processBody();
       logActivity();
       // $FlowFixMe
       cb(err, res, body);


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**
bug

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**
`processBody` does not use any parameters so there should be none in any invocation.

<!-- Resolves #??? -->
