### PR TITLE
fix: correctly check if the proxy setting evaluates to false

### DIFF
--- a/src/lib/up-storage.js
+++ b/src/lib/up-storage.js
@@ -551,7 +551,7 @@ class ProxyStorage implements IProxy {
       // Otherwise misconfigured proxy could return 407:
       // https://github.com/rlidwka/sinopia/issues/254
       //
-      if (this.proxy === false) {
+      if (!this.proxy) {
         headers['X-Forwarded-For'] = (req.headers['x-forwarded-for'] ? req.headers['x-forwarded-for'] + ', ' : '') + req.connection.remoteAddress;
       }
     }


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**
bug

The following has been addressed in the PR:

*  The `property` check was checking for a boolean but the typings expect a string.

**Description:**
See https://github.com/verdaccio/verdaccio/blob/5a8d92f5f93c16f505f51dddecd1c2d520771971/src/lib/up-storage.js#L53

<!-- Resolves #??? -->
