### PR TITLE
fix: add new enpoind that allow download tarballs according the standard

### DIFF
--- a/src/api/endpoint/api/package.js
+++ b/src/api/endpoint/api/package.js
@@ -65,7 +65,7 @@ export default function(route: Router, auth: IAuth, storage: IStorageHandler, co
     });
   });
 
-  route.get('/:scopedPackage/-/:scope/:filename', function(req: $RequestExtend, res: $ResponseExtend) {
+  route.get('/:scopedPackage/-/:scope/:filename', can('access'), function(req: $RequestExtend, res: $ResponseExtend) {
     const { scopedPackage, filename } = req.params;
 
     downloadStream(scopedPackage, filename, storage, req, res);

--- a/src/api/endpoint/api/package.js
+++ b/src/api/endpoint/api/package.js
@@ -11,6 +11,20 @@ import type { Router } from 'express';
 import type { Config } from '@verdaccio/types';
 import type { IAuth, $ResponseExtend, $RequestExtend, $NextFunctionVer, IStorageHandler } from '../../../../types';
 
+const downloadStream = (packageName: string, filename: string, storage: any, req: $RequestExtend, res: $ResponseExtend) => {
+  const stream = storage.getTarball(packageName, filename);
+
+  stream.on('content-length', function(content) {
+    res.header('Content-Length', content);
+  });
+  stream.on('error', function(err) {
+    return res.report_error(err);
+  });
+
+  res.header(HEADERS.CONTENT_TYPE, HEADERS.OCTET_STREAM);
+  stream.pipe(res);
+};
+
 export default function(route: Router, auth: IAuth, storage: IStorageHandler, config: Config) {
   const can = allow(auth);
   // TODO: anonymous user?
@@ -51,16 +65,13 @@ export default function(route: Router, auth: IAuth, storage: IStorageHandler, co
     });
   });
 
-  route.get('/:package/-/:filename', can('access'), function(req: $RequestExtend, res: $ResponseExtend) {
-    const stream = storage.getTarball(req.params.package, req.params.filename);
+  route.get('/:scopedPackage/-/:scope/:filename', function(req: $RequestExtend, res: $ResponseExtend) {
+    const { scopedPackage, filename } = req.params;
 
-    stream.on('content-length', function(content) {
-      res.header('Content-Length', content);
-    });
-    stream.on('error', function(err) {
-      return res.report_error(err);
-    });
-    res.header('Content-Type', HEADERS.OCTET_STREAM);
-    stream.pipe(res);
+    downloadStream(scopedPackage, filename, storage, req, res);
+  });
+
+  route.get('/:package/-/:filename', can('access'), function(req: $RequestExtend, res: $ResponseExtend) {
+    downloadStream(req.params.package, req.params.filename, storage, req, res);
   });
 }


### PR DESCRIPTION
**Description:**

Add a new endpoint to allow download scoped tarballs according to the distribution metatada.

```
https://registry.npmjs.org/@verdaccio/streams/-/@verdaccio/streams_2.0.0-beta.0.tgz
```

 Resolves #1257 
