### PR TITLE
fix: comment out experiments from configuration files

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -68,7 +68,6 @@ middlewares:
 logs:
   - { type: stdout, format: pretty, level: http }
   #- {type: file, path: verdaccio.log, level: info}
-
-experiments:
-  # support for npm token command
-  token: false
+#experiments:
+#  # support for npm token command
+#  token: false

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -68,7 +68,6 @@ middlewares:
 logs:
   - { type: stdout, format: pretty, level: http }
   #- {type: file, path: verdaccio.log, level: info}
-
-experiments:
-  # support for npm token command
-  token: false
+#experiments:
+#  # support for npm token command
+#  token: false

--- a/test/unit/modules/config/config.spec.ts
+++ b/test/unit/modules/config/config.spec.ts
@@ -62,6 +62,9 @@ const checkDefaultConfPackages = (config) => {
   expect(config.publish).toBeUndefined();
   expect(config.url_prefix).toBeUndefined();
   expect(config.url_prefix).toBeUndefined();
+
+  expect(config.experiments).toBeUndefined();
+  expect(config.jwt).toBeUndefined();
 };
 
 describe('Config file', () => {
@@ -88,6 +91,10 @@ describe('Config file', () => {
       expect(config.auth.htpasswd.file).toBe('./htpasswd');
       checkDefaultConfPackages(config);
     });
+  });
+
+  describe('Config file', () => {
+
   });
 
 });


### PR DESCRIPTION
**Description:**

The experiment flag is enabled, it is not dangerous since the token is disabled by default, but is wrong. This PR comment it out.
```
warn --- config file  - /Users/user/.config/verdaccio/config.yaml
 warn --- ⚠️  experiments are enabled, we recommend do not use experiments in production, comment out this section to disable it
 warn ---  - support for token  is disabled
 warn --- Verdaccio started
 warn --- Plugin successfully loaded: verdaccio-htpasswd
 warn --- Plugin successfully loaded: verdaccio-audit
 warn --- http address - http://localhost:4873/ - verdaccio/4.3.1
```

