### PR TITLE
fix(deps): add missing prod dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "envinfo": "7.3.1",
     "express": "4.17.1",
     "handlebars": "4.1.2",
+    "http-errors": "1.7.3",
     "js-yaml": "3.13.1",
     "jsonwebtoken": "8.5.1",
     "kleur": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4249,7 +4249,18 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@1.7.3, http-errors@~1.7.2:
+http-errors@1.7.3:
+  version "1.7.3"
+  resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
+  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.4"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
+http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.verdaccio.org/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==


### PR DESCRIPTION
http-errors needs to be a prod dependency
as it is used in code.

https://github.com/verdaccio/verdaccio/blob/c1672f7e32658905caa8a5634602723b1b5246c1/src/lib/logger.ts#L9

<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

<!-- Resolves #??? -->
