### PR TITLE
feat: prevent secrets from leaking to source control

### DIFF
--- a/.secrets-baseline
+++ b/.secrets-baseline
@@ -1,0 +1,2989 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2019-07-19T05:01:56Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    }
+  ],
+  "results": {
+    "package.json": [
+      {
+        "hashed_secret": "f7ca6a21d278eb5ce64611aadbdb77ef1511d3dd",
+        "line_number": 49,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/lib/auth-utils.ts": [
+      {
+        "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
+        "line_number": 10,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
+        "line_number": 174,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "f35dd4c51c0a89bd055b5ad30c162c778981306d",
+        "line_number": 179,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "45c43fe97e3a06ab078b0eeff6fbe622cc417a25",
+        "line_number": 197,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/lib/auth.ts": [
+      {
+        "hashed_secret": "3812d6abc055424d0556b35f48774c7b0044eac2",
+        "line_number": 32,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "6981afa9890d125c05133d13053201f32292ec9f",
+        "line_number": 38,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/lib/config.ts": [
+      {
+        "hashed_secret": "3812d6abc055424d0556b35f48774c7b0044eac2",
+        "line_number": 24,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "45c43fe97e3a06ab078b0eeff6fbe622cc417a25",
+        "line_number": 100,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "cbfe12c3dd5ecd14ad3f4ce85deb0ca2ee11b0c1",
+        "line_number": 102,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/lib/constants.ts": [
+      {
+        "hashed_secret": "f34fbc9a9769ba9eff5aff3d008a6b49f85c08b1",
+        "line_number": 14,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "b9343f1143ccb83555b450eb54dde96a05522ccc",
+        "line_number": 115,
+        "type": "Secret Keyword"
+      }
+    ],
+    "src/lib/crypto-utils.ts": [
+      {
+        "hashed_secret": "45c43fe97e3a06ab078b0eeff6fbe622cc417a25",
+        "line_number": 14,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "f35dd4c51c0a89bd055b5ad30c162c778981306d",
+        "line_number": 23,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/e2e/config/config-protected-e2e.yaml": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "line_number": 14,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/e2e/config/config-scoped-e2e.yaml": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "line_number": 14,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/e2e/partials/pkg-protected.js": [
+      {
+        "hashed_secret": "bb1e9de8a2e550ca43c48d5d1d5b326f32d910b3",
+        "line_number": 38,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/e2e/partials/pkg-scoped.js": [
+      {
+        "hashed_secret": "bb1e9de8a2e550ca43c48d5d1d5b326f32d910b3",
+        "line_number": 38,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/flow/plugins/storage/example.storage.plugin.js": [
+      {
+        "hashed_secret": "45c43fe97e3a06ab078b0eeff6fbe622cc417a25",
+        "line_number": 87,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/functional/config.functional.js": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "line_number": 5,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/functional/fixtures/publish.json5": [
+      {
+        "hashed_secret": "613e6330611a94739969e967da203142c1fa0410",
+        "line_number": 15,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cd7c17a6aa4cfbb110f338f4cda3d48ad43fc54f",
+        "line_number": 26,
+        "type": "Base64 High Entropy String"
+      }
+    ],
+    "test/functional/package/scoped.json": [
+      {
+        "hashed_secret": "82b18548f2a3b1688532a07c86bd5f2b985323c2",
+        "line_number": 29,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/functional/package/scoped.ts": [
+      {
+        "hashed_secret": "82b18548f2a3b1688532a07c86bd5f2b985323c2",
+        "line_number": 31,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/functional/plugins/auth.ts": [
+      {
+        "hashed_secret": "308a9501a3165af904851c4337026699a0e2237d",
+        "line_number": 7,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "fd10d1442fd328ec4a5ed255b2c503614b69cbff",
+        "line_number": 8,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/functional/readme/pkg-no-readme.json": [
+      {
+        "hashed_secret": "917ca74222fc0e454cb90fd256f5f35428457d8f",
+        "line_number": 26,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/functional/readme/pkg-readme.json": [
+      {
+        "hashed_secret": "917ca74222fc0e454cb90fd256f5f35428457d8f",
+        "line_number": 26,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/functional/search/search.json": [
+      {
+        "hashed_secret": "917ca74222fc0e454cb90fd256f5f35428457d8f",
+        "line_number": 26,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/functional/store/config-1.yaml": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "line_number": 18,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/functional/store/config-2.yaml": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "line_number": 25,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "308a9501a3165af904851c4337026699a0e2237d",
+        "line_number": 31,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/functional/store/config-3.yaml": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "line_number": 19,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/functional/tags/dist-tags-merge.json": [
+      {
+        "hashed_secret": "917ca74222fc0e454cb90fd256f5f35428457d8f",
+        "line_number": 26,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/lib/server.ts": [
+      {
+        "hashed_secret": "f35dd4c51c0a89bd055b5ad30c162c778981306d",
+        "line_number": 42,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/lib/utils-test.ts": [
+      {
+        "hashed_secret": "2b835c700ce2c4237a61972df6ec27fba872e256",
+        "line_number": 8,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/types/index.ts": [
+      {
+        "hashed_secret": "45c43fe97e3a06ab078b0eeff6fbe622cc417a25",
+        "line_number": 37,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/modules/api/api.spec.ts": [
+      {
+        "hashed_secret": "97752a468368b0d6b192140d6a140c38fd0cbd8b",
+        "line_number": 287,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
+        "line_number": 786,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/modules/auth/auth-utils.spec.ts": [
+      {
+        "hashed_secret": "f35dd4c51c0a89bd055b5ad30c162c778981306d",
+        "line_number": 30,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "cbfe12c3dd5ecd14ad3f4ce85deb0ca2ee11b0c1",
+        "line_number": 33,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "8cb2237d0679ca88db6464eac60da96345513964",
+        "line_number": 43,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
+        "line_number": 233,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/modules/auth/jwt.spec.ts": [
+      {
+        "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
+        "line_number": 121,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "eaacdf2d9ed66df2601c8b51ab4084db14336d11",
+        "line_number": 132,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/modules/auth/profile.spec.ts": [
+      {
+        "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
+        "line_number": 50,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "dfb2f12ac9b2dd601f34da1b31b24228ce60577c",
+        "line_number": 61,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "ada3d2a3b5dafb531df9be3cf35cedf18ed79512",
+        "line_number": 77,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "195a8aef5c5b2397fdbf5fb429a517b089745309",
+        "line_number": 95,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/modules/utils/api.__test.template.ts": [
+      {
+        "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
+        "line_number": 80,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/modules/web/api.web.spec.ts": [
+      {
+        "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
+        "line_number": 17,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "fed915afaba64ebcdfeb805d59ea09a33275c423",
+        "line_number": 178,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/partials/changePackage/metadata-change": [
+      {
+        "hashed_secret": "9e480aca65f4e4537d4d0f8e167a9d8434fa533e",
+        "line_number": 31,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/config-unit-mock-server-test.yaml": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "line_number": 12,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/partials/config/yaml/api.spec/web-config.yaml": [
+      {
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "line_number": 10,
+        "type": "Secret Keyword"
+      }
+    ],
+    "test/unit/partials/forbidden-place.js": [
+      {
+        "hashed_secret": "bb1e9de8a2e550ca43c48d5d1d5b326f32d910b3",
+        "line_number": 38,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/metadata": [
+      {
+        "hashed_secret": "9e480aca65f4e4537d4d0f8e167a9d8434fa533e",
+        "line_number": 37,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/metadata-update-versions-tags": [
+      {
+        "hashed_secret": "2b835c700ce2c4237a61972df6ec27fba872e256",
+        "line_number": 75,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/mock-store/.sinopia-db.json": [
+      {
+        "hashed_secret": "09c8822b725f70ba161538dcbc7dba80ce56e118",
+        "line_number": 1,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "09c8822b725f70ba161538dcbc7dba80ce56e118",
+        "line_number": 1,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/mock-store/@jquery/jquery/package.json": [
+      {
+        "hashed_secret": "4aea94eff4db5260be13575ff054dcbf34b2c49e",
+        "line_number": 71,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/mock-store/jquery/package.json": [
+      {
+        "hashed_secret": "12f5ec39f703cfec2b9f3dfc6f92709801190878",
+        "line_number": 1605,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d6e93f4f2a7f5262cddd05e1fcb9e4699506c371",
+        "line_number": 1691,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5ec8124fef4857ef7e67e950ef9ff9256089e57e",
+        "line_number": 1777,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e6e604529181a622f17bde06354aeac4b23eecab",
+        "line_number": 1864,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1c612c613f4fc56d020d10de4dfcb08315605711",
+        "line_number": 1952,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "60cd035bd378650b928a87c3012fb44298d1db4d",
+        "line_number": 2039,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "756050243bc41f66b8849c1405cf25750452469a",
+        "line_number": 2159,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fabb53a7113d53d6bdb85834d3a5863bbcf0546e",
+        "line_number": 2277,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e9b9a61f7066665c0bf9406026e7251cf24e1167",
+        "line_number": 2394,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "51f443cb104348b06693a2ceae9b3b6b0f0bc988",
+        "line_number": 2514,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cc886b9d9194219bf45e2a57ce901b6441b90e93",
+        "line_number": 2632,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "12dcae33c76402c63c7cc9c3f55a4bc8a15c5441",
+        "line_number": 2753,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9f4cf81463bbed847ba98c3d4cd63a68955d0318",
+        "line_number": 2875,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1ef0f56a4b48d9bdd349427a454430acd30d964d",
+        "line_number": 2996,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ebbb561a4e0e40d75ad42f5dcf36f84b3a90f90c",
+        "line_number": 3118,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2844ff8c916a819de09ee9e9d2997b6207d78e0d",
+        "line_number": 3239,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7b3c2f5ea234578a56b08246c53a0196393c25f2",
+        "line_number": 3361,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6a94d790cc1f9f006a05dd1348ff1b2d8e5576a2",
+        "line_number": 3482,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ec4b15fc38d7cc8d669697e29dbe8ef4203e8c93",
+        "line_number": 3612,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "50a97a2367d0387292070c477937e4b85440e8e1",
+        "line_number": 3742,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "03b31e9c1bff9d9f8d034d853e787c5f87f40c86",
+        "line_number": 3872,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "295db900f3f674513ad68d11fd131abf6f44d14e",
+        "line_number": 4006,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "45853e82542b0a926fd4394ed62d50696a3d295f",
+        "line_number": 4140,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c19b88ea85b14a2e4a0e1c7c60dca5934d1ce004",
+        "line_number": 4274,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d684acaf2f81ff01b18f754165b785ada897e262",
+        "line_number": 4424,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1ad0e3e1b751ed9b59cae743c339ae3afaf34445",
+        "line_number": 4568,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f86d93e137b95f29b4d30b6223dd6cb5ad9dddc5",
+        "line_number": 4678,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e2245d96b6255b1b20f0abac68f2acd4dd5d7e03",
+        "line_number": 4683,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4edbbce314e350fb052da6cfb2a17fe59327f17a",
+        "line_number": 4688,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "628e390bbc307c25aa3bdb821cbdada61a1211a9",
+        "line_number": 4693,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d70e01efc976b430dfdc1b771582e04f1da1a99f",
+        "line_number": 4698,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "56dbab03670ad43084947fcde83d984d975ca676",
+        "line_number": 4703,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ffdc2f843db42af57a28c2d13ded68edc5a1e664",
+        "line_number": 4708,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ca3370505cf3a7c765557d277e21822541122df5",
+        "line_number": 4713,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2b6bc01270161cae918446d701fd1907ca1bd78e",
+        "line_number": 4718,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "171dc815497be5ee7e19d5333bf286338aec746b",
+        "line_number": 4723,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0264de7a1ede50efdede0540f5f37c4472b97c25",
+        "line_number": 4728,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1c05fca6c365802751065bd7b6028b99f01bba46",
+        "line_number": 4733,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bf35928ccbe8ef0b9232222ff8c11e67d80175d4",
+        "line_number": 4738,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "60d3600aeea34713c8cf256b02301f4c11b4b28e",
+        "line_number": 4743,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "223d868a6772e815ca495c919d10a189ddd72d13",
+        "line_number": 4748,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "841b6c41aba85f71f2759f23df267d80ebffec13",
+        "line_number": 4753,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "542179051a05e40d0e92a3b371f91e6a5ec8ea07",
+        "line_number": 4758,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d6b04379f93fea727e62590f85f298d62ce95540",
+        "line_number": 4763,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9ab8fc8ace0dc4e4e30e8f460965650ed24d5eb8",
+        "line_number": 4768,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2720e10666addd2e3f911f0ecde17fa4a90d3535",
+        "line_number": 4773,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9d38788a7bb0b997450c966dec291c2334fa7e3f",
+        "line_number": 4778,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cdde22827bcada9f58be89b00989aa7a768d887c",
+        "line_number": 4783,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "814fdd2bc07b43562fb3e7acd1d1a62df3e0db81",
+        "line_number": 4788,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2c9870def403a05beeacbecd9ff2ab066303cbf2",
+        "line_number": 4793,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2ec11faac1a352cde4bde69ddb8ea21f4c1b6259",
+        "line_number": 4798,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ae9a3b228a83b703bd5a2602aee5ae9776b1ffbf",
+        "line_number": 4803,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "32603cdaf81341cba0a0d977b9dfee16132a1d2f",
+        "line_number": 4808,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "da1c5b34f0883182f4282767e9ccdaadb980421a",
+        "line_number": 4813,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2b9a66a8b22f7e95d8a4e1e0ef1c9ee30ce6421c",
+        "line_number": 4818,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "94b7a974a02b1168a28b95e92da1447077f1b996",
+        "line_number": 4823,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "849ae1c2ea50af11e94ff473f812c1f82becebfb",
+        "line_number": 4828,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ec7977b8f77e83c77cc137a4436e0e5e79fe34ea",
+        "line_number": 4833,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cf3d4e1a3f4aaa4687e41683babc36f8639c4bf5",
+        "line_number": 4838,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "44848b240348c650af3399490e5c2ac3b36a765e",
+        "line_number": 4843,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f1c5a5e3d19843b32f91c1518c1dae9fc2e0e9db",
+        "line_number": 4848,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2bd644902bf5885f248959336e7407273390006b",
+        "line_number": 4853,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "15eca3766b4ebc371ad2d053030cdf967ad39b92",
+        "line_number": 4858,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "412d8e038e85f6aa88a8b6dd24233b6220c4f987",
+        "line_number": 4863,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6c58ff353010cca6869f2cf7a592ee1dd41016f5",
+        "line_number": 4868,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "126d348966312a786eac0532a741670655e2d942",
+        "line_number": 4873,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "43aa6fd10a36f5d459f0e1714d6ce6ff540bf6ff",
+        "line_number": 4878,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "499fc08e5830091c5d4413f372abcfcecbee890f",
+        "line_number": 4883,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b67adfc6051a335ee2ce2c7627056694a99f47cf",
+        "line_number": 4888,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e5a2cab7418711e509e4d633785a3c9b70a07704",
+        "line_number": 4893,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "35dc98119cf820de3c644a35ad4117044f0ed7fe",
+        "line_number": 4898,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "08a5b5d54ecdfeef23ee18864a84cb9bc3380bdd",
+        "line_number": 4903,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ff47d71b5499d658ee465f04069793d8d1bb1549",
+        "line_number": 4908,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4aea94eff4db5260be13575ff054dcbf34b2c49e",
+        "line_number": 4914,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/mock-store/npm_test/package.json": [
+      {
+        "hashed_secret": "9e480aca65f4e4537d4d0f8e167a9d8434fa533e",
+        "line_number": 37,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5d181739c5292cfc12a5e8aab688c4a2a32d1482",
+        "line_number": 69,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/mock-store/vue/package.json": [
+      {
+        "hashed_secret": "e0eaf3abd900bdf1cda36b0a5857143c4855860c",
+        "line_number": 1995,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9e7de90bc3ef2809f4f109d49ad9fa6266c54fd4",
+        "line_number": 2063,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8ec069a602a24d009d42bc681a566803382a09a7",
+        "line_number": 2131,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6f72ed240ba5b462ee0514bb1307397cb4f13f55",
+        "line_number": 2199,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9695cb862bea44cab130ae207b9d66ccf01589e1",
+        "line_number": 2267,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7d4defde1ed7100dd8da22aeea94690f3523c1e9",
+        "line_number": 2335,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "dd657a287b21b7cddfcc326263b5e653ba862592",
+        "line_number": 2403,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c42c284472347a5cda732802d6bf2a0b48e0991c",
+        "line_number": 2471,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "da1dbf61715a441677aa17477f0e718ab02f37ac",
+        "line_number": 2539,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7c69483709857703177ffedff75051e6b3d75328",
+        "line_number": 2608,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "69b469db0e0fa8483b2997ca34af9485fe965eac",
+        "line_number": 2677,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f7528b4072c7d6039b11cf60f309b28a9c959304",
+        "line_number": 2746,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1e7e317c15c4adefe22b36f69b7a085f2b45cd1d",
+        "line_number": 2815,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8d19ccf4782eed3df072ce54f8702753c80db2ac",
+        "line_number": 2884,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f4e6ab4a9e51bff390239cf98aa23854ae497459",
+        "line_number": 2953,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "57d5a0b464a3416b720758a2d6ed4a1da2ab8a18",
+        "line_number": 3022,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9ea59135ccccf3c26aa1a8cf1933f4fd9d59ece1",
+        "line_number": 3091,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "33e9da6e163f8ce5457c2e0de4e6a249300a8ab6",
+        "line_number": 3161,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d7850a727da8751bd69b44843fafd2f4346a8dc8",
+        "line_number": 3231,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8c3932ff41adee5eaf4c21c937fb997f50511d17",
+        "line_number": 3301,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "29b97496c1963547e61a4f8c4cfbe73d384d1a8c",
+        "line_number": 3371,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5a5f3da46e5974bbfe8a9aac5f83a94f43edaf47",
+        "line_number": 3444,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7a20d7b741e1719da985026250790fbf037a04b7",
+        "line_number": 3514,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8cb82e3c78f29aa0d9de6b85a91df947cb4c2dd4",
+        "line_number": 3587,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "395c74844d07bd01d3b4ddb2f2a55cc7da4b371f",
+        "line_number": 3660,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e80545b32ab5001b68fb3c505d667f03987240be",
+        "line_number": 3733,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c255de610c068bbbf49b765695f281e6711fae53",
+        "line_number": 3804,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e9c79d661812151ca9dc8b08734e30d01b73c2fd",
+        "line_number": 3875,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2b137cf34a891c95aa54a96ecc4f2b7821269d4b",
+        "line_number": 3946,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a0fea7acac9225b26797085491eb6ce0115bea0a",
+        "line_number": 4016,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "25663da60e2c33927e417d5f61d586cb5622a03b",
+        "line_number": 4089,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e51a1f742f4a0ce6e32ac998cb4e33eaf4264a86",
+        "line_number": 4159,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "df49736ee32fef3b76be4296dfef0a64d86d9543",
+        "line_number": 4232,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "93a5f8c5f49f29231e4a6b6a70c645ee8c122f84",
+        "line_number": 4302,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3a2b6b9ef4008e02ac6c2780ca12707506574af7",
+        "line_number": 4372,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e282b2f26ae9b92056e7c6dae2150139c83f330e",
+        "line_number": 4450,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7618d0dec6ed8d16b66c0a51232218e2f4d3f2ef",
+        "line_number": 4528,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fe319ba807106b8661efb89cfbb7e0d7c58ae37e",
+        "line_number": 4606,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "212e8cad4f783b2abd8cdb4bfd0f817f629e8ed5",
+        "line_number": 4684,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "281c157aedc3c9a789fab8c5f23b0db7c861d183",
+        "line_number": 4763,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "02f75f6990e8733fe2292d145c35d517e0156ab2",
+        "line_number": 4842,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4e43520dcc07069891802f3cb92cd6a1769d9efa",
+        "line_number": 4922,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "545f91bbb948a34a16f5d990bd33418ddda7e513",
+        "line_number": 5003,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "699033973e5f39dfd1b4d15a4b8742f9e52d735f",
+        "line_number": 5083,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c43bd7d0509e4f5a7be8fa3f65113506bad88e88",
+        "line_number": 5164,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1afc31b9ee4a11d1f59c2477f162c87c42d71bef",
+        "line_number": 5244,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "31836e026392d39b0dc9fdbe4d5573a9586bde65",
+        "line_number": 5324,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c5e325ff79e0ea26f62389e30b8f63bbe08319e2",
+        "line_number": 5404,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1a61b7bdea9782292b3c447e42d691adf64a754e",
+        "line_number": 5485,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "08fe4ef64b047833f0352baa980e397a74bf993a",
+        "line_number": 5565,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0557b6b1a60f151b59db2ca90c536ba3d8a2fff2",
+        "line_number": 5645,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8eb310289006377ee28b3deadb9ae649d8fa9100",
+        "line_number": 5726,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8fbe9115d170167efb4cfa59f87077abc0922e99",
+        "line_number": 5806,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f5dc64ba01974dbc9bd902679cabd603f0f6e2ce",
+        "line_number": 5886,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a701b9449a4483ef942eef87831b144445dda022",
+        "line_number": 5967,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6560b2db9f1114a3c4d7cf6eede13a1716d41edd",
+        "line_number": 6047,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7f98fc2f4b0b02e82fe9801ff75abb735a309332",
+        "line_number": 6127,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c2ddd56f79902dd45273f393fd050ab1d309ad14",
+        "line_number": 6207,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "25da890af37d80fdd00f39841f7181d5da94f7e0",
+        "line_number": 6288,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "acc6fde8ceca1f1cf2a832e66ba9d6041aa7c4ae",
+        "line_number": 6368,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9c067bb0c3bcb0917ef88f12d356ec843c9c454d",
+        "line_number": 6449,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9699eb8a236c872b0736b9da492dc582b94dc63b",
+        "line_number": 6529,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0d379f317384a32849373708d8ae82eede3995a0",
+        "line_number": 6610,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c37e00d57f373bff17f6f107164df7595c2aed02",
+        "line_number": 6690,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bd4f218bbdb89431603b1ebcdecb87ca594ebbea",
+        "line_number": 6771,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "60ed333aa4b3308cb72773b6cde1d4568210e458",
+        "line_number": 6852,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "671b08d2279cf2de6352979ebc5fc30a7fbdd430",
+        "line_number": 6932,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e389871a32529c08f632b911110279c3b702aae2",
+        "line_number": 7013,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "165f02f4af5da8e52c9b1262b8c22e9e62280ee7",
+        "line_number": 7095,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e4bac868e25e2b395246f6be2656e8e8d6dd388e",
+        "line_number": 7175,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3b0ec27803331293867c33a414ee08005e078d26",
+        "line_number": 7256,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "400651c697115eaa014ba954aea537eb16973202",
+        "line_number": 7337,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7687c122e643e27e28438bfb137caadcfce85553",
+        "line_number": 7418,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1e44526d055e3bdf6b66c3e07bea7fae8e6112ab",
+        "line_number": 7499,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8de781ead8ec88da505d4b7cfb5f6a1ae271c75f",
+        "line_number": 7580,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4a53c69061f90ec8470c21d4fd7367c433551a11",
+        "line_number": 7662,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f21a4fb6f6b88217cf3c658c550524742e42a842",
+        "line_number": 7745,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "424b938bae2e02d8ee4906652ccbd01bb47d3191",
+        "line_number": 7827,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "541ccd4bda1fa66cd5f731908df604b1de786e10",
+        "line_number": 7909,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fd3e9f625842cf0828ac3b3be9feb1731ceb2f57",
+        "line_number": 8011,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9a2e62d478b0ba698e7201d1ff34e10b5005355f",
+        "line_number": 8113,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "dd48b432e8bb8b206d927d8c6cfde39470e9264d",
+        "line_number": 8217,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "281b6a1c3dede6a5f9c1e74990e51e88d0c30d9b",
+        "line_number": 8319,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2488726d059b8b33f598763b95cc894345268e0b",
+        "line_number": 8423,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e3ea0d5067ddf667fc2e44575d45ac4f0fe1b0a8",
+        "line_number": 8525,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bd6585d063a66fddad989080d32b5af3e8fd6113",
+        "line_number": 8734,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "36a1397c380871f5606737c3f8e73cbcabf7aba3",
+        "line_number": 8836,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4ea4bc9ad240cebf3c250abe6e5abdb8c60ce95c",
+        "line_number": 8940,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "288380003a9cbb79eda2208f497899f32589c5d2",
+        "line_number": 9041,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "df5a5e4b23938d6a04baad0f9c98ee54f3983fc9",
+        "line_number": 9144,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "858c2276aca4e50168b5b4c99cf2522b1874fef6",
+        "line_number": 9246,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "52165e4747281e34c764b48c9a14edf39827d20c",
+        "line_number": 9350,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fb1f019f06c311ee3a36f3dd10e5d88ccd5c96f9",
+        "line_number": 9452,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "37f12ace485b7408eada2e4826fc658e2719471f",
+        "line_number": 9555,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "813205f147ed7c682de1aa6b151f3a2f37cb1116",
+        "line_number": 9660,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c05ae99c25c068b30ef08272c7f08893796fd1b7",
+        "line_number": 9770,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "492cd045b44077b96dfef78ed073159fa9c0cb61",
+        "line_number": 9880,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b3d39fcec80410041ad32282dd50a4949e364bd7",
+        "line_number": 9991,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4cb55a4da5566aa6c830f3ce9dc5faeea7a3b5f9",
+        "line_number": 10101,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b0e8a96661382010f4b40a0eb7fd062e6fce918f",
+        "line_number": 10212,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "eec1df06a91bfcb0c337243a3667325f6fecdbb3",
+        "line_number": 10322,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7cdc34a6b45888552d55a664a5f35ddc9ce66f1e",
+        "line_number": 10433,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bcde446ca391e252838a86446992dfce3b049f44",
+        "line_number": 10544,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "16f083c8370e0710ebc14f87f54af6eb6387360a",
+        "line_number": 10656,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7827574a7dd1ef83bce865bf04bd255f22c27c85",
+        "line_number": 10765,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7f7116959e5e75db2e6d3c3fd0b8b16eebecb7d2",
+        "line_number": 10875,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "09d7cb9310ef436383f9c6fcf79890d5119ebe9f",
+        "line_number": 10984,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "77e2d4ccf738c84a6b28a25e6446e616b8596f24",
+        "line_number": 11094,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3e721ea51e21c04855258e87f3add4c2bed8b815",
+        "line_number": 11203,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a1e41c3e01809ccb04934d95d8926dc4b13c7e41",
+        "line_number": 11313,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "dbbf4f036ea68a36b3a3d0ae1232954de0bb8fbb",
+        "line_number": 11426,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "932b4d50d9c7e8c9b1e600fa55430798021025f2",
+        "line_number": 11541,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5714adab73272ca64a074b2ed0d3f706218baad6",
+        "line_number": 11656,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4d2224908222398d284148bc78da2f2c2626f62c",
+        "line_number": 11771,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "37fecccd2ff8c3f83685df4e53165508bf3002a7",
+        "line_number": 11881,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "44208a8804346d5b4396cf68fba0327f08ab66f0",
+        "line_number": 11992,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b61db01fa959ca744fc526b40fba9c1aec18f534",
+        "line_number": 12107,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "79719868824327daea61b232c2ec1d4838c9fe1f",
+        "line_number": 12220,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f974e2103a301d9257a0af2b59349bb0f8398f76",
+        "line_number": 12334,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "22de60335c7d3382489ff389d7c8997156af7396",
+        "line_number": 12449,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7141f2966852d89db48665a4ca2aef6d3440aff8",
+        "line_number": 12559,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "169ede3170730783b1d9511e4f3cc36d18d71cb4",
+        "line_number": 12670,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e1a6fa27d2c9cde25eea927439fee318cbd27786",
+        "line_number": 12784,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ed69aa394790fb9fe7fe8065d8700786dc9ab4f9",
+        "line_number": 12898,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "59b4c080068466213d272bfa80c5e0b07b2c087d",
+        "line_number": 13012,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7ce26e293a7f43056d32c5c919441aa6f6148192",
+        "line_number": 13127,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c51faca3e5256333269932b89c1dd21d737eb43f",
+        "line_number": 13242,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c180749d49d382a092a0cf73f41a89af81d3e4cb",
+        "line_number": 13357,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "35526905870f02990072324d6dbac9aa3bf336e9",
+        "line_number": 13472,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f8f714853f30923187c17a75daa17af2fcbcb7f1",
+        "line_number": 13587,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9e5aa92bc563f22b79ccbf07e78688494f199605",
+        "line_number": 13702,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "41e62868c8e1aee15ac63aa6e1e04251fb472180",
+        "line_number": 13817,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fc65cfbf74083420dbd1448f676bbef01c8acb9f",
+        "line_number": 13932,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5c9353e579fcfb050c1cc652d1728ab280fa109c",
+        "line_number": 14053,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b2dcd593a3c75ff2c385cbe56622f82077670cf7",
+        "line_number": 14182,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "226d781fca93b4b66e6c12a315574fd983c54ef0",
+        "line_number": 14311,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b868c72e1315678afe5e51e81a802a9375adbaaf",
+        "line_number": 14422,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "68375014af678fd47f40e2f9061fe011b991bffe",
+        "line_number": 14534,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e3b41ea502da736e766b1552582c088f5c17e5d6",
+        "line_number": 14663,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "850c696dac38f71f91e26d461286164af1185099",
+        "line_number": 14774,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "37a52b385305cd1410b0bf33cd16843b97101992",
+        "line_number": 14886,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "afa364bb81cb5387fae88d3c6b0373e73fe4237d",
+        "line_number": 15015,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fac5e4778f2632489ffebeaf1036df6d348e7a7b",
+        "line_number": 15144,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "879dc2a06c2a45566fa2a9b0f8f85fb756efc6ac",
+        "line_number": 15273,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "dcd2f9691f5372316757fec0de059430cce4b8f9",
+        "line_number": 15402,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "eccbc6fe13fd37ad5b38663de88a55792965afad",
+        "line_number": 15531,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a59d1981fb799b219fe7c76b8c6e7f5a500aaba2",
+        "line_number": 15662,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "01f31dfcca14cca2c99566751b4c81f384b84625",
+        "line_number": 15793,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f312cadd951f250d958b65ec441455eb5df19d59",
+        "line_number": 15932,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "64cf3641b780f092a467c6667dadbdcc1b71447c",
+        "line_number": 16071,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bebc66020303185342f861e1749b7296f5a9adf5",
+        "line_number": 16210,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1ae4187c69395bb4d9ccdf1039589242d7647f0a",
+        "line_number": 16353,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cfee71aecd761872815799c041a42fb03f6c9563",
+        "line_number": 16496,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0f46780362982bec3215af27ca4e53c62308d64b",
+        "line_number": 16639,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "23293d5f9d3a07156f3fbd0402ae0bde55588647",
+        "line_number": 16782,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8e70b01f516dd28f7e106126bdf6a15eb7faff8c",
+        "line_number": 16927,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e740b510bfbc2f9748d87b851eafd24301dcb9d3",
+        "line_number": 17072,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "01d48b3cf70cd02162c45fc3236f0dbb18e760d4",
+        "line_number": 17217,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4aaa075615fa21b3597799d5a1c1e85636e1eeb6",
+        "line_number": 17363,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "357c9667a03b55d68053c57581a504934c7de492",
+        "line_number": 17509,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8bf76415ec2bf570b8b35d962001ec9d6a0cc6b9",
+        "line_number": 17655,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6e2660bd731828315ebe474ebc320bd16545d7c6",
+        "line_number": 17801,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "aa9112e58abb938f3ed50b6e37251ec7ee189c4f",
+        "line_number": 17950,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4e4c4711d49beae5d905baaaaa60dbdfba3dd078",
+        "line_number": 18099,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b2b62c4c0a4c0ac94ca4c7e9f6dd3675dd8cd7e3",
+        "line_number": 18249,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bcc61af504739e9a83519bf9876be9eb4b854087",
+        "line_number": 18401,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f882ca381b1d7d218f77f9055dd979302d19d85c",
+        "line_number": 18542,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0a79e9c8555c6287df703fc164cec18cad44af49",
+        "line_number": 18683,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "da74ad55a292696e01bf27fee58e3bf8c97c9923",
+        "line_number": 18824,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b40b6425f9549bdee116d6b36f370ee40dde6f32",
+        "line_number": 18965,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "02264c26a047eb9ae906085c213905b52eb0ed4d",
+        "line_number": 19106,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9f6a54d5b024d1632d9fbe28a82ed9d551216b1b",
+        "line_number": 19252,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1c0a6746003f4edb6199a765e09c3a8100487678",
+        "line_number": 19398,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4385ff564c1b36550ca303721643512087926900",
+        "line_number": 19545,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a885ca0f81721a6ba3878741f19d53906936fb4e",
+        "line_number": 19692,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "728f09463ecffa9b2c3a47bf279909ff41e129f3",
+        "line_number": 19839,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8c3d3dfee6853a341c2fe161aac8f8c3470509d7",
+        "line_number": 19986,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bc8c5e0ddab848abeca3841a640c86f1059c6405",
+        "line_number": 20143,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fd5ca9498f6458fdde298ea763df5ecd9b40967c",
+        "line_number": 20300,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0aa4f74e92cfb8e402f186661a5c9d9f45c71a05",
+        "line_number": 20458,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ffa21c362cf174facec8409b9a11e894a5efff5c",
+        "line_number": 20616,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a5de8270043b89eb003395be82a44a6ab9988a5d",
+        "line_number": 20774,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c3098d52379803ad059ebc50373c97bf9a9390b1",
+        "line_number": 20935,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6488c2cc6714169f70eb897df5c927f752f848a2",
+        "line_number": 21096,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7cd6d2885c09ce977adf3779ded64af8fd981fc3",
+        "line_number": 21257,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9cf0cfa0e704c1e80b04a7a32610f05dbaeacfd0",
+        "line_number": 21419,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d74f2aed5c6526913ce8e38e51f3531bfee76b97",
+        "line_number": 21581,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6a9c82e4c95aace9894b11aeb1a5d5469a004542",
+        "line_number": 21743,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4679044cbb8513a587d3c89bcd7676f48acf9c46",
+        "line_number": 21905,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "94bbc706cfb19bdd6eedc4d344302d2da4f9b7bf",
+        "line_number": 22067,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0e94e0989db41ce44f819d90e79493ab118674ef",
+        "line_number": 22229,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "70e73f374064bf552c63b9c328799e45eecb1a87",
+        "line_number": 22391,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e70947b2f7cb5a80d00e14c7f0e5207a3c954764",
+        "line_number": 22553,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b44bd85c72a26f61186d59632dfa5a457476644a",
+        "line_number": 22715,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "71cd41a05eb04b0d6adb6451a3bbf0a8d2b695c0",
+        "line_number": 22877,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a3b5b3b796d6d961bbdd6060182062336e6b7a12",
+        "line_number": 23039,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cbf0932c29fd3ea0e9d67b2df6ef430b9fc8b18f",
+        "line_number": 23214,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4e229e8174c7f714ffdaab4a39ade407c3748cd7",
+        "line_number": 23391,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "88576c42b156bf139652ba26b8094dc44c9d6764",
+        "line_number": 23568,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2a818a28c429d088d2d03d8b6414e2f2e7f7eec5",
+        "line_number": 23746,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "70cf2ed7151f0b189cdbca342f4c7a5fb6b16c86",
+        "line_number": 24022,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "408c1b7fb2548eba8cd8bb892326977269dbebe0",
+        "line_number": 24027,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f1c07d0a0644d5b0fe104a13f32275d73f4d8960",
+        "line_number": 24032,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "461f7c184ad0a2025add48687d6aaa10b91cabea",
+        "line_number": 24037,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "dd4d0d7d129a50e5ee183791a0eee0bcdf7a1638",
+        "line_number": 24042,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cae3a3c963a768bb0a3048b1d04d3791a5d39906",
+        "line_number": 24047,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "be60b8db2fda4814aa03f93e082f4c8cd44894cd",
+        "line_number": 24052,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "124cbec844db04466ac9b52900a917b29b249d1a",
+        "line_number": 24057,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3fd3062f1cc0fc29d52bce60c84ef7a4941091d7",
+        "line_number": 24062,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d5d0009ea0357e1b5ecf629b70d2e878d22fd5c9",
+        "line_number": 24067,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "57deb18b3e0911ab6786537beed3d3e40c046b20",
+        "line_number": 24072,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fc7214b9e543f452e9b552377cfa31a7970da974",
+        "line_number": 24077,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2d5a211912660401da9ffb3d55ad1d0a518482e9",
+        "line_number": 24082,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "22bae7af2c35175ada7976f326d98352a8a0d6c1",
+        "line_number": 24087,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "82b2a0ed698d9a4c814477b1f7d234ba3b316ad4",
+        "line_number": 24092,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5c693622fff810491fc26d09c5c77f91f79c4ccc",
+        "line_number": 24097,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b4dd73555bad170ea6974b5d40ba6c275eb35378",
+        "line_number": 24102,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cef58c3b475f96c74be3dd699935ee623dd53bfc",
+        "line_number": 24107,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "97255d67db84b04ff61d1f5d917500cf4f112e28",
+        "line_number": 24112,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1256403bb2de295cd4c7e6b3b92f0765ec5cbadf",
+        "line_number": 24117,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "33542dec20219c9a3c679cbae6edeea53e7df17b",
+        "line_number": 24122,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bdcb0bace3abac077ceb2cb6154bd1c3ca618793",
+        "line_number": 24127,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "000242741b73f8566e702470a5c07b1dc7eeca62",
+        "line_number": 24132,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bd74dd96a61560d8bd650a5c059e2eda6364146d",
+        "line_number": 24137,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b5931accf87811c12aa868d47ab46b9a0c4f56c5",
+        "line_number": 24142,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "575250a9ea3f3714d8fc068d2973e4d2703bb983",
+        "line_number": 24147,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1e6f0538775a16516a61aab24b1e693c40788be2",
+        "line_number": 24152,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c9828a7732a8320b6e7f013ba2f3b982c59a643b",
+        "line_number": 24157,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "28e0e151d06f2c898497c86affaf95d0aebd7945",
+        "line_number": 24162,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c3863ee1b9604ec8cff9cb4b6ad6251a8b42f205",
+        "line_number": 24167,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "81c89cd9bab5e7f63b7e981b4270758a7f007591",
+        "line_number": 24172,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3489c8722afb0e3e39ce593402cc16648767984d",
+        "line_number": 24177,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "409ee8d3f3a8e930decf8556573bb6e835101d94",
+        "line_number": 24182,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ed8579b4e3d80585f198b597571732ac7fd5bf93",
+        "line_number": 24187,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5eb82631677987c2c0187c945b3b6c4cef728106",
+        "line_number": 24192,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a0ac515d8a164eca1519578f1cd0cded7ba59d0a",
+        "line_number": 24197,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e38a904ed481c7170fbdd9b18a75d28cb35e5ba0",
+        "line_number": 24202,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "834e9cc0db6336e29d1be1fef2fd1691e35889d0",
+        "line_number": 24207,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7202055939dd1673399fe90cdd0b1902443b8154",
+        "line_number": 24212,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8318862f13836ad043414a6598272ccc1b193487",
+        "line_number": 24217,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "832a461eed50625a99810de2018be5b9f613a6c7",
+        "line_number": 24222,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3ba7a7e5dd701b9267872186a36ec6631778a938",
+        "line_number": 24227,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8b4884d1398cfd774e19d560c3c416ebcd388145",
+        "line_number": 24232,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "011cbacdd38458d292d2b57a1305a78503244a58",
+        "line_number": 24237,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ca8045d33a263d830d6106bd2204224940e0e03c",
+        "line_number": 24242,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7589aef75b3cabc09c9dea0c4e0fc31605bb0ebc",
+        "line_number": 24247,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "94e6d3d44bab46f131426020b16e7cea4b08159b",
+        "line_number": 24252,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1d008ce176947e2ba624161502f5558ce8373225",
+        "line_number": 24257,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7220cd3d7d560e7e4cc2b0cdc425d7935f54cd31",
+        "line_number": 24262,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "16e883ceef8c6107600623248924fa11f689fbf4",
+        "line_number": 24267,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "88805709f933d77801e2af7ee7a7d2b6fee7ad1b",
+        "line_number": 24272,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e5f53f0ddd85422ebc8aea43e9d1cf3eba763404",
+        "line_number": 24277,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cf911d7cbe26d06a08e56b591e0f5fcb300592b6",
+        "line_number": 24282,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "edf7246348e0aa77f659a53f4506ee3e93c9a1aa",
+        "line_number": 24287,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a7720b893e771035f03b4499dd1e84c50404e621",
+        "line_number": 24292,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ab7efeee1d61e7dc0c6f2b0cf48e9397eab0e330",
+        "line_number": 24297,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "703922e6df8bde2f1cf28c3ef708f317d7a6344d",
+        "line_number": 24302,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e87919bc2c0bf757d86f9c063356da70a42e9500",
+        "line_number": 24307,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cfddc533ca39598f3b2fb6fe2705c5d160306f6f",
+        "line_number": 24312,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7d373878b4d4654042a5a1f23b6d86a8dec7fef6",
+        "line_number": 24317,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cb9831f7bfc5000f355c12ae8c6eb53dfdf5159f",
+        "line_number": 24322,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fa867a4595168e6212e47302c14af2613672f994",
+        "line_number": 24327,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a7347d566633493e11377e4ea0bfb5dc7d54700b",
+        "line_number": 24332,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f18778f604c7d349e7e743b4b7e3c262e9d46b8b",
+        "line_number": 24337,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "86be1f73be01f199384e42090e3e3307c2756242",
+        "line_number": 24342,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8843ef1d3d119557d43b87b5ae51ddce2064331b",
+        "line_number": 24347,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8207c407e75f890ab222a90952677028ca3856ad",
+        "line_number": 24352,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "45431c5ce60d051780547b4c0f18f43c8b0369aa",
+        "line_number": 24357,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "08969302f063e88c979bdba30dc1f963a418192b",
+        "line_number": 24362,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "46201b521c0938a8b1389d57aea2d85198d8cc08",
+        "line_number": 24367,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "55c11985f5dc52dd05e753e5ea75f8ae9c225661",
+        "line_number": 24372,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8e68a1d516b7630cb0464f974efb95be87154f28",
+        "line_number": 24377,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "717d6a28fed9dc32f1f2f83d50e8a56da0b42d4c",
+        "line_number": 24382,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9f1eac1afefcba62f6613d7d22bfd7b6ca5a5082",
+        "line_number": 24387,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "efb962e9ffc7cffc992903868986d120f0b940cd",
+        "line_number": 24392,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f20d82eb45abb07051f7afe09b59c96cf0de7680",
+        "line_number": 24397,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "30bc1d68da2f52bc87cbb19b14729709189207b7",
+        "line_number": 24402,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0ca5f5597fd8d87fde419ada1f66b1ce94a0a78a",
+        "line_number": 24407,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1ce522dbb53efe7902b5101c9e303520fbeb7268",
+        "line_number": 24412,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e85d62e8b7cbb463ab56a1b4cd9d4e4829b79ae1",
+        "line_number": 24417,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c8555da9d39cd48f11daed1c4e0bb6851183cff4",
+        "line_number": 24422,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7126216867c1c3c3247109e597c265402fdb2b51",
+        "line_number": 24427,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "dfaf8743f782f7e97725f5946d6cc407937be5b8",
+        "line_number": 24432,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d01c9f57940ddc7598e03cc60d48fdbc73b975f9",
+        "line_number": 24437,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a65d0158db5a93463fed7e0c22e69392b3f6d600",
+        "line_number": 24442,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bf9be8cf29e91f8e95252514ec6f697b8db1e5fa",
+        "line_number": 24447,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "06e80909081f90fd629a76d976e0310d6b90d7c9",
+        "line_number": 24452,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c63439ab85a49094f8207b3120697faf26bcfefe",
+        "line_number": 24457,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d0ddf78ab42a848785bd869f96bebd4a75e85ef1",
+        "line_number": 24462,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "71317a2b560033f7967ada1aa6c859fde091fb5b",
+        "line_number": 24467,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "86fc2324903442538bcaec0c175af503344364ff",
+        "line_number": 24472,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b04fa00c7333e0ac119af1ca711cccb74749bae0",
+        "line_number": 24477,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "45f99c1d5b72ac208cc2a39d5cb96efa8aed906b",
+        "line_number": 24482,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "478f11508ceee4099a4eb69744270381bc1220aa",
+        "line_number": 24487,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b7ffccbd556b1ec92ea25dd09defa11724160323",
+        "line_number": 24492,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "06f14341f782352ab033b4894382c8ca2e9cab96",
+        "line_number": 24497,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a97de3072b696fa310e37080c07e0a8426c5d8ea",
+        "line_number": 24502,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1d8d5b74ae2fbc1a2646aa8a1e36411519355c78",
+        "line_number": 24507,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e71b27ed04c4c12bd00b70568839ac560b3f7c70",
+        "line_number": 24512,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e1a98d920e1eff685bbacef48bd14bd21e237d17",
+        "line_number": 24517,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8660bd46f00360ac4c37d47ee3d35706e24ad4bc",
+        "line_number": 24522,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e484164b97a540eca523adb043f7534c3dc63488",
+        "line_number": 24527,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fa1f5f5e05d2616e8aa787acc968e09fd9e9e1e7",
+        "line_number": 24532,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d0fdf70aace518eeb1887906a2fa378d46c5dc49",
+        "line_number": 24537,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "caf95be8fcbafbd2ce81bbd462d27b15d5e941d2",
+        "line_number": 24542,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "02f91a1230cb11350a90f18f827a25682174eb17",
+        "line_number": 24547,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bf8b84288e15c516e6a7055be15cb51caa51c59d",
+        "line_number": 24552,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fba1e2de5e4c3926b22706c993be42aee8f7a6b8",
+        "line_number": 24557,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1acec9e5d2283b2ea9145f8c960fda1c1ca0adb1",
+        "line_number": 24562,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "3ae09819b5a82fbbaed3bc6d90a1addac97edd04",
+        "line_number": 24567,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "01c7a869f403da73d8f3262b528b55a437d57b88",
+        "line_number": 24572,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7f79395ac7b2cbd650c78e769f2f3555ff945908",
+        "line_number": 24577,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f8131b4428ff692a964e7a4fedb699b34b1f87db",
+        "line_number": 24582,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bbb670ff0e185f3c92ac9e3d60e0705c40cbaeeb",
+        "line_number": 24587,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "39f576a0dae848bdcd019ec3cb23197353e3c649",
+        "line_number": 24592,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "4664ea151d2dd8fb84f4360dff3b5a86302acbb9",
+        "line_number": 24597,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c1654d9baf0e9ecb4a0397178240a30423d2b5ef",
+        "line_number": 24602,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "dc00b0a262affde63a3af78fb8c0402eae2efc39",
+        "line_number": 24607,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "719b9a7b34b139923f84a76d0a0c7c10016db970",
+        "line_number": 24612,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ccf235957b7b15a97c6daa8e3a9356ac3848223e",
+        "line_number": 24617,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "91b74af507736a17db8e44d81332ae48cf5dc29e",
+        "line_number": 24622,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c01df5e3153538944dc644514bc4115184d51eaf",
+        "line_number": 24627,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "55b3eae2d7a7eb842bb87cb5606c1bdcc75de05e",
+        "line_number": 24632,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f8bbb8024d0b3d1cf638225c48a1286a4b86bc60",
+        "line_number": 24637,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0c0c434c39f165541f90addc017b1285c3b71cfd",
+        "line_number": 24642,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "60ac9f156d1440947136acdbb59042a80187ab58",
+        "line_number": 24647,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "76f25db50272e0226019c4484b5ae6a064e70c3f",
+        "line_number": 24652,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bd68307f5782d9623183c8ee4efea0d31448a7ce",
+        "line_number": 24657,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1a215c240cde4a63fc9bd7021afee2b6bbef5a79",
+        "line_number": 24662,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cb3fcac1e5265a7133397bb02a775b6e6587a97d",
+        "line_number": 24667,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "aac6a2873e99d014d7ed6aef8fbf589d8d60ee9e",
+        "line_number": 24672,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "73757cfd09584033daec92313e775357837c0680",
+        "line_number": 24677,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b12622e0bc9ca52e375ed5ffed53b44e44c5c170",
+        "line_number": 24682,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cf97fbcb464e842c1d5b98228648623ce1722f1f",
+        "line_number": 24687,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bf33fe01f7a3573e0d6a2fd58f15e84319a4cdf1",
+        "line_number": 24692,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "80204409f05e1a8031e97806ecc2c02641726e01",
+        "line_number": 24697,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d327c7d688ae26152cb3a14d5f11f3569c53efb4",
+        "line_number": 24702,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e46de5ca23b0d95c0ff04bf47d23440349a66ca2",
+        "line_number": 24707,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b59bfa98cfe452341077eb20b14684336fc075e6",
+        "line_number": 24712,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "57d7e50927cae319502a7cd0670da42423f0e707",
+        "line_number": 24717,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fd9272d1e81b48c6d4b374c8bc0e1c23bc7fdfd9",
+        "line_number": 24722,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "01932307ee760d9f1423ab0f227af4aa6bdc16cc",
+        "line_number": 24727,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "098cebb8671653b1a1fc8e68109447acf6411419",
+        "line_number": 24732,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0830d57fc58c2cbba7a95adfddf1595b5cb1fecf",
+        "line_number": 24737,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d255b9a7d93108f12eb001d283d8cee707d2dbb3",
+        "line_number": 24742,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c54acc13ef9aea82d4c7c7a35bba243ec5b8754f",
+        "line_number": 24747,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f6ec64eee0e841d8531777f36cf4b1cc249d342a",
+        "line_number": 24752,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "d42042b8d59066de3cd34add389d5b3c56a357df",
+        "line_number": 24757,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e8e378b61f8661e99d683e73c0c756d68b598636",
+        "line_number": 24762,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "deca068f7cb2e76c05d0a4b06b05943cbc8da401",
+        "line_number": 24767,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7b8682201b2233a195942d28face7af3802fee9b",
+        "line_number": 24772,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0f063371b3e7328672af759624ec43c5b9eb7494",
+        "line_number": 24777,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5f02018a316540f30fd47298276f34bde3eb42ad",
+        "line_number": 24782,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "194a352ad21b4055a85c1f934403700255d64a10",
+        "line_number": 24787,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7d51d43ec502f6411f41cb6b0989e8f544cb84b5",
+        "line_number": 24792,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "99f44386e34c8cafa23411fcc0369c1a1ea296d0",
+        "line_number": 24797,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "65de35bd5ccd1746eb22fac9b4ed3a5eb10715c9",
+        "line_number": 24802,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e9ae33d6b392c5652d8e104a353c5ea8c225338f",
+        "line_number": 24807,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b95423266717cd4ba8f08c4ce8d29b6de41b8242",
+        "line_number": 24812,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "641eece83bc4d9173548baadd93b250d2e5789e6",
+        "line_number": 24817,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "942934bc58303ddcefe8d0ba0fdc18e73d82eae6",
+        "line_number": 24822,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a5e9f447f5043b6a76330a8a7861ca570fc7fe17",
+        "line_number": 24827,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8a2f4a4a6d5acba6d83f3094551e12e22da989f2",
+        "line_number": 24832,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b008d94f4bab22a8ebe66c71941116c4e08eba08",
+        "line_number": 24837,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "abfd216d5c2024c7c8176fe8a3e5d886333fda35",
+        "line_number": 24842,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "962560d9116168e635dc6044617faa87a1e4f9a1",
+        "line_number": 24847,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9bba22348f5adf006b942e0e20b6f703a59798cf",
+        "line_number": 24852,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1a556a290dc50dbb574bb5bbe49248f874b52f97",
+        "line_number": 24857,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "36157b03b8e9945404eda4057bb33678f3a7db5a",
+        "line_number": 24862,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8dfe52eba4f6811118caaa4bdf90a924516a2df5",
+        "line_number": 24867,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "473f7b39ed1d792a37f58b5f55a6f3d80c3238f9",
+        "line_number": 24872,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2ad08fd9799292d458947a648fd97f2fbe2bbb86",
+        "line_number": 24877,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bad775c0d033b9c5c958aa32dd759627b6b54966",
+        "line_number": 24882,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1bed788ae168f64e5504e0e5c8e9bb4aab4fad14",
+        "line_number": 24887,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "041f86f19bb912b2cb94ff17f0565ec09d170230",
+        "line_number": 24892,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bb6ca8732cfa078d1b1b28d100d586db9a4b8432",
+        "line_number": 24897,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a823394b9e0ae1e731945460372d469f9c7eae9a",
+        "line_number": 24902,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fb5ad48798b99eb5d13400355b0ff9b4cd38c854",
+        "line_number": 24907,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "32e3eda339e849bf0016986efff2babd3b691a55",
+        "line_number": 24912,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2c8eaad2576e047b1640f3f95fe27806e2539b12",
+        "line_number": 24917,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a9c33baad8fe7d9d1f9ca38ac3d72cc7cef2563b",
+        "line_number": 24922,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cf7aeb46fe6668887f77d6bc13608d4fa017c45f",
+        "line_number": 24927,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f60f8bc653a9226db88b605951da1e8dbcf8cf01",
+        "line_number": 24932,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "355719336c5c5ee12976907be5eb2eef884f83ea",
+        "line_number": 24937,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "23a1a734c192a58e2d80dfb091b97e60e4585498",
+        "line_number": 24942,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "531045aa336cb00b21013c96defec94d13d1bef8",
+        "line_number": 24947,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fa4de46109a7a7d93e3eda027eccb2774a2c6c13",
+        "line_number": 24952,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "15b84972d13a214e2a74c92c9aff7e2c4db090e9",
+        "line_number": 24957,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "06d8ec8166d330d9d9dfb53e75f117df63e1651f",
+        "line_number": 24962,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "dd5fddb8419408b3882802ddb9d35d6e819c2c08",
+        "line_number": 24967,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "88949296dff245f3953ecc6e0521560db375c17c",
+        "line_number": 24972,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "cb175a2c4dd0d4d26c85c81d4999ed7c207efc05",
+        "line_number": 24977,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "264f0a1c25cbc910467fe0ada7131ad95e18535a",
+        "line_number": 24982,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5806049a87379c8de4bc2f0039d23238a89de019",
+        "line_number": 24987,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f9da41502317dcf2a05b304e904271e8af31e034",
+        "line_number": 24992,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "bddf77b1e0871cc207493c840c1b3ae49a512b88",
+        "line_number": 24997,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1f817f9450db5b4780ea7e44780d2865e29e28d4",
+        "line_number": 25002,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1b0c24bbec6907643f71b9503ecac654e2dafea5",
+        "line_number": 25007,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f57325ae946b8f160ca07c11a816b8ebff0a3c48",
+        "line_number": 25012,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c78cebc5afb2a82cbcef9851c75264b3e6bb3f4a",
+        "line_number": 25017,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b3ef8efcd34b6100cbd671cbd43a36f0dff9152e",
+        "line_number": 25022,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ec8996593973d61f2ad2eea9a63a0769f09fb25e",
+        "line_number": 25027,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "df0af264f700f2ddab8f77a4c50e8168d6690ea4",
+        "line_number": 25032,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1845f23cfb13addb49dc8c0e37041ee27ec18934",
+        "line_number": 25037,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ccfb569259e72ca321e33e8336b45297dab877d1",
+        "line_number": 25042,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0b08e282dd7419796e088a7999642a93c86ac634",
+        "line_number": 25047,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "14986639654a357847b23cc30af438d7e57d6ba5",
+        "line_number": 25052,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "43d9416c67e2a60bd2783aab60317bf4fdec23f5",
+        "line_number": 25057,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "1654c0dc861bdf404fd5b3666080a951a9682164",
+        "line_number": 25062,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "b2fecdca6c5e5088f1d1363b27b22efe41ac093e",
+        "line_number": 25067,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0fb0814afc2a8e41bb19a6191bbc4d5950350188",
+        "line_number": 25072,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "62a9bfc81bfb7e681b0aa825ffad2a493999ddc8",
+        "line_number": 25077,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "371eff03ca86bcc46d761e993e3e8ff74a9bc6e1",
+        "line_number": 25082,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7842a460ca6e134502684bd307e0042af07b8d25",
+        "line_number": 25087,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e918ae20837b4045c9f8ebe546d0a4eedf6dbddf",
+        "line_number": 25092,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fbe9b8f4fef1ac1b27a0a283e6c2cbf7fe9f71fe",
+        "line_number": 25097,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "28ff09747befb5ae7d894f2be4b8ca4d68ad850b",
+        "line_number": 25102,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9860c3888120a8ac3b78e1939766e37db2724901",
+        "line_number": 25107,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a8fb0255de88946ada1953e0114c45f7f1bd99fd",
+        "line_number": 25112,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e2eb6f7ed1add9f7e80ba7c92eda508e58487832",
+        "line_number": 25117,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f0ad5d25259e8950190cc28f1c8c96b6e01715b3",
+        "line_number": 25122,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6269798118fe2d9145c21c09c38f6c090826cfa7",
+        "line_number": 25127,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "8c168db670091e70bf146e0fd976a36bab56d95d",
+        "line_number": 25132,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e7b3f5082ddde702e9105c896561d388fd1a7fb8",
+        "line_number": 25137,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "085f1d24ceb4c35ed0c1f158c60c165b4c5fd9f3",
+        "line_number": 25142,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "98a241c9f3a92a05bb2b7979e98d4865a80831c7",
+        "line_number": 25147,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5c69b95ed34bdd2d9d81abf07a2e77d4db4fdec3",
+        "line_number": 25152,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "203c234ea75655f95f4445c2346a3b4db2fac2d0",
+        "line_number": 25157,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "806356b06fa623e0632bc095f720f6a8e1126ea6",
+        "line_number": 25162,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/publish-api.js": [
+      {
+        "hashed_secret": "bb1e9de8a2e550ca43c48d5d1d5b326f32d910b3",
+        "line_number": 38,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/storage/verdaccio-corrupted.db.json": [
+      {
+        "hashed_secret": "5d7eb490cf16357d24404f4a46d95a70148cbb7c",
+        "line_number": 1,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "5d7eb490cf16357d24404f4a46d95a70148cbb7c",
+        "line_number": 1,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "test/unit/partials/storage/verdaccio.db.json": [
+      {
+        "hashed_secret": "8a99a3f9c348af61cf47186b819b63187dbfe11f",
+        "line_number": 1,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "8a99a3f9c348af61cf47186b819b63187dbfe11f",
+        "line_number": 1,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "types/index.ts": [
+      {
+        "hashed_secret": "3812d6abc055424d0556b35f48774c7b0044eac2",
+        "line_number": 111,
+        "type": "Secret Keyword"
+      }
+    ]
+  },
+  "version": "0.12.2"
+}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@verdaccio/types": "5.2.2",
     "codecov": "3.5.0",
     "cross-env": "5.2.0",
-    "detect-secrets": "1.0.1",
+    "detect-secrets": "1.0.2",
     "eslint": "5.16.0",
     "get-stdin": "7.0.0",
     "husky": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@verdaccio/types": "5.2.2",
     "codecov": "3.5.0",
     "cross-env": "5.2.0",
-    "detect-secrets": "1.0.2",
+    "detect-secrets": "1.0.3",
     "eslint": "5.16.0",
     "get-stdin": "7.0.0",
     "husky": "2.7.0",
@@ -135,14 +135,14 @@
     "relative": true,
     "linters": {
       "*.yaml": [
-        "detect-secrets-launcher",
         "prettier --parser yaml --no-config --single-quote --write",
+        "detect-secrets-launcher --baseline .secrets-baseline",
         "git add"
       ],
       "*": [
-        "detect-secrets-launcher",
         "eslint .",
         "prettier --write",
+        "detect-secrets-launcher --baseline .secrets-baseline",
         "git add"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@verdaccio/types": "5.2.2",
     "codecov": "3.5.0",
     "cross-env": "5.2.0",
+    "detect-secrets": "1.0.1",
     "eslint": "5.16.0",
     "get-stdin": "7.0.0",
     "husky": "2.7.0",
@@ -131,12 +132,15 @@
     }
   },
   "lint-staged": {
+    "relative": true,
     "linters": {
       "*.yaml": [
+        "detect-secrets-launcher",
         "prettier --parser yaml --no-config --single-quote --write",
         "git add"
       ],
       "*": [
+        "detect-secrets-launcher",
         "eslint .",
         "prettier --write",
         "git add"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3089,10 +3089,10 @@ detect-newline@^2.1.0:
   resolved "https://registry.verdaccio.org/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
-detect-secrets@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/detect-secrets/-/detect-secrets-1.0.2.tgz#f0093ca4db1d54908e3b3c90be98f88dbb11676f"
-  integrity sha512-Ap9hetQaNlHfxGRSlDrfoEIPQAduR9E1FijJj6AN1zYeW/r6GB5jXfM92dhfA7PaFvywh2BreA4J8nQFiE8AJg==
+detect-secrets@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/detect-secrets/-/detect-secrets-1.0.3.tgz#ad46e11bdffc96a9338118cf5952d1a0609d91a1"
+  integrity sha512-+qZ1S0Zssnz74uluISDHUkH7OpMI2tKbyn8PhQuNY/ffvZ4JvSCC9ouWAtE2Ac6726NtTip6GkNacSuxYpnAZw==
   dependencies:
     debug "^4.1.0"
     which "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3089,10 +3089,10 @@ detect-newline@^2.1.0:
   resolved "https://registry.verdaccio.org/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
-detect-secrets@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/detect-secrets/-/detect-secrets-1.0.1.tgz#c359bb655a0977d0342a648e11e5504051860f5c"
-  integrity sha512-aVrNH3Cj708lX99yVQBgnQflQiNjxjMZcbEHGHQqdxw2wHpBJFM8lcRG1c5XpRPgNmQSrYW3NffgW8Qd2VfBxg==
+detect-secrets@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/detect-secrets/-/detect-secrets-1.0.2.tgz#f0093ca4db1d54908e3b3c90be98f88dbb11676f"
+  integrity sha512-Ap9hetQaNlHfxGRSlDrfoEIPQAduR9E1FijJj6AN1zYeW/r6GB5jXfM92dhfA7PaFvywh2BreA4J8nQFiE8AJg==
   dependencies:
     debug "^4.1.0"
     which "^1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3089,6 +3089,14 @@ detect-newline@^2.1.0:
   resolved "https://registry.verdaccio.org/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detect-secrets@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/detect-secrets/-/detect-secrets-1.0.1.tgz#c359bb655a0977d0342a648e11e5504051860f5c"
+  integrity sha512-aVrNH3Cj708lX99yVQBgnQflQiNjxjMZcbEHGHQqdxw2wHpBJFM8lcRG1c5XpRPgNmQSrYW3NffgW8Qd2VfBxg==
+  dependencies:
+    debug "^4.1.0"
+    which "^1.3.1"
+
 diff-sequences@^24.3.0:
   version "24.3.0"
   resolved "https://registry.verdaccio.org/diff-sequences/-/diff-sequences-24.3.0.tgz#0f20e8a1df1abddaf4d9c226680952e64118b975"
@@ -8285,7 +8293,7 @@ which-module@^2.0.0:
   resolved "https://registry.verdaccio.org/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
   integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
 
-which@^1.2.10, which@^1.2.9, which@^1.3.0:
+which@^1.2.10, which@^1.2.9, which@^1.3.0, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.verdaccio.org/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==


### PR DESCRIPTION
**Type:**
Feature

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**
Adds support through [`detect-secrets`](https://github.com/Yelp/detect-secrets) which wraps Yelp's generic detect-secrets tool, to test for secrets being committed to source control using the pre-commit framework the project already has, and as a result prevent secrets like passwords, tokens and others to leak into source control.

The `detect-secrets` npm package will try different methods of invoking the `detect-secrets-hook` tool to run the secrets test for each file, and if it isn't able to find it will silently fail to not interrupt developer workflow. In a future re-visit of this capability we can update this to be a breaking change and fail the commit (or perhaps fail the CI, which might be a bit late, but better than never).