### PR TITLE
fix: warning text is hard to read when running under root

### DIFF
--- a/src/lib/cli.js
+++ b/src/lib/cli.js
@@ -16,7 +16,7 @@ import { parseConfigFile } from './utils';
 require('pkginfo')(module);
 
 if (process.getuid && process.getuid() === 0) {
-  global.console.warn(bgYellow('Verdaccio doesn\'t need superuser privileges. Don\'t run it under root.'));
+  global.console.warn(bgYellow().red('*** WARNING: Verdaccio doesn\'t need superuser privileges. Don\'t run it under root! ***'));
 }
 
 const MIN_NODE_VERSION = '6.9.0';


### PR DESCRIPTION
**Type:** fix
**Description:** warning text is hard to read when running under root.

Using the white text on a yellow background is not a good idea.
![image](https://user-images.githubusercontent.com/10294977/58068972-3128a880-7bc6-11e9-83a1-b0c39e1a3ba5.png)

I change it to use the red text.
![image](https://user-images.githubusercontent.com/10294977/58069012-561d1b80-7bc6-11e9-8116-4f281eb635ac.png)


**Discuss:**
Should we exit immediately when detect running under root? and if the user needs to run it under root, we support an argument such as `--unsafe-allow-root` to allow running under root.
