### PR TITLE
fix : add version extraction from the body publish request

### DIFF
--- a/src/api/middleware.js
+++ b/src/api/middleware.js
@@ -106,7 +106,11 @@ export function allow(auth: IAuth) {
     return function(req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer) {
       req.pause();
       const packageName = req.params.scope ? `@${req.params.scope}/${req.params.package}` : req.params.package;
-      const packageVersion = req.params.filename ? getVersionFromTarball(req.params.filename) : undefined;
+      const packageVersion = req.params.filename
+        ? getVersionFromTarball(req.params.filename)
+        : req.body && req.body.versions
+        ? Object.keys(req.body.versions)[0]
+        : undefined;
 
       // $FlowFixMe
       auth['allow_' + action]({ packageName, packageVersion }, req.remote_user, function(error, allowed) {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR: Correctly passing package version to the plugins

**Description:**
I've developed a small auth plugin that checks a package version prior to publishing: https://github.com/neptunix/verdaccio-betaversion

Turned out that a package version parameter is passed as `undefined`. That fix retrieves the version from the npm body request.
