### PR TITLE
fix(deps): bump @verdaccio/ui-theme from 0.3.11 to 0.3.12 (#1657)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@verdaccio/local-storage": "^9.0.0",
     "@verdaccio/readme": "^8.5.0",
     "@verdaccio/streams": "^8.5.2",
-    "@verdaccio/ui-theme": "^0.3.10",
+    "@verdaccio/ui-theme": "^0.3.12",
     "JSONStream": "1.3.5",
     "async": "3.1.0",
     "body-parser": "1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1964,10 +1964,10 @@
   resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.3.9.tgz#6ff0f05315912b4ba39e29eb589ecc8833640990"
   integrity sha512-InTpEowYo6M9TjpQh4cVh/HZH1DW9oyhy8UpC1H4FOwvyknctN0dMavOseKWSrPAj+gPDzUw0IKAvwDI4OcPEg==
 
-"@verdaccio/ui-theme@^0.3.10":
-  version "0.3.11"
-  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.3.11.tgz#9d7b280923134e234a06d271c74394d8b351d323"
-  integrity sha512-CbUkZQu0VqTxBc0FJ2zsEANsUlypAIPZ3uJD2uz4wH4DBaMXT5E8OXcr/kIhvyZpWUhw8p55OgMbBHbRxPe57Q==
+"@verdaccio/ui-theme@^0.3.12":
+  version "0.3.12"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.3.12.tgz#189e82d6d991e98668f510953003d6c00bab9e09"
+  integrity sha512-YoVa3Nt77nvQauVykQoQXtM8WSPbwi/ms8BRI6BqOzP5eoIiHwqKHauCt0+TtyAZkQmC62QTWkAec1smTPbF0Q==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

fixes: https://github.com/verdaccio/verdaccio/issues/1648
Co-Authored-By: Daniel Ruf <danielruf@users.noreply.github.com>


Resolves #1648
