### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -25,7 +25,10 @@ If applicable, add screenshots to help explain your problem.
  - Docker commands [e.g. docker pull ...]
  - Docker Version [e.g. v18.05.0-ce-rc1]
 
-**Configuration File (cat ~/.config/verdaccio/config.yaml)** 
+**Configuration File (cat ~/.config/verdaccio/config.yaml)**
+
+**Environment information**
+Please paste the results of `verdaccio --info` here 
 
 **Debugging output**
  - `$ NODE_DEBUG=request verdaccio` display request calls (verdaccio <--> uplinks)

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -22,7 +22,10 @@ Some advices before file an issue
  - `$ npm -ddd` prints:
  - `$ npm config get registry` prints:
  - Verdaccio terminal output
- - Which (Windows, OS X/macOS, or Linux) environment are you running verdaccio?:
+ - Please paste the results of `verdaccio --info` here:
+
+ <!-- Local environment information -->
+ 
  - Verdaccio configuration file, eg: `cat ~/.config/verdaccio/config.yaml`
   - Container Options:
    - Docker?:


### PR DESCRIPTION
`v4.1.0` features an `--info` option with which the user can get information regarding his local environment.
Hence, it makes sense to update the issue template(s) prompting the user to paste the results as received.