### PR TITLE
Show usage without setting registry globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ You would need set some npm configuration, this is optional.
 $ npm set registry http://localhost:4873/
 ```
 
+For one-off commands or to avoid setting the registry globally:
+```bash
+NPM_CONFIG_REGISTRY=http://localhost:4873 npm i
+```
+
 Now you can navigate to [http://localhost:4873/](http://localhost:4873/) where your local packages will be listed and can be searched.
 
 > Warning: Verdaccio [does not currently support PM2's cluster mode](https://github.com/verdaccio/verdaccio/issues/1301#issuecomment-489302298), running it with cluster mode may cause unknown behavior.


### PR DESCRIPTION
**Type:**
documentation

The following has been addressed in the PR:
Add snippet to README showing a way to use `verdaccio` without `npm config set registry`

*  There is a related issue?
None known

*  Unit or Functional tests are included in the PR
No

**Description:**
`npm config set registry` changes the registry for all `npm` commands until it is unset. This can lead to `http://localhost:4873` being written to `package-lock.json` and `yarn.lock` files unexpectedly. An alternative is provided to run a single command with the registry provided by `verdaccio`.

