### PR TITLE
Feat auth jwt plugin

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -223,6 +223,14 @@ class Auth implements IAuth {
   }
 
   apiJWTmiddleware() {
+    const plugins = this.plugins.slice(0);
+    const helpers = {buildAnonymousUser, authenticatedUser};
+    for (const plugin of plugins) {
+      if (plugin.apiJWTmiddleware) {
+        return plugin.apiJWTmiddleware(helpers);
+      }
+    }
+
     return (req: $RequestExtend, res: $Response, _next: NextFunction) => {
       req.pause();
 

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -224,7 +224,7 @@ class Auth implements IAuth {
 
   apiJWTmiddleware() {
     const plugins = this.plugins.slice(0);
-    const helpers = {buildAnonymousUser, authenticatedUser};
+    const helpers = { createAnonymousRemoteUser, createRemoteUser };
     for (const plugin of plugins) {
       if (plugin.apiJWTmiddleware) {
         return plugin.apiJWTmiddleware(helpers);


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:

This PR is to at least generate a discussion about the possibility of making the `apiJWTmiddleware` auth overwriteable by Auth plugins. The logic behind why I'd find is useful is I can then tie directly into my token based authentication system and disable login/adduser from the npm registry itself. In my case when users signup & login on our existing system we'll put our token in the `.npmrc` then use that token in our plugin `apiJWTmiddleware` function to validate & create the user appropriately or return an error. 

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

<!-- Resolves #??? -->
