### PR TITLE
feature: introduce server keepAliveTimeout into config files

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -50,6 +50,12 @@ packages:
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs
 
+# You can specify HTTP/1.1 server keep alive timeout in seconds for incomming connections.
+# A value of 0 makes the http server behave similarly to Node.js versions prior to 8.0.0, which did not have a keep-alive timeout.
+# WORKAROUND: Through given configuration you can workaround following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enought.
+server:
+  keepAliveTimeout: 60
+
 # To use `npm audit` uncomment the following section
 middlewares:
   audit:

--- a/conf/full.yaml
+++ b/conf/full.yaml
@@ -115,6 +115,12 @@ packages:
 # - [::1]:4873                # ipv6
 # - unix:/tmp/verdaccio.sock    # unix socket
 
+# You can specify HTTP/1.1 server keep alive timeout in seconds for incomming connections.
+# A value of 0 makes the http server behave similarly to Node.js versions prior to 8.0.0, which did not have a keep-alive timeout.
+# WORKAROUND: Through given configuration you can workaround following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enought.
+server:
+  keepAliveTimeout: 60
+
 # Configure HTTPS, it is required if you use "https" protocol above.
 #https:
 #  key: path/to/server.key

--- a/src/lib/bootstrap.js
+++ b/src/lib/bootstrap.js
@@ -89,7 +89,10 @@ function startVerdaccio(config: any,
       } else { // http
         webServer = http.createServer(app);
       }
-
+      if (config.server && config.server.keepAliveTimeout) {
+        // $FlowFixMe library definition for node is not up to date (doesn't contain recent 8.0 changes)
+        webServer.keepAliveTimeout = config.server.keepAliveTimeout;
+      }
       unlinkAddressPath(addr);
 
       callback(webServer, addr, pkgName, pkgVersion);


### PR DESCRIPTION
**Type:**  feature
**Description:**
Set default timeout to 60 seconds (it's workaround for issue reported in #301).

