### PR TITLE
Add missing octokit/rest package for the trigger-release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@commitlint/cli": "7.5.2",
     "@commitlint/config-conventional": "7.5.0",
+    "@octokit/rest": "16.25.0",
     "@verdaccio/babel-preset": "0.1.0",
     "@verdaccio/types": "5.0.0-beta.4",
     "codecov": "3.3.0",


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:

*  CI release script fails due to missing `octokit/rest` package. This PR adds it.

**Description:**

<!-- Resolves #??? -->
