### PR TITLE
chore: build add node13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,5 +152,5 @@ workflows:
           <<: *ignore_non_dev_branches
       - coverage:
           requires:
-            - test_node_latest
+            - test_e2e
           <<: *ignore_non_dev_branches

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,13 @@ executors:
       - image: circleci/node:latest-browsers
   node_latest:
     docker:
-    - image: circleci/node:latest
+    - image: circleci/node:10
+  node_lts_12:
+    docker:
+      - image: circleci/node:12
   node_lts:
     docker:
-      - image: circleci/node:lts
+      - image: circleci/node:13
   default_executor: node_latest
 
 aliases:
@@ -94,7 +97,12 @@ jobs:
     steps:
       - restore_repo
       - run_test
-
+  test_node_lts_12:
+    <<: *defaults
+    executor: node_lts
+    steps:
+      - restore_repo
+      - run_test
   test_e2e:
     <<: *defaults
     executor: node_latest_browser
@@ -131,9 +139,16 @@ workflows:
           requires:
             - prepare
           <<: *ignore_non_dev_branches
+      - test_node_lts_12:
+          requires:
+            - prepare
+          <<: *ignore_non_dev_branches
       - test_e2e:
           requires:
             - prepare
+            - test_node_lts
+            - test_node_lts_12
+            - test_node_latest
           <<: *ignore_non_dev_branches
       - coverage:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,13 @@ executors:
       - image: circleci/node:latest-browsers
   node_latest:
     docker:
-    - image: circleci/node:10
+    - image: circleci/node:13
   node_lts_12:
     docker:
       - image: circleci/node:12
-  node_lts:
+  node_lts_10:
     docker:
-      - image: circleci/node:13
+      - image: circleci/node:10
   default_executor: node_latest
 
 aliases:
@@ -90,16 +90,15 @@ jobs:
           key: *coverage_key
           paths:
             - coverage
-
-  test_node_lts:
+  test_node_lts_12:
     <<: *defaults
-    executor: node_lts
+    executor: node_lts_12
     steps:
       - restore_repo
       - run_test
-  test_node_lts_12:
+  test_node_lts_10:
     <<: *defaults
-    executor: node_lts
+    executor: node_lts_10
     steps:
       - restore_repo
       - run_test
@@ -135,20 +134,20 @@ workflows:
           requires:
             - prepare
           <<: *ignore_non_dev_branches
-      - test_node_lts:
+      - test_node_lts_12:
           requires:
             - prepare
           <<: *ignore_non_dev_branches
-      - test_node_lts_12:
+      - test_node_lts_10:
           requires:
             - prepare
           <<: *ignore_non_dev_branches
       - test_e2e:
           requires:
             - prepare
-            - test_node_lts
-            - test_node_lts_12
             - test_node_latest
+            - test_node_lts_10
+            - test_node_lts_12
           <<: *ignore_non_dev_branches
       - coverage:
           requires:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: [10, 12]
+        node_version: [10, 12, 13]
 
     runs-on: ubuntu-latest
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "80...85"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+    patch: no
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "diff,flags,tree"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
**Description:**

Before check others PR I want to clarify how we are testing, I add Node 13 to be more explicit since the LTS are having a long maintenance https://nodejs.org/en/about/releases/ most likely we will have 4 versions running for a while.

Furthermore reorganize the steps, E2E goes to the end and then coverage. Also updates GitHub CI to use node 13.

![Screen Shot 2019-12-13 at 7 47 52 AM](https://user-images.githubusercontent.com/558752/70776287-e5fdff00-1d7c-11ea-8ea0-1479f8f70bca.png)

E2E will be soon not more UI anymore, rather our own package being tested as we advise to (short future term).
