### PR TITLE
fix: adding Content-Type to response in GET /-/all (#1697)

### DIFF
--- a/src/api/endpoint/api/search.ts
+++ b/src/api/endpoint/api/search.ts
@@ -1,3 +1,5 @@
+import { HEADERS } from "../../../lib/constants";
+
 /**
  * @prettier
  */
@@ -11,6 +13,7 @@ export default function(route, auth, storage): void {
     let firstPackage = true;
 
     res.status(200);
+    res.set(HEADERS.CONTENT_TYPE, HEADERS.JSON_CHARSET)
 
     /*
      * Offical NPM registry (registry.npmjs.org) no longer return whole database,

--- a/test/unit/modules/api/api.spec.ts
+++ b/test/unit/modules/api/api.spec.ts
@@ -621,7 +621,7 @@ describe('endpoint unit test', () => {
           .get('/-/all/since?stale=update_after&startkey=' + cacheTime)
           // .set('accept-encoding', HEADERS.JSON)
           // .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
-          // .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HEADERS.CONTENT_TYPE, HEADERS.JSON_CHARSET)
           .expect(HTTP_STATUS.OK)
           .end(function(err) {
             if (err) {


### PR DESCRIPTION
**Type:** fix

The following has been addressed in the PR:

*  There is a related issue?
#1697 
*  Unit or Functional tests are included in the PR
Yes

**Description:**

This fix adds the _Content-Type: application/json_ header to responses for _GET /-/all_ requests.  

Unity recently made a change that requires this header to be included in responses for it's package manager to work correctly.  Other package manager clients could also add this restriction in the future.
