### PR TITLE
fix: changed the exit code for info flag

### DIFF
--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -65,7 +65,7 @@ function init() {
     startVerdaccio(verdaccioConfiguration, cliListener, configPathLocation, pkgVersion, pkgName, listenDefaultCallback);
   } catch (err) {
     logger.logger.fatal({file: configPathLocation, err: err}, 'cannot open config file @{file}: @{!err.message}');
-    process.exit(1);
+    process.exit(0);
   }
 }
 

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -65,7 +65,7 @@ function init() {
     startVerdaccio(verdaccioConfiguration, cliListener, configPathLocation, pkgVersion, pkgName, listenDefaultCallback);
   } catch (err) {
     logger.logger.fatal({file: configPathLocation, err: err}, 'cannot open config file @{file}: @{!err.message}');
-    process.exit(0);
+    process.exit(1);
   }
 }
 
@@ -82,7 +82,7 @@ if (commander.info) {
       });
     // eslint-disable-next-line no-console
     console.log(data);
-    process.exit(1);
+    process.exit(0);
   })();
 } else  if (commander.args.length == 1 && !commander.config) {
   // handling "verdaccio [config]" case if "-c" is missing in command line


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**
bugfix

The following has been addressed in the PR:

*  There is a related issue? NA
*  Unit or Functional tests are included in the PR NA

**Description:**
The `process.exit` code is `1` for the `--info` flag so it will give a nodejs error format at the end instead of silently exiting.
Changed it to `0`
<!-- Resolves #??? -->
