### PR TITLE
fix: allows pkg names that starts with dash

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,7 +50,7 @@ export function convertPayloadToBase64(payload: string): Buffer {
  * @param {*} name  the package name
  * @return {Boolean} whether is valid or not
  */
-export function validateName(name: string, isScoped: boolean = false): boolean {
+export function validateName(name: string): boolean {
   if (_.isString(name) === false) {
     return false;
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,18 +50,27 @@ export function convertPayloadToBase64(payload: string): Buffer {
  * @param {*} name  the package name
  * @return {Boolean} whether is valid or not
  */
-export function validateName(name: string): boolean {
+export function validateName(name: string, isScoped: boolean = false): boolean {
   if (_.isString(name) === false) {
     return false;
   }
 
   const normalizedName: string = name.toLowerCase();
 
-  // all URL-safe characters and "@" for issue #75
+  /**
+   * Some context about the first regex
+   * - npm used to have a different tarball naming system.
+   * eg: http://registry.npmjs.com/thirty-two
+   * https://registry.npmjs.org/thirty-two/-/thirty-two@0.0.1.tgz
+   * The file name thirty-two@0.0.1.tgz, the version and the pkg name was separated by an at (@)
+   * while nowadays the naming system is based in dashes
+   * https://registry.npmjs.org/verdaccio/-/verdaccio-1.4.0.tgz
+   *
+   * more info here: https://github.com/rlidwka/sinopia/issues/75
+   */
   return !(
     !normalizedName.match(/^[-a-zA-Z0-9_.!~*'()@]+$/) ||
     normalizedName.charAt(0) === '.' || // ".bin", etc.
-    normalizedName.charAt(0) === '-' || // "-" is reserved by couchdb
     normalizedName === 'node_modules' ||
     normalizedName === '__proto__' ||
     normalizedName === 'favicon.ico'

--- a/test/unit/modules/utils/utils.spec.ts
+++ b/test/unit/modules/utils/utils.spec.ts
@@ -246,6 +246,8 @@ describe('Utilities', () => {
           expect(validateName('verdaccio')).toBeTruthy();
           expect(validateName('some.weird.package-zzz')).toBeTruthy();
           expect(validateName('old-package@0.1.2.tgz')).toBeTruthy();
+          // fix https://github.com/verdaccio/verdaccio/issues/1400
+          expect(validateName('-build-infra')).toBeTruthy();
         });
 
         test('should be valid using uppercase', () => {


### PR DESCRIPTION
**Description**

In sinopia https://github.com/rlidwka/sinopia/commit/9f662a69e19a15dd90f568fc3a3ebf65b33cbd80#diff-50e3aa130a4f97a42ee2cf111c7b1d9d a validation name a package that start with dashes eg:(`@scope/-my-pkg`) was added with the argument that pattern is reserved by *couchdb*, but, npmjs clearly allows that pattern now. I guess this is not a restriction anymore.

fix: https://github.com/verdaccio/verdaccio/issues/1400

This PR remove such validation.

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:

*  There is a related issue? yes
*  Unit or Functional tests are included in the PR yes

**Description:**

Resolves #1400
