### PR TITLE
feat: browse web package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@verdaccio/local-storage": "2.2.1",
     "@verdaccio/readme": "8.0.0",
     "@verdaccio/streams": "8.0.0",
-    "@verdaccio/ui-theme": "0.2.3",
+    "@verdaccio/ui-theme": "0.3.0",
     "JSONStream": "1.3.5",
     "async": "3.1.0",
     "body-parser": "1.19.0",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,6 @@
 /**
  * @prettier
  */
-
 import _ from 'lodash';
 import fs from 'fs';
 import assert from 'assert';
@@ -598,4 +597,14 @@ export function encodeScopedUri(packageName) {
 
 export function hasDiffOneKey(versions) {
   return Object.keys(versions).length !== 1;
+}
+
+export function isVersionValid(packageMeta, packageVersion): boolean {
+  const hasVersion = typeof packageVersion !== 'undefined';
+  if (!hasVersion) {
+    return false;
+  }
+
+  const hasMatchVersion = Object.keys(packageMeta.versions).includes(packageVersion);
+  return hasMatchVersion;
 }

--- a/test/unit/modules/web/api.web.spec.ts
+++ b/test/unit/modules/web/api.web.spec.ts
@@ -86,7 +86,7 @@ describe('endpoint web unit test', () => {
           });
       });
 
-      //FIXME: disable, we need to inspect why fails randomly
+      //FIXME: disabled, we need to inspect why fails randomly
       test.skip('should display scoped readme 404', (done) => {
         request(app)
           .get('/-/verdaccio/package/readme/@scope/404')
@@ -115,9 +115,36 @@ describe('endpoint web unit test', () => {
           });
       });
 
+      test('should display sidebar info by version', (done) => {
+        request(app)
+          .get('/-/verdaccio/sidebar/@scope/pk1-test?v=1.0.6')
+          .expect(HTTP_STATUS.OK)
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .end(function(err, res) {
+            const sideBarInfo = res.body;
+            const latestVersion = publishMetadata.versions[publishMetadata[DIST_TAGS].latest];
+
+            expect(sideBarInfo.latest.author).toBeDefined();
+            expect(sideBarInfo.latest.author.avatar).toMatch(/www.gravatar.com/);
+            expect(sideBarInfo.latest.author.name).toBe(latestVersion.author.name);
+            expect(sideBarInfo.latest.author.email).toBe(latestVersion.author.email);
+            done();
+          });
+      });
+
       test('should display sidebar info 404', (done) => {
         request(app)
           .get('/-/verdaccio/sidebar/@scope/404')
+          .expect(HTTP_STATUS.NOT_FOUND)
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .end(function() {
+            done();
+          });
+      });
+
+      test('should display sidebar info 404 with version', (done) => {
+        request(app)
+          .get('/-/verdaccio/sidebar/@scope/pk1-test?v=0.0.0-not-found')
           .expect(HTTP_STATUS.NOT_FOUND)
           .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
           .end(function() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1732,10 +1732,10 @@
   resolved "https://registry.verdaccio.org/@verdaccio%2ftypes/-/types-5.2.2.tgz#ecea86c864b905314e29c88e5f93aebcf116c5ff"
   integrity sha512-5NbSsCcwCt5ZrA6+vXqUXFM2tAXkS++dju5XSh4TGM+ISon/FS/oUQtE7zmhlaftCt2z2LRhg0/b3wV8QUxSGQ==
 
-"@verdaccio/ui-theme@0.2.3":
-  version "0.2.3"
-  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.2.3.tgz#d25335be52bc15ad5c57cbff7607ddc8bf857833"
-  integrity sha512-rzn336VTjReOyxPdYapMDxgH+5PvxpT49GGdnHOcB7JEdDgl4Qa2mQIzRol/3GLahXMfOX+6uRY/ySBdlRo69A==
+"@verdaccio/ui-theme@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.3.0.tgz#573a04437cc672e3efe6f4db055f775d86df0958"
+  integrity sha512-CpbiJTxacv/j7yG31x089ZRM4bVTqGRxQEgN4uyqepWtYu6OgI/SvU6rpTuF1BjMkBuvSv8SRBKhpJav5oEs0Q==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

* You can browse and click on each version to display detail for such version
* Allows to to browse and download older versions
* Add label of which version is being displayed
* ⚠️ README always point to the latest one (Verdaccio does not save all readme)

![Kapture 2019-09-01 at 10 51 07](https://user-images.githubusercontent.com/558752/64075807-3ca76780-ccbd-11e9-877b-42900d3fb9f4.gif)

Resolves https://github.com/verdaccio/ui/issues/109
