### PR TITLE
fix: unpublish and add or remove star colision

### DIFF
--- a/.secrets-baseline
+++ b/.secrets-baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2019-07-27T21:44:36Z",
+  "generated_at": "2019-08-10T11:09:03Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -40,31 +40,26 @@
     "src/lib/auth-utils.ts": [
       {
         "hashed_secret": "6947818ac409551f11fbaa78f0ea6391960aa5b8",
-        "line_number": 10,
+        "line_number": 12,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
-        "line_number": 174,
+        "line_number": 187,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "f35dd4c51c0a89bd055b5ad30c162c778981306d",
-        "line_number": 179,
+        "line_number": 192,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "45c43fe97e3a06ab078b0eeff6fbe622cc417a25",
-        "line_number": 197,
+        "line_number": 210,
         "type": "Secret Keyword"
       }
     ],
     "src/lib/auth.ts": [
-      {
-        "hashed_secret": "3812d6abc055424d0556b35f48774c7b0044eac2",
-        "line_number": 32,
-        "type": "Secret Keyword"
-      },
       {
         "hashed_secret": "6981afa9890d125c05133d13053201f32292ec9f",
         "line_number": 38,
@@ -91,12 +86,12 @@
     "src/lib/constants.ts": [
       {
         "hashed_secret": "f34fbc9a9769ba9eff5aff3d008a6b49f85c08b1",
-        "line_number": 14,
+        "line_number": 15,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "b9343f1143ccb83555b450eb54dde96a05522ccc",
-        "line_number": 115,
+        "line_number": 116,
         "type": "Secret Keyword"
       }
     ],
@@ -270,12 +265,12 @@
     "test/unit/modules/api/api.spec.ts": [
       {
         "hashed_secret": "97752a468368b0d6b192140d6a140c38fd0cbd8b",
-        "line_number": 293,
+        "line_number": 304,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
-        "line_number": 802,
+        "line_number": 828,
         "type": "Secret Keyword"
       }
     ],
@@ -304,12 +299,12 @@
     "test/unit/modules/auth/jwt.spec.ts": [
       {
         "hashed_secret": "364bdf2ed77a8544d3b711a03b69eeadcc63c9d7",
-        "line_number": 121,
+        "line_number": 118,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "eaacdf2d9ed66df2601c8b51ab4084db14336d11",
-        "line_number": 132,
+        "line_number": 129,
         "type": "Secret Keyword"
       }
     ],

--- a/src/api/endpoint/api/star.ts
+++ b/src/api/endpoint/api/star.ts
@@ -4,6 +4,7 @@ import { USERS, HTTP_STATUS } from '../../../lib/constants';
 import {Response} from 'express';
 import {$RequestExtend, $NextFunctionVer, IStorageHandler} from '../../../../types';
 import _ from 'lodash';
+import { logger } from '../../../lib/logger';
 
 export default function(storage: IStorageHandler) {
   const validateInputs = (newUsers, localUsers, username, isStar) => {
@@ -21,6 +22,7 @@ export default function(storage: IStorageHandler) {
 
   return (req: $RequestExtend, res: Response, next: $NextFunctionVer): void => {
     const name = req.params.package;
+    logger.debug({name}, 'starring a package for @{name}');
     const afterChangePackage = function(err?: Error) {
       if (err) {
         return next(err);

--- a/src/api/middleware.ts
+++ b/src/api/middleware.ts
@@ -1,15 +1,10 @@
-/**
- * @prettier
- * @flow
- */
-
 import _ from 'lodash';
 
 import { validateName as utilValidateName, validatePackage as utilValidatePackage, getVersionFromTarball, isObject, ErrorCode } from '../lib/utils';
 import { API_ERROR, HEADER_TYPE, HEADERS, HTTP_STATUS, TOKEN_BASIC, TOKEN_BEARER } from '../lib/constants';
 import { stringToMD5 } from '../lib/crypto-utils';
 import { $ResponseExtend, $RequestExtend, $NextFunctionVer, IAuth } from '../../types';
-import { Config, Package } from '@verdaccio/types';
+import { Config, Package, RemoteUser } from '@verdaccio/types';
 import { logger } from '../lib/logger';
 import { VerdaccioError } from '@verdaccio/commons-api';
 
@@ -108,9 +103,10 @@ export function allow(auth: IAuth): Function {
       req.pause();
       const packageName = req.params.scope ? `@${req.params.scope}/${req.params.package}` : req.params.package;
       const packageVersion = req.params.filename ? getVersionFromTarball(req.params.filename) : undefined;
+      const remote: RemoteUser = req.remote_user;
+      logger.trace({ action, user: remote.name }, `[middleware/allow][@{action}] allow for @{user}`);
 
-      // $FlowFixMe
-      auth['allow_' + action]({ packageName, packageVersion }, req.remote_user, function(error, allowed): void {
+      auth['allow_' + action]({ packageName, packageVersion }, remote, function(error, allowed): void {
         req.resume();
         if (error) {
           next(error);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -71,25 +71,30 @@ class Auth implements IAuth {
     }
 
     for (const plugin of validPlugins) {
-      this.logger.trace({ username }, 'updating password for @{username}');
-      plugin.changePassword(
-        username,
-        password,
-        newPassword,
-        (err, profile): void => {
-          if (err) {
-            this.logger.error(
-              { username, err },
-              `An error has been produced
-          updating the password for @{username}. Error: @{err.message}`
-            );
-            return cb(err);
-          }
+      if (_.isNil(plugin) || _.isFunction(plugin.changePassword) === false) {
+        this.logger.trace('auth plugin does not implement changePassword, trying next one');
+        continue;
+      } else {
+        this.logger.trace({username}, 'updating password for @{username}');
+        plugin.changePassword!(
+          username,
+          password,
+          newPassword,
+          (err, profile): void => {
+            if (err) {
+              this.logger.error(
+                {username, err},
+                `An error has been produced
+            updating the password for @{username}. Error: @{err.message}`
+              );
+              return cb(err);
+            }
 
-          this.logger.trace({ username }, 'updated password for @{username} was successful');
-          return cb(null, profile);
-        }
-      );
+            this.logger.trace({username}, 'updated password for @{username} was successful');
+            return cb(null, profile);
+          }
+        );
+      }
     }
   }
 
@@ -152,7 +157,7 @@ class Auth implements IAuth {
         // p.add_user() execution
         plugin[method](user, password, function(err, ok): void {
           if (err) {
-            self.logger.trace({ user, err }, 'the user @{user} could not being added. Error: @{err}');
+            self.logger.trace({ user, err: err.message }, 'the user @{user} could not being added. Error: @{err}');
             return cb(err);
           }
           if (ok) {
@@ -203,6 +208,7 @@ class Auth implements IAuth {
 
     for (const plugin of this.plugins) {
       if (_.isNil(plugin) || _.isFunction(plugin.allow_unpublish) === false) {
+        this.logger.trace({ packageName }, 'allow unpublish for @{packageName} plugin does not implement allow_unpublish');
         continue;
       } else {
         plugin.allow_unpublish!(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,6 +10,7 @@ export const DEFAULT_DOMAIN = 'localhost';
 export const TIME_EXPIRATION_24H = '24h';
 export const TIME_EXPIRATION_7D = '7d';
 export const DIST_TAGS = 'dist-tags';
+export const LATEST = 'latest';
 export const USERS = 'users';
 export const DEFAULT_MIN_LIMIT_PASSWORD = 3;
 export const DEFAULT_USER = 'Anonymous';
@@ -128,6 +129,7 @@ export const API_ERROR = {
   MAX_USERS_REACHED: 'maximum amount of users reached',
   VERSION_NOT_EXIST: "this version doesn't exist",
   FILE_NOT_FOUND: 'File not found',
+  UNSUPORTED_REGISTRY_CALL: 'unsupported registry call',
   BAD_STATUS_CODE: 'bad status code',
   PACKAGE_EXIST: 'this package is already present',
   BAD_AUTH_HEADER: 'bad authorization header',

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -58,6 +58,7 @@ class LocalStorage implements IStorage {
    */
   public removePackage(name: string, callback: Callback): void {
     const storage: any = this._getLocalStorage(name);
+    this.logger.debug({ name }, `[storage] removing package @{name}`);
 
     if (_.isNil(storage)) {
       return callback(ErrorCode.getNotFound());
@@ -77,6 +78,8 @@ class LocalStorage implements IStorage {
       this.localData.remove(name, (removeFailed: Error): void => {
         if (removeFailed) {
           // This will happen when database is locked
+          this.logger.debug({ name }, `[storage/removePackage] the database is locked, removed has failed for @{name}`);
+
           return callback(ErrorCode.getBadData(removeFailed.message));
         }
 
@@ -309,9 +312,11 @@ class LocalStorage implements IStorage {
    */
   public changePackage(name: string, incomingPkg: Package, revision: string | void, callback: Callback): void {
     if (!isObject(incomingPkg.versions) || !isObject(incomingPkg[DIST_TAGS])) {
+      this.logger.debug({name}, `changePackage bad data for @{name}`);
       return callback(ErrorCode.getBadData());
     }
 
+    this.logger.debug({name}, `changePackage udapting package for @{name}`);
     this._updatePackage(
       name,
       (localData, cb): void => {
@@ -740,6 +745,7 @@ class LocalStorage implements IStorage {
   }
 
   private _deleteAttachments(storage: any, attachments: string[], callback: Callback): void {
+    this.logger.debug({l: attachments.length }, `[storage/_deleteAttachments] delete attachments total: @{l}`);
     const unlinkNext = function(cb): void {
       if (_.isEmpty(attachments)) {
         return cb();

--- a/src/lib/storage-utils.ts
+++ b/src/lib/storage-utils.ts
@@ -1,8 +1,3 @@
-/**
- * @prettier
- * @flow
- */
-
 import _ from 'lodash';
 import { ErrorCode, isObject, normalizeDistTags, semverSort } from './utils';
 import Search from './search';
@@ -248,4 +243,14 @@ export function prepareSearchPackage(data: Package, time: unknown): any {
 
     return pkg;
   }
+}
+
+/**
+ * Check whether the package metadta has enough data to be published
+ * @param pkg metadata
+ */
+export function isPublishablePackage(pkg: Package): boolean {
+  const keys: string[] = Object.keys(pkg);
+
+  return _.includes(keys, 'versions');
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -182,7 +182,7 @@ export function getLocalRegistryTarballUri(uri: string, pkgName: string, req: Re
   const protocol = getWebProtocol(req.get(HEADERS.FORWARDED_PROTO), req.protocol);
   const domainRegistry = combineBaseUrl(protocol, headers.host, urlPrefix);
 
-  return `${domainRegistry}/${pkgName.replace(/\//g, '%2f')}/-/${tarballName}`;
+  return `${domainRegistry}/${encodeScopedUri(pkgName)}/-/${tarballName}`;
 }
 
 /**
@@ -590,4 +590,12 @@ export function pad(str, max): string {
     return str + ' '.repeat(max - str.length);
   }
   return str;
+}
+
+export function encodeScopedUri(packageName) {
+  return packageName.replace(/\//g, '%2f');
+}
+
+export function hasDiffOneKey(versions) {
+  return Object.keys(versions).length !== 1;
 }

--- a/test/unit/__helper/expects.ts
+++ b/test/unit/__helper/expects.ts
@@ -1,0 +1,20 @@
+import {DIST_TAGS, LATEST} from "../../../src/lib/constants";
+
+
+/**
+ * Verify whether the package tag match with the desired version.
+ */
+export function getTaggedVersionFromPackage(pkg, pkgName, tag: string = LATEST, version: string) {
+	// extract the tagged version
+	const taggedVersion = pkg[DIST_TAGS][tag];
+	expect(taggedVersion).toBeDefined();
+	expect(taggedVersion).toEqual(version);
+
+	// the version must exist
+	const latestPkg = pkg.versions[taggedVersion];
+	expect(latestPkg).toBeDefined();
+	// the name must match
+	expect(latestPkg.name).toEqual(pkgName);
+
+	return latestPkg;
+}

--- a/test/unit/__helper/utils.ts
+++ b/test/unit/__helper/utils.ts
@@ -1,17 +1,123 @@
 import { Package } from "@verdaccio/types";
 
-export function generatePackageMetadata(pkgName: string): Package {
+export function generateAttachment(pkgName, version) {
+	return {
+			"content_type": "application\/octet-stream",
+			"data": "H4sIAAAAAAAAE+2W32vbMBDH85y\/QnjQp9qxLEeBMsbGlocNBmN7bFdQ5WuqxJaEpGQdo\/\/79KPeQsnIw5KUDX\/9IOvurLuz\/DHSjK\/YAiY6jcXSKjk6sMqypHWNdtmD6hlBI0wqQmo8nVbVqMR4OsNoVB66kF1aW8eML+Vv10m9oF\/jP6IfY4QyyTrILlD2eqkcm+gVzpdrJrPz4NuAsULJ4MZFWdBkbcByI7R79CRjx0ScCdnAvf+SkjUFWu8IubzBgXUhDPidQlfZ3BhlLpBUKDiQ1cDFrYDmKkNnZwjuhUM4808+xNVW8P2bMk1Y7vJrtLC1u1MmLPjBF40+Cc4ahV6GDmI\/DWygVRpMwVX3KtXUCg7Sxp7ff3nbt6TBFy65gK1iffsN41yoEHtdFbOiisWMH8bPvXUH0SP3k+KG3UBr+DFy7OGfEJr4x5iWVeS\/pLQe+D+FIv\/agIWI6GX66kFuIhT+1gDjrp\/4d7WAvAwEJPh0u14IufWkM0zaW2W6nLfM2lybgJ4LTJ0\/jWiAK8OcMjt8MW3OlfQppcuhhQ6k+2OgkK2Q8DssFPi\/IHpU9fz3\/+xj5NjDf8QFE39VmE4JDfzPCBn4P4X6\/f88f\/Pu47zomiPk2Lv\/dOv8h+P\/34\/D\/p9CL+Kp67mrGDRo0KBBp9ZPsETQegASAAA=",
+			"length": 512
+		}
+}
+
+export function generateVersion(pkgName, version) {
+	return {
+		"name": pkgName,
+		"version": version,
+		"description": "some foo dependency",
+		"main": "index.js",
+		"scripts": {
+			"test": "echo \"Error: no test specified\" && exit 1"
+		},
+		"keywords": [],
+		"author": {
+			"name": "User NPM",
+			"email": "user@domain.com"
+		},
+		"license": "ISC",
+		"dependencies": {
+			"verdaccio": "^4.0.0"
+		},
+		"readme": "# test",
+		"readmeFilename": "README.md",
+		"_id": `${pkgName}@${version}`,
+		"_npmVersion": "5.5.1",
+		"_npmUser": {
+			'name': 'foo',
+		},
+		"dist": {
+			"integrity": "sha512-6gHiERpiDgtb3hjqpQH5\/i7zRmvYi9pmCjQf2ZMy3QEa9wVk9RgdZaPWUt7ZOnWUPFjcr9cmE6dUBf+XoPoH4g==",
+			"shasum": "2c03764f651a9f016ca0b7620421457b619151b9", // pragma: allowlist secret
+			"tarball": `http:\/\/localhost:5555\/${pkgName}\/-\/${pkgName}-${version}.tgz`
+		}
+	}
+}
+
+/**
+ * Generates a metadata body including attachments.
+ * If you intent to build a body for npm publish, please include only one version.
+ * if you intent to to generate a complete metadata include multiple versions.
+ */
+export function generatePackageBody(pkgName: string, _versions: string[] = ['1.0.0']): Package {
+	const latest: string = _versions[_versions.length - 1];
+	const versions = _versions.reduce((cat, version) => {
+		cat[version] = generateVersion(pkgName, version);
+		return cat;
+	}, {});
+
+	const attachtment = _versions.reduce((cat, version) => {
+		cat[`${pkgName}-${version}.tgz`] = generateAttachment(pkgName, version);
+		return cat;
+	}, {});
+
+	// @ts-ignore
+	return {
+		"_id": pkgName,
+		"name": pkgName,
+		"readme": "# test",
+		"dist-tags": {
+			"latest": latest
+		},
+		"versions": versions,
+		"_attachments": attachtment
+	}
+}
+
+/**
+ * The metadata that comes from npm unpublish only contains the versions won't be removed and
+ * also does not includes any _attachment.
+ * @param pkgName
+ * @param _versions
+ */
+export function generatePackageUnpublish(pkgName: string, _versions: string[] = ['1.0.0']): Package {
+	const latest: string = _versions[_versions.length - 1];
+	const versions = _versions.reduce((cat, version) => {
+		cat[version] = generateVersion(pkgName, version);
+		return cat;
+	}, {});
+
+	// @ts-ignore
+	return {
+		"_id": pkgName,
+		"name": pkgName,
+		"readme": "# test",
+		// users usually is present when run npm star [pkg]
+		"users": {},
+		"dist-tags": {
+			"latest": latest
+		},
+		"versions": versions,
+	}
+}
+
+export function generateStarMedatada(pkgName: string, users): any {
+	return {
+		"_id": pkgName,
+		"_rev": "3-b0cdaefc9bdb77c8",
+		"users": users
+	}
+}
+
+export function generatePackageMetadata(pkgName: string, version: string = '1.0.0'): Package {
 	// @ts-ignore 
 	return {
 		"_id": pkgName,
 		"name": pkgName,
 		"dist-tags": {
-			"latest": "1.0.0"
+			"latest": version
 		},
 		"versions": {
-			"1.0.0": {
+			[version]: {
 				"name": pkgName,
-				"version": "1.0.0",
+				"version": version,
 				"description": "",
 				"main": "index.js",
 				"scripts": {
@@ -30,7 +136,7 @@ export function generatePackageMetadata(pkgName: string): Package {
 				},
 				"readme": "# test",
 				"readmeFilename": "README.md",
-				"_id": `${pkgName}@1.0.0`,
+				"_id": `${pkgName}@${version}`,
 				"_npmVersion": "5.5.1",
 				"_npmUser": {
 						'name': 'foo',
@@ -38,13 +144,13 @@ export function generatePackageMetadata(pkgName: string): Package {
 				"dist": {
 					"integrity": "sha512-6gHiERpiDgtb3hjqpQH5\/i7zRmvYi9pmCjQf2ZMy3QEa9wVk9RgdZaPWUt7ZOnWUPFjcr9cmE6dUBf+XoPoH4g==",
 					"shasum": "2c03764f651a9f016ca0b7620421457b619151b9", // pragma: allowlist secret
-					"tarball": `http:\/\/localhost:5555\/${pkgName}\/-\/${pkgName}-1.0.0.tgz`
+					"tarball": `http:\/\/localhost:5555\/${pkgName}\/-\/${pkgName}-${version}.tgz`
 				}
 			}
 		},
 		"readme": "# test",
 		"_attachments": {
-			[`${pkgName}-1.0.0.tgz`]: {
+			[`${pkgName}-${version}.tgz`]: {
 				"content_type": "application\/octet-stream",
 				"data": "H4sIAAAAAAAAE+2W32vbMBDH85y\/QnjQp9qxLEeBMsbGlocNBmN7bFdQ5WuqxJaEpGQdo\/\/79KPeQsnIw5KUDX\/9IOvurLuz\/DHSjK\/YAiY6jcXSKjk6sMqypHWNdtmD6hlBI0wqQmo8nVbVqMR4OsNoVB66kF1aW8eML+Vv10m9oF\/jP6IfY4QyyTrILlD2eqkcm+gVzpdrJrPz4NuAsULJ4MZFWdBkbcByI7R79CRjx0ScCdnAvf+SkjUFWu8IubzBgXUhDPidQlfZ3BhlLpBUKDiQ1cDFrYDmKkNnZwjuhUM4808+xNVW8P2bMk1Y7vJrtLC1u1MmLPjBF40+Cc4ahV6GDmI\/DWygVRpMwVX3KtXUCg7Sxp7ff3nbt6TBFy65gK1iffsN41yoEHtdFbOiisWMH8bPvXUH0SP3k+KG3UBr+DFy7OGfEJr4x5iWVeS\/pLQe+D+FIv\/agIWI6GX66kFuIhT+1gDjrp\/4d7WAvAwEJPh0u14IufWkM0zaW2W6nLfM2lybgJ4LTJ0\/jWiAK8OcMjt8MW3OlfQppcuhhQ6k+2OgkK2Q8DssFPi\/IHpU9fz3\/+xj5NjDf8QFE39VmE4JDfzPCBn4P4X6\/f88f\/Pu47zomiPk2Lv\/dOv8h+P\/34\/D\/p9CL+Kp67mrGDRo0KBBp9ZPsETQegASAAA=",
 				"length": 512

--- a/test/unit/modules/api/__snapshots__/publish.spec.ts.snap
+++ b/test/unit/modules/api/__snapshots__/publish.spec.ts.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Publish endpoints - publish package should add a new package 1`] = `
+exports[`Publish endpoints - publish package should change the existing package 1`] = `[MockFunction]`;
+
+exports[`Publish endpoints - publish package should publish a new a new package 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [
@@ -23,31 +25,7 @@ exports[`Publish endpoints - publish package should add a new package 1`] = `
 }
 `;
 
-exports[`Publish endpoints - publish package should change the existing package 1`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "verdaccio",
-      Object {
-        "dist-tags": Object {},
-        "name": "verdaccio",
-        "time": Object {},
-        "versions": Object {},
-      },
-      undefined,
-      [Function],
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
-exports[`Publish endpoints - publish package should star a package 1`] = `
+exports[`Publish endpoints - publish package test start should star a package 1`] = `
 [MockFunction] {
   "calls": Array [
     Array [

--- a/test/unit/modules/api/publish.spec.ts
+++ b/test/unit/modules/api/publish.spec.ts
@@ -244,7 +244,7 @@ describe('Publish endpoints - publish package', () => {
     expect(storage.changePackage).toMatchSnapshot();
   });
 
-  test('should add a new package', () => {
+  test('should publish a new a new package', () => {
     const storage = {
       addPackage: jest.fn(),
     };
@@ -266,32 +266,34 @@ describe('Publish endpoints - publish package', () => {
     expect(next).toHaveBeenCalledWith(new Error(API_ERROR.BAD_PACKAGE_DATA));
   });
 
-  test('should star a package', () => {
-    const storage = {
-      changePackage: jest.fn(),
-      getPackage({ name, req, callback }) {
-        callback(null, {
-          users: {},
-        });
-      },
-    };
-    req = {
-      params: {
-        package: 'verdaccio',
-      },
-      body: {
-        _rev: REVISION_MOCK,
-        users: {
-          verdaccio: true,
+  describe('test start', () => {
+    test('should star a package', () => {
+      const storage = {
+        changePackage: jest.fn(),
+        getPackage({ name, req, callback }) {
+          callback(null, {
+            users: {},
+          });
         },
-      },
-      remote_user: {
-        name: 'verdaccio',
-      },
-    };
+      };
+      req = {
+        params: {
+          package: 'verdaccio',
+        },
+        body: {
+          _rev: REVISION_MOCK,
+          users: {
+            verdaccio: true,
+          },
+        },
+        remote_user: {
+          name: 'verdaccio',
+        },
+      };
 
-    // @ts-ignore
-    publishPackage(storage)(req, res, next);
-    expect(storage.changePackage).toMatchSnapshot();
+      // @ts-ignore
+      publishPackage(storage)(req, res, next);
+      expect(storage.changePackage).toMatchSnapshot();
+    });
   });
 });

--- a/test/unit/modules/cli/cli.spec.ts
+++ b/test/unit/modules/cli/cli.spec.ts
@@ -14,6 +14,8 @@ jest.mock('../../../../src/lib/logger', () => ({
   logger: {
     child: jest.fn(),
     warn: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
     error: jest.fn(),
     fatal: jest.fn()
   }

--- a/test/unit/partials/config/yaml/api.spec.yaml
+++ b/test/unit/partials/config/yaml/api.spec.yaml
@@ -3,22 +3,51 @@ uplinks:
   npmjs:
     url: http://localhost:4873/
 packages:
+  '@public-anyone-can-publish/*':
+    access: $anonymous jota_unpublish
+    publish: $anonymous jota_unpublish
+    unpublish: $anonymous jota_unpublish
+  '@scope/starPackage':
+    access: $all
+    publish: jota_star
+    unpublish: jota_star
+  '@only-one-can-publish/*':
+    access: jota_unpublish
+    publish: jota_unpublish
+    unpublish: jota_unpublish
+  '@jquery/*':
+    access: $all
+    publish: $all
+    proxy: npmjs
+  '@scope/*':
+    access: test
+    publish: dsadsa
+    proxy: npmjs
   '@*/*':
     access: $all
     publish: $all
     unpublish: $authenticated
     proxy: npmjs
-  '@jquery/*':
-    access: $all
-    publish: $all
-    proxy: npmjs
   'auth-package':
     access: $authenticated
     publish: $authenticated
+  'only-you-can-publish':
+    access: $authenticated
+    publish: you
+    unpublish: you
   'non-unpublish':
     access: $authenticated
-    publish: $authenticated
-    # this is intended, empty block
+    publish: jota_unpublish_fail
+    # There is some conditions to keep on mind here
+    # - If unpublish is empty, fallback with the publish value
+    # - If the user has permissions to publish and this empty it will be allowed to unpublish
+    # - If we want to forbid anyone to unpublish,  just write here any unexisting user
+    unpublish: some_unexisting_user_defined_here_might_be_a_hash
+  'only-unpublish':
+    access: $authenticated
+    # comment out is intended, we want to test if publish prop is not defined
+    # publish: jota_unpublish_fail
+    #
     unpublish:
   'super-admin-can-unpublish':
     access: $authenticated

--- a/test/unit/partials/star-api.js
+++ b/test/unit/partials/star-api.js
@@ -1,7 +1,0 @@
-const json = {
-  "_id": "@scope\/pk1-test",
-  "_rev": "4-6abcdb4efd41a576",
-  "users": {}
-}
-
- module.exports = json;

--- a/types/index.ts
+++ b/types/index.ts
@@ -15,7 +15,13 @@ import {
   JWTSignOptions,
   PackageAccess,
   ILocalData,
-  StringValue as verdaccio$StringValue, IReadTarball, Package, IPluginStorageFilter, Author} from '@verdaccio/types';
+  StringValue as verdaccio$StringValue,
+  IReadTarball,
+  Package,
+  IPluginStorageFilter,
+  Author,
+  AuthPluginPackage
+} from '@verdaccio/types';
 import lunrMutable from 'lunr-mutable-indexes';
 import {NextFunction, Request, Response} from 'express';
 
@@ -111,6 +117,7 @@ export interface IAuth extends IBasicAuth<Config>, IAuthMiddleware, IAuthWebUI {
   secret: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   plugins: any[];
+  allow_unpublish(pkg: AuthPluginPackage, user: RemoteUser, callback: Callback): void;
 }
 
 export interface IWebSearch {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,7 +4110,7 @@ growly@^1.3.0:
   resolved "https://registry.verdaccio.org/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@*, handlebars@4.1.2, handlebars@^4.1.0, handlebars@^4.1.2:
+handlebars@4.1.2, handlebars@^4.1.0, handlebars@^4.1.2:
   version "4.1.2"
   resolved "https://registry.verdaccio.org/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
   integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
@@ -4242,20 +4242,9 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@1.7.3:
+http-errors@1.7.3, http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
-  integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.4"
-    setprototypeof "1.1.1"
-    statuses ">= 1.5.0 < 2"
-    toidentifier "1.0.0"
-
-http-errors@~1.7.2:
-  version "1.7.3"
-  resolved "https://registry.verdaccio.org/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
   dependencies:
     depd "~1.1.2"


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

*  There is a related issue? yes
*  Unit or Functional tests are included in the PR yes

**Description:**

The issue was the npm star use a similar payload, but we did not check properly the shape of the payload, this fix and allow unpublish correctly.

Improve unit testing for publishing and unpublishing
Add new code documentation for future changes.

Resolves #1359
