### PR TITLE
docs: remove outdated comment

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -71,7 +71,6 @@ packages:
 server:
   keepAliveTimeout: 60
 
-# To use `npm audit` uncomment the following section
 middlewares:
   audit:
     enabled: true

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -71,7 +71,6 @@ packages:
     # if package is not available locally, proxy requests to 'npmjs' registry
     proxy: npmjs
 
-# To use `npm audit` uncomment the following section
 middlewares:
   audit:
     enabled: true


### PR DESCRIPTION
**Type:** docs

The following has been addressed in the PR:

*  Removes an outdated comment in the `default.yml` and `docker.yml` config files

**Description:**

`audit` has been enabled by default since https://github.com/verdaccio/verdaccio/commit/8df186c5d52d19de9a895ca3c254f1e345f1a9b2.