### PR TITLE
feat: add star and unstar api

### DIFF
--- a/src/api/endpoint/api/publish.js
+++ b/src/api/endpoint/api/publish.js
@@ -115,7 +115,7 @@ export default function(router: Router, auth: IAuth, storage: IStorageHandler, c
     try {
       metadata = validate_metadata(req.body, name);
     } catch (err) {
-      return next(ErrorCode.getBadData(`${JSON.stringify(req.body)}bad incoming package data`));
+      return next(ErrorCode.getBadData(`bad incoming package data`));
     }
 
     if (req.params._rev) {

--- a/src/api/endpoint/api/star.js
+++ b/src/api/endpoint/api/star.js
@@ -1,0 +1,49 @@
+// @flow
+
+import type {$Response} from 'express';
+import type {$RequestExtend, $NextFunctionVer, IStorageHandler} from '../../../../types';
+
+export default function(storage: IStorageHandler) {
+  return (req: $RequestExtend, res: $Response, next: $NextFunctionVer): void => {
+    const name = req.params.package;
+    // Check is star or unstar
+    const isStar = Object.keys(req.body.users).indexOf(req.remote_user.name) >= 0;
+    const afterChangePackage = function(err) {
+      if (err) {
+        return next(err);
+      }
+      res.status(200);
+      next({
+        success: true,
+      });
+    };
+
+    storage.getPackage({
+      name,
+      req,
+      callback: function(err, info) {
+        if (err) {
+          return next(err);
+        }
+        let newUsers = {
+          ...info.users,
+        };
+        if (isStar) {
+          newUsers = {
+            ...newUsers,
+            [req.remote_user.name]: true,
+          };
+        } else if (newUsers[req.remote_user.name]) {
+          delete newUsers[req.remote_user.name];
+        }
+        const newMetadata = {
+          ...info,
+          users: newUsers,
+        };
+        storage.changePackage(name, newMetadata, req.body._rev, function(err) {
+          afterChangePackage(err);
+        });
+      },
+    });
+  };
+}

--- a/src/lib/local-storage.js
+++ b/src/lib/local-storage.js
@@ -6,7 +6,7 @@ import assert from 'assert';
 import UrlNode from 'url';
 import _ from 'lodash';
 // $FlowFixMe
-import {ErrorCode, isObject, getLatestVersion, tagVersion, validateName, DIST_TAGS} from './utils';
+import {ErrorCode, isObject, getLatestVersion, tagVersion, validateName, DIST_TAGS, USERS} from './utils';
 import {
   generatePackageTemplate, normalizePackage, generateRevision, getLatestReadme, cleanUpReadme, normalizeContributors,
 fileExist, noSuchFile, DEFAULT_REVISION, pkgFileName,
@@ -346,7 +346,7 @@ class LocalStorage implements IStorage {
           }
         }
       }
-
+      localData[USERS] = incomingPkg[USERS];
       localData[DIST_TAGS] = incomingPkg[DIST_TAGS];
       cb();
     }, function(err) {

--- a/src/lib/storage-utils.js
+++ b/src/lib/storage-utils.js
@@ -111,7 +111,7 @@ export function normalizeContributors(contributors: Array<Author>): Array<Author
   return contributors;
 }
 
-export const WHITELIST = ['_rev', 'name', 'versions', 'dist-tags', 'readme', 'time', '_id'];
+export const WHITELIST = ['_rev', 'name', 'versions', 'dist-tags', 'readme', 'time', '_id', 'users'];
 
 export function cleanUpLinksRef(keepUpLinkData: boolean, result: Package): Package {
   const propertyToKeep = [...WHITELIST];

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -27,6 +27,7 @@ const pkgVersion = module.exports.version;
 const pkgName = module.exports.name;
 
 export const DIST_TAGS = 'dist-tags';
+export const USERS = 'users';
 
 export function getUserAgent(): string {
   assert(_.isString(pkgName));

--- a/test/unit/api/api.spec.js
+++ b/test/unit/api/api.spec.js
@@ -5,6 +5,7 @@ import rimraf from 'rimraf';
 
 import configDefault from '../partials/config/index';
 import publishMetadata from '../partials/publish-api';
+import starMetadata from '../partials/star-api';
 import forbiddenPlace from '../partials/forbidden-place';
 import Config from '../../../src/lib/config';
 import endPointAPI from '../../../src/api/index';
@@ -556,6 +557,50 @@ describe('endpoint unit test', () => {
           });
       });
 
+      describe('should test star api', () => {
+        test('should star a package', (done) => {
+          request(app)
+            .put('/@scope%2fpk1-test')
+            .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+            .send(JSON.stringify({
+              ...starMetadata,
+              users: {
+                [credentials.name]: true
+              }
+            }))
+            .expect(HTTP_STATUS.OK)
+            .end(function(err, res) {
+              if (err) {
+                expect(err).toBeNull();
+                return done(err);
+              }
+              expect(res.body.success).toBeDefined();
+              expect(res.body.success).toBeTruthy();
+              done();
+            });
+        });
+
+        test('should unstar a package', (done) => {
+          request(app)
+            .put('/@scope%2fpk1-test')
+            .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+            .send(JSON.stringify(starMetadata))
+            .expect(HTTP_STATUS.OK)
+            .end(function(err, res) {
+              if (err) {
+                expect(err).toBeNull();
+                return done(err);
+              }
+              expect(res.body.success).toBeDefined();
+              expect(res.body.success).toBeTruthy();
+              done();
+            });
+        });        
+      });
+
+        
+      });
+
       test('should unpublish a new package', (done) => {
         //FUTURE: for some reason it does not remove the scope folder
         request(app)
@@ -572,7 +617,8 @@ describe('endpoint unit test', () => {
             done();
           });
       });
-    });
+
+
   });
 
   describe('Registry WebUI endpoints', () => {

--- a/test/unit/partials/star-api.js
+++ b/test/unit/partials/star-api.js
@@ -1,0 +1,7 @@
+const json = {
+  "_id": "@scope\/pk1-test",
+  "_rev": "4-6abcdb4efd41a576",
+  "users": {}
+}
+
+module.exports = json;


### PR DESCRIPTION
**Type: feature**
* Unit tests are included in the PR

**Description:**
Starring is still unsupported in current version.
This pr will support the star and unstar function by adding star handler in publish.js

**Remarks:**
users field need to be added in @verdaccio/types
```flow
declare type verdaccio$Package = {
  _id?: string;
  name: string;
  versions: verdaccio$Versions;
  'dist-tags': verdaccio$GenericBody;
  time?: verdaccio$GenericBody;
  readme?: string;
  users?: verdaccio$GenericBody;
  _distfiles: verdaccio$DistFiles;
  _attachments: verdaccio$AttachMents;
  _uplinks: verdaccio$UpLinks;
  _rev: string;
}
```
