### PR TITLE
feat: allow custom jwt configuration for user generated tokens

### DIFF
--- a/src/api/endpoint/api/v1/token.ts
+++ b/src/api/endpoint/api/v1/token.ts
@@ -67,7 +67,7 @@ export default function(route: Router, auth: IAuth, storage: IStorageHandler, co
 			}
 
 			try {
-				const token = await getApiToken(auth, config, user, password);
+				const token = await getApiToken(auth, config, user, password, {userGeneratedToken: true});
 				const key = stringToMD5(token);
 				// TODO: use a utility here
 				const maskedToken = mask(token, 5);

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -148,7 +148,7 @@ export function isAESLegacy(security: Security): boolean {
   return _.isNil(legacy) === false && _.isNil(jwt) && legacy === true;
 }
 
-export async function getApiToken(auth: IAuthWebUI, config: Config, remoteUser: RemoteUser, aesPassword: string): Promise<string> {
+export async function getApiToken(auth: IAuthWebUI, config: Config, remoteUser: RemoteUser, aesPassword: string, options: {userGeneratedToken?: boolean} = {}): Promise<string> {
   const security: Security = getSecurity(config);
 
   if (isAESLegacy(security)) {
@@ -158,7 +158,7 @@ export async function getApiToken(auth: IAuthWebUI, config: Config, remoteUser: 
     });
   }
   // i am wiling to use here _.isNil but flow does not like it yet.
-  const { jwt } = security.api;
+  const { jwt } = (options.userGeneratedToken && security.user) ? security.user : security.api;
 
   if (jwt && jwt.sign) {
     return await auth.jwtEncrypt(remoteUser, jwt.sign);

--- a/test/unit/modules/auth/auth-utils.spec.ts
+++ b/test/unit/modules/auth/auth-utils.spec.ts
@@ -44,7 +44,8 @@ describe('Auth utilities', () => {
     password: string,
     secret = '12345',
     methodToSpy: string,
-    methodNotBeenCalled: string): Promise<string> {
+    methodNotBeenCalled: string,
+    options?:{userGeneratedToken: boolean}): Promise<string> {
     const config: Config = getConfig(configFileName, secret);
     const auth: IAuth = new Auth(config);
     // @ts-ignore
@@ -56,7 +57,7 @@ describe('Auth utilities', () => {
       real_groups: [],
       groups: []
     };
-    const token = await getApiToken(auth, config, user, password);
+    const token = await getApiToken(auth, config, user, password, options);
     expect(spy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spyNotCalled).not.toHaveBeenCalled();
@@ -124,6 +125,14 @@ describe('Auth utilities', () => {
     test('should sign token with jwt enabled', async () => {
       const token = await signCredentials('security-jwt',
         'test', 'test', 'secret', 'jwtEncrypt', 'aesEncrypt');
+
+      expect(_.isString(token)).toBeTruthy();
+      verifyJWT(token, 'test', 'test', 'secret');
+    });
+
+    test('should sign token with jwt enabled for user generated token', async () => {
+      const token = await signCredentials('security-jwt-user-enabled',
+        'test', 'test', 'secret', 'jwtEncrypt', 'aesEncrypt', {userGeneratedToken: true});
 
       expect(_.isString(token)).toBeTruthy();
       verifyJWT(token, 'test', 'test', 'secret');

--- a/test/unit/partials/config/yaml/security/security-jwt-user-enabled.yaml
+++ b/test/unit/partials/config/yaml/security/security-jwt-user-enabled.yaml
@@ -1,0 +1,6 @@
+security:
+  user:
+    jwt:
+      sign:
+        expiresIn: 7d
+        notBefore: 0


### PR DESCRIPTION
**Type:**

The following has been addressed in the PR:

*  There is a related issue?
https://github.com/verdaccio/verdaccio/issues/1702

*  Unit or Functional tests are included in the PR
Yes

**Description:**
This feature extends https://github.com/verdaccio/verdaccio/pull/1427 with the ability to set a custom JWT configuration for user generated tokens from the ```npm token create``` command.

This is beneficial as it would allow differentiation in for example the jwt expiration time (```expiresIn```) and in combination with the ability to revoke a user generated token per https://github.com/verdaccio/verdaccio/pull/1705 would make this suitable for usage in CI systems.

**Dependencies**
Type update in monorepo see PR https://github.com/verdaccio/monorepo/pull/328