### PR TITLE
fix(deps): bump @verdaccio/local-storage from 8.5.0 to 9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@verdaccio/commons-api": "^8.5.0",
-    "@verdaccio/local-storage": "^8.5.0",
+    "@verdaccio/local-storage": "^9.0.0",
     "@verdaccio/readme": "^8.5.0",
     "@verdaccio/streams": "^8.5.2",
     "@verdaccio/ui-theme": "^0.3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,6 +1833,14 @@
     http-errors "1.7.3"
     http-status-codes "1.4.0"
 
+"@verdaccio/commons-api@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fcommons-api/-/commons-api-9.0.0.tgz#d13d73e3d784fb2292965015176bd7f870583cb1"
+  integrity sha512-rX4ABMh80dXyWRo8gEppiyA04siVAGzmhCG+vvVu7fGN6hn3XU1pR4xYeKWMDq4ofWpyI777uMftcYzbZc9AtA==
+  dependencies:
+    http-errors "1.7.3"
+    http-status-codes "1.4.0"
+
 "@verdaccio/eslint-config@^8.5.0":
   version "8.5.0"
   resolved "https://registry.verdaccio.org/@verdaccio%2feslint-config/-/eslint-config-8.5.0.tgz#c1e762e91cba579f81c5806d140a4f97182c53aa"
@@ -1863,10 +1871,10 @@
   dependencies:
     lockfile "1.0.4"
 
-"@verdaccio/file-locking@^8.5.2":
-  version "8.5.2"
-  resolved "https://registry.verdaccio.org/@verdaccio%2ffile-locking/-/file-locking-8.5.2.tgz#ca7ca11b4b5866b29da9b17c4a6ef5409d9250eb"
-  integrity sha512-fRtoUgCe8tAa9XU/uSnRVCn3vSt6cLrqwpxdLWtJyS4MFil9OqozcACk9dGxyEF4jbCVdBd9Q6q7dM6Astzlzw==
+"@verdaccio/file-locking@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2ffile-locking/-/file-locking-9.0.0.tgz#0c29c230a7657423a9c0fbbb72bce3ba9aa3e190"
+  integrity sha512-acxyAgoLHPQwCTJVao1ZWzTDZvTDNykfoHk/lSDGX7OolaB9g741WnNHB1a9z9jj2SW3AVe5iMAs08eP2tdvVA==
   dependencies:
     lockfile "1.0.4"
 
@@ -1883,14 +1891,14 @@
     lodash "4.17.15"
     mkdirp "0.5.1"
 
-"@verdaccio/local-storage@^8.5.0":
-  version "8.5.2"
-  resolved "https://registry.verdaccio.org/@verdaccio%2flocal-storage/-/local-storage-8.5.2.tgz#b1e07df11a561cc12d54a8835edb1e07bba6a450"
-  integrity sha512-qU6ETcDq9YdxpC52KEVmS9hAQpcG+59v89nO0Re33N2q791Ft2tYmX5BmnE8hUVTK9cKkwqzIeAlEy2BrIFgdA==
+"@verdaccio/local-storage@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2flocal-storage/-/local-storage-9.0.0.tgz#03e09531045de178f260355d334717e809fb3f96"
+  integrity sha512-1FYLGYigBtISDSF6euELTcUlJ5Gn4mLh4ptQ803nhCmpK5BzwBk1hrwKOrPGL0nrYLY12+pSHsMFc/HmlNv06A==
   dependencies:
-    "@verdaccio/commons-api" "^8.5.0"
-    "@verdaccio/file-locking" "^8.5.2"
-    "@verdaccio/streams" "^8.5.2"
+    "@verdaccio/commons-api" "^9.0.0"
+    "@verdaccio/file-locking" "^9.0.0"
+    "@verdaccio/streams" "^9.0.0"
     async "3.1.0"
     level "5.0.1"
     lodash "4.17.15"
@@ -1928,6 +1936,11 @@
   version "8.5.2"
   resolved "https://registry.verdaccio.org/@verdaccio%2fstreams/-/streams-8.5.2.tgz#d6f366f94b905bb945bcdfa1572fde8e09f53d7a"
   integrity sha512-Rbw+vm/KHgy5OQB+jSxxIXYvVFmG/fuFmBeH7F4fp2r5h7w1TP/mlQZI7PVlPPhLZtM6Xdrzf6H+NRCwRncwIg==
+
+"@verdaccio/streams@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fstreams/-/streams-9.0.0.tgz#42e48471b2acbfe6fe1264ba3230ef3545d8261e"
+  integrity sha512-lmzIuxkG4fnJzhqiDm45OmizVPm73soKSlbswSKe4hlYsHXJVdpcY4m3/bYPFDMZYi7Bd5M3yqzhLrCn2Hh82w==
 
 "@verdaccio/types@^9.0.0":
   version "9.0.0"


### PR DESCRIPTION
Fixed at https://github.com/verdaccio/monorepo/pull/312

Co-Authored-By: Daniel Ruf <danielruf@users.noreply.github.com>

**Description:**

Resolves #1639
