### PR TITLE
fix: fixed user creation endpoint to properly import groups

### DIFF
--- a/src/api/endpoint/api/user.ts
+++ b/src/api/endpoint/api/user.ts
@@ -23,13 +23,13 @@ export default function(route: Router, auth: IAuth, config: Config): void {
     const remoteName = req.remote_user.name;
 
     if (_.isNil(remoteName) === false && _.isNil(name) === false && remoteName === name) {
-      auth.authenticate(name, password, async function callbackAuthenticate(err, groups): Promise<void> {
+      auth.authenticate(name, password, async function callbackAuthenticate(err, user): Promise<void> {
         if (err) {
           logger.trace({ name, err }, 'authenticating for user @{username} failed. Error: @{err.message}');
           return next(ErrorCode.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.BAD_USERNAME_PASSWORD));
         }
 
-        const restoredRemoteUser: RemoteUser = createRemoteUser(name, groups);
+        const restoredRemoteUser: RemoteUser = createRemoteUser(name, user.groups || []);
         const token = await getApiToken(auth, config, restoredRemoteUser, password);
 
         res.status(HTTP_STATUS.CREATED);


### PR DESCRIPTION
This is a fix for this: https://github.com/verdaccio/verdaccio/issues/1426

Root cause is that the `auth.authenticate()` method calls back with the arguments `(err, user)` but the method to add a user is expecting `(err, groups)`.

I'd like to also add tests to this PR but i'm not sure the best way to go about it. I didn't see an interface for this kind of callback in the monorepo or flow-types. Is there a preferred method to approach this kind of issue?

Resolves #1426