### PR TITLE
fix: routing is aware of reverse proxy directory #1297

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@verdaccio/local-storage": "2.1.0",
     "@verdaccio/streams": "2.0.0",
-    "@verdaccio/ui-theme": "0.1.2",
+    "@verdaccio/ui-theme": "0.1.5",
     "JSONStream": "1.3.5",
     "async": "3.0.1-0",
     "body-parser": "1.19.0",

--- a/src/api/web/index.js
+++ b/src/api/web/index.js
@@ -75,14 +75,25 @@ module.exports = function(config, auth, storage) {
   });
 
   function renderHTML(req, res) {
-    const base = combineBaseUrl(getWebProtocol(req.get(HEADERS.FORWARDED_PROTO), req.protocol), req.get('host'), config.url_prefix);
+    const protocol = getWebProtocol(req.get(HEADERS.FORWARDED_PROTO), req.protocol);
+    const host = req.get('host');
+    const { url_prefix } = config;
+    const uri = `${protocol}://${host}`;
+    const base = combineBaseUrl(protocol, host, url_prefix);
+    const primaryColor = _.get(config, 'web.primary_color') ? config.web.primary_color : '';
+    const title = _.get(config, 'web.title') ? config.web.title : WEB_TITLE;
+    const scope = _.get(config, 'web.scope') ? config.web.scope : '';
+    const options = { uri, protocol, host, url_prefix, base, primaryColor, title, scope };
+
     const webPage = template
+      .replace(/ToReplaceByVerdaccioUI/g, JSON.stringify(options))
       .replace(/ToReplaceByVerdaccio/g, base)
+      .replace(/ToReplaceByPrefix/g, url_prefix)
       .replace(/ToReplaceByVersion/g, pkgJSON.version)
-      .replace(/ToReplaceByTitle/g, _.get(config, 'web.title') ? config.web.title : WEB_TITLE)
+      .replace(/ToReplaceByTitle/g, title)
       .replace(/ToReplaceByLogo/g, logoURI)
-      .replace(/ToReplaceByPrimaryColor/g, _.get(config, 'web.primary_color') ? config.web.primary_color : '')
-      .replace(/ToReplaceByScope/g, _.get(config, 'web.scope') ? config.web.scope : '');
+      .replace(/ToReplaceByPrimaryColor/g, primaryColor)
+      .replace(/ToReplaceByScope/g, scope);
 
     res.setHeader('Content-Type', HEADERS.TEXT_HTML);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,10 +1460,10 @@
   resolved "https://registry.verdaccio.org/@verdaccio%2ftypes/-/types-5.0.0-beta.4.tgz#433a36bef5b3bbd31711c48071989ac35dc83e54"
   integrity sha512-aPrCUrFMXo/ikgT/9YEAr5EDlH2gFJGfdrUra2ipQxV3SbNrRN95KxwwSDS+W+YKG0+rAIQKIxnx8hf6gEtePQ==
 
-"@verdaccio/ui-theme@0.1.2":
-  version "0.1.2"
-  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.1.2.tgz#9710f41bf3cf2d35777029baa07bb44b3a158497"
-  integrity sha512-k3DV81hSyNCovmfCAyuqX+/NrJRLpHaiBYGETb/rTQ4D047SHhpOUwL3NUuEc227o4V52LsaB6Xe1D7G1s9DCA==
+"@verdaccio/ui-theme@0.1.5":
+  version "0.1.5"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.1.5.tgz#07fff1d81521dfb111bf74c49ea27d0d498f0a35"
+  integrity sha512-pmAkjpVF89ziyHNkyl8lzjN4EyaUbAcGdYk5S7D5TWgwdM3cCqn8s2Ipjq/7VjC18S/VpK8MKqYrA4nX5mXevg==
 
 JSONStream@1.3.5, JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

*  There is a related issue? yes
*  Unit or Functional tests are included in the PR no

**Description:**

The bug is well described here  #1297 .

This PR aims to update the `url_prefix` prop that is usually being used when Verdaccio uses under reverse proxy. The documentation suggests using a full URL, which I think is no the best approach, not good for maintenance if the domain changes also configuration file must be updated.  This PR will assume the `url_prefix` is not a URL anymore. 

Here a full repo that proves the new configuration works fine under the NGINX set up
https://github.com/verdaccio/docker-examples/tree/master/reverse_proxy/nginx

```yaml
url_prefix: /verdaccio/
```

Depends on
- [x] Update UI https://github.com/verdaccio/ui/pull/45
- [x] Update docs
- [x] Push a demo docker image for better testing before merge `verdaccio/verdaccio:fix-1297`

Resolves #1297
Resolves https://github.com/verdaccio/docker-examples/issues/10