### PR TITLE
fix: mkdir failed and ec2 infinitely re-launch

### DIFF
--- a/contrib/aws/cloudformation-ec2-efs.yaml
+++ b/contrib/aws/cloudformation-ec2-efs.yaml
@@ -159,7 +159,7 @@ Resources:
             mount -a -t efs defaults
 
             # Create/update the config & password files.
-            mkdir "$BASE/conf" -p
+            [[ -d "$BASE/conf" ]] || mkdir "$BASE/conf"
             curl -o "$BASE/conf/htpasswd" "${VerdaccioHtpasswdUrl}"
             curl -o "$BASE/conf/config.yaml" "${VerdaccioConfigUrl}"
 

--- a/contrib/aws/cloudformation-ec2-efs.yaml
+++ b/contrib/aws/cloudformation-ec2-efs.yaml
@@ -159,7 +159,7 @@ Resources:
             mount -a -t efs defaults
 
             # Create/update the config & password files.
-            mkdir "$BASE/conf"
+            mkdir "$BASE/conf" -p
             curl -o "$BASE/conf/htpasswd" "${VerdaccioHtpasswdUrl}"
             curl -o "$BASE/conf/config.yaml" "${VerdaccioConfigUrl}"
 


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**bug**

The following has been addressed in the PR:

*  There is a related issue? : no
*  Unit or Functional tests are included in the PR: no

**Description:**

cloud formation template launch successfully on initial ec2/efs sets, but could not recover after 2nd launch.

cloud-init error message indicate mkdir failed.

```shell
$ sudo cat /var/log/cloud-init-output.log
mkdir: cannot create directory '/verdaccio/conf': File exists
```

This PR address cloud formation template to be used for auto scaling environment.