### PR TITLE
fix: updated combine url fix method

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -141,12 +141,19 @@ export function validateMetadata(object: Package, name: string): Package {
  * @return {String} base registry url
  */
 export function combineBaseUrl(protocol: string, host: string | void, prefix?: string | void): string {
-  let result = `${protocol}://${host}`;
+  const result = `${protocol}://${host}`;
 
-  if (prefix) {
-    prefix = prefix.replace(/\/$/, '');
+  const prefixOnlySlash = prefix === '/';
+  if (prefix && !prefixOnlySlash) {
+    if (prefix.endsWith('/')) {
+      prefix = prefix.slice(0, -1);
+    }
 
-    result = prefix.indexOf('/') === 0 ? `${result}${prefix}` : prefix;
+    if (prefix.startsWith('/')) {
+      return `${result}${prefix}`;
+    }
+
+    return prefix;
   }
 
   return result;

--- a/test/unit/modules/utils/utils.spec.ts
+++ b/test/unit/modules/utils/utils.spec.ts
@@ -212,7 +212,10 @@ describe('Utilities', () => {
       });
 
       test('should create a base url for registry', () => {
+        expect(combineBaseUrl("http", 'domain', '')).toEqual('http://domain');
+        expect(combineBaseUrl("http", 'domain', '/')).toEqual('http://domain');
         expect(combineBaseUrl("http", 'domain', '/prefix/')).toEqual('http://domain/prefix');
+        expect(combineBaseUrl("http", 'domain', '/prefix/deep')).toEqual('http://domain/prefix/deep');
         expect(combineBaseUrl("http", 'domain', 'only-prefix')).toEqual('only-prefix');
       });
 


### PR DESCRIPTION
**Type:** bug 

Added more unit test cases and fixed `combineBaseUrl` method.
`RegExp` was changed to `slice` for optimization.

