### PR TITLE
feat: add new prop to audit middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "pkginfo": "0.4.1",
     "request": "2.87.0",
     "semver": "6.2.0",
-    "verdaccio-audit": "1.2.0",
+    "verdaccio-audit": "1.2.1",
     "verdaccio-htpasswd": "2.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8186,10 +8186,10 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.verdaccio.org/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-verdaccio-audit@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.verdaccio.org/verdaccio-audit/-/verdaccio-audit-1.2.0.tgz#932485729a39f518bd4fd8d5688160cc5edafcbb"
-  integrity sha512-383K+EFqsc0kirh2mXrd7xCBzEIQBHlGZsJCT99W8UxKtdG1vyaHiPOe8wb7/aLENSOu7G7UFSMrad/F3oCrtw==
+verdaccio-audit@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.verdaccio.org/verdaccio-audit/-/verdaccio-audit-1.2.1.tgz#24aca87c0cd2f3b576e123d2da8b53d620f836c6"
+  integrity sha512-kSQ4s3B0VgO43r7zOjteINzomeTEjaQwRwcNX0XDcm671pM+ZzPFEbv6VZ+vN75KdwCYmli5r8AUI9TMcj1JEg==
   dependencies:
     express "4.16.4"
     request "2.88.0"


### PR DESCRIPTION
- context: https://github.com/verdaccio/verdaccio-audit/pull/12
- related https://github.com/verdaccio/verdaccio/issues/1293

Co-Authored-By: Danny Frencham <dfrencham@users.noreply.github.com>

**Description:**

It adds new property to audit middleware.

```
middlewares:
  audit:
    enabled: true
    strict_ssl: true # optional, defaults to true
```

Helps with #1293
cc: powered by @dfrencham