### PR TITLE
fix: prevent issue with leading hyphen in package name - fixes #1429

### DIFF
--- a/src/api/middleware.ts
+++ b/src/api/middleware.ts
@@ -33,7 +33,7 @@ export function setSecurityWebHeaders(req: $RequestExtend, res: $ResponseExtend,
 // flow: express does not match properly
 // flow info https://github.com/flowtype/flow-typed/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+express
 export function validateName(req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer, value: string, name: string): void {
-  if (value.charAt(0) === '-') {
+  if (value === '-') {
     // special case in couchdb usually
     next('route');
   } else if (utilValidateName(value)) {
@@ -46,7 +46,7 @@ export function validateName(req: $RequestExtend, res: $ResponseExtend, next: $N
 // flow: express does not match properly
 // flow info https://github.com/flowtype/flow-typed/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+express
 export function validatePackage(req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer, value: string, name: string): void {
-  if (value.charAt(0) === '-') {
+  if (value === '-') {
     // special case in couchdb usually
     next('route');
   } else if (utilValidatePackage(value)) {


### PR DESCRIPTION
<!--

Before Pull Request check whether your commits follow this convention

https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#git-commit-guidelines

  * If your PR fix an issue don't forget to update the unit test and documentation in /docs folder
  * If your PR delivers a new feature, please, provide examples and why such feature should be considered.
  * Document your changes /docs
  * Add unit test
  * Follow the commit guidelines in order to get a quick approval

Pick one/multiple type, if none apply please suggest one, we might be included it by default

eg: bug / feature / documentation / unit test / build

-->
**Type:**
bugfix

The following has been addressed in the PR:

*  Prevent issue with leading hyphen / dash in package names

**Description:**
It seems the handling and passing of routes and paths changed. Depending on where we are (-/ping or -/web/detail/kleur) we either geht `-` or `kleur`. If the package contains a leading hyphen / dash this did not work as it was handled as internal couchdb route (using the `charAt(0)` check).

Resolves #1429
