### PR TITLE
Add an incomplete implementation of the v1/search api

### DIFF
--- a/src/api/endpoint/api/v1/search.ts
+++ b/src/api/endpoint/api/v1/search.ts
@@ -33,8 +33,9 @@ function compileTextSearch(textSearch) {
 
 export default function(route, auth, storage): void {
     route.get('/-/v1/search', (req, res)=>{
-        let [text, size, from, quality, popularity, maintenance] = 
-            ['text', 'size', 'from', 'quality', 'popularity', 'maintenance']
+        // TODO: implement proper result scoring weighted by quality, popularity and maintenance query parameters
+        let [text, size, from /*, quality, popularity, maintenance */] = 
+            ['text', 'size', 'from' /* , 'quality', 'popularity', 'maintenance' */]
             .map(k => req.query[k])
         
         size = parseInt(size) || 20;

--- a/src/api/endpoint/api/v1/search.ts
+++ b/src/api/endpoint/api/v1/search.ts
@@ -91,7 +91,6 @@ export default function(route, auth, storage): void {
         resultStream.on('end', ()=>{
             if(!completed)
                 sendResponse()
-            res.end()
         })
     })
 }

--- a/src/api/endpoint/api/v1/search.ts
+++ b/src/api/endpoint/api/v1/search.ts
@@ -1,6 +1,7 @@
 import semver from 'semver'
+import { Package } from '@verdaccio/types';
 
-function compileTextSearch(textSearch) {
+function compileTextSearch(textSearch: string): ((pkg: Package) => boolean) {
         const personMatch = (person, search) => {
             if(typeof person === 'string')
                 return person.includes(search);
@@ -34,7 +35,7 @@ function compileTextSearch(textSearch) {
 export default function(route, auth, storage): void {
     route.get('/-/v1/search', (req, res)=>{
         // TODO: implement proper result scoring weighted by quality, popularity and maintenance query parameters
-        let [text, size, from /*, quality, popularity, maintenance */] = 
+        let [text, size, from /* , quality, popularity, maintenance */] = 
             ['text', 'size', 'from' /* , 'quality', 'popularity', 'maintenance' */]
             .map(k => req.query[k])
         
@@ -47,7 +48,7 @@ export default function(route, auth, storage): void {
         const resultBuf = [] as any;
         let completed = false;
 
-        const sendResponse = () => {
+        const sendResponse = (): void => {
             completed = true;
             resultStream.destroy()
 

--- a/src/api/endpoint/api/v1/search.ts
+++ b/src/api/endpoint/api/v1/search.ts
@@ -1,0 +1,97 @@
+import semver from 'semver'
+
+function compileTextSearch(textSearch) {
+        const personMatch = (person, search) => {
+            if(typeof person === 'string')
+                return person.includes(search);
+            
+            if(typeof person === 'object')
+                for(const field of Object.values(person))
+                    if(typeof field === 'string' && field.includes(search))
+                        return true;
+            
+            return false;
+        }
+        const matcher = function(q) {
+            const match = q.match(/author:(.*)/)
+            if(match !== null)
+                return (pkg) => personMatch(pkg.author, match[1])
+
+            // TODO: maintainer, keywords, not/is unstable insecure, boost-exact
+            // TODO implement some scoring system for freetext
+            return (pkg) => {
+                return ['name', 'displayName', 'description']
+                    .map(k => pkg[k])
+                    .filter(x => x !== undefined)
+                    .some(txt => txt.includes(q))
+            };
+        }
+
+        const textMatchers = (textSearch || '').split(' ').map(matcher);
+        return (pkg) => textMatchers.every(m => m(pkg));
+}
+
+export default function(route, auth, storage): void {
+    route.get('/-/v1/search', (req, res)=>{
+        let [text, size, from, quality, popularity, maintenance] = 
+            ['text', 'size', 'from', 'quality', 'popularity', 'maintenance']
+            .map(k => req.query[k])
+        
+        size = size ?? 20;
+        from = from ?? 0;
+        
+        const isInteresting = compileTextSearch(text);
+
+        const resultStream = storage.search(0, {req: {query: {local: true}}});
+        const resultBuf = [] as any;
+        let completed = false;
+
+        const sendResponse = () => {
+            completed = true;
+            resultStream.destroy()
+
+            const final = resultBuf.slice(from, size).map(pkg => {
+                        return {
+                            package: pkg,
+                            flags: {
+                                unstable:
+                                    Object.keys(pkg.versions)
+                                        .some(v => semver.satisfies(v, '^1.0.0'))
+                                         ? undefined
+                                         : true
+                            },
+                            score: {
+                                final: 1,
+                                detail: {
+                                    quality: 1,
+                                    popularity: 1,
+                                    maintenance: 0
+                                }
+                            },
+                            searchScore: 100000
+                        }
+                    })
+            const response = {
+                    objects: final,
+                    total: final.length,
+                    time: new Date().toUTCString()
+                }
+
+            res.status(200)
+                .json(response)
+        }
+
+        resultStream.on('data', (pkg)=>{
+            if(!isInteresting(pkg))
+                return;
+            resultBuf.push(pkg)
+            if(!completed && resultBuf.length >= size + from)
+                sendResponse();
+        })
+        resultStream.on('end', ()=>{
+            if(!completed)
+                sendResponse()
+            res.end()
+        })
+    })
+}

--- a/src/api/endpoint/api/v1/search.ts
+++ b/src/api/endpoint/api/v1/search.ts
@@ -37,8 +37,8 @@ export default function(route, auth, storage): void {
             ['text', 'size', 'from', 'quality', 'popularity', 'maintenance']
             .map(k => req.query[k])
         
-        size = size ?? 20;
-        from = from ?? 0;
+        size = parseInt(size) || 20;
+        from = parseInt(from) || 0;
         
         const isInteresting = compileTextSearch(text);
 

--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -15,6 +15,8 @@ import stars from './api/stars';
 import profile from './api/v1/profile';
 import token from './api/v1/token';
 
+import v1Search from './api/v1/search'
+
 const { match, validateName, validatePackage, encodeScopePackage, antiLoop } = require('../middleware');
 
 export default function(config: Config, auth: IAuth, storage: IStorageHandler) {
@@ -54,6 +56,9 @@ export default function(config: Config, auth: IAuth, storage: IStorageHandler) {
   publish(app, auth, storage, config);
   ping(app);
   stars(app, storage);
+
+  v1Search(app, auth, storage)
+
   if (_.get(config, 'experiments.token') === true) {
     token(app, auth, storage, config);
   }


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

*  #310 

**Description:**

Rudimentary implementation of the /-/v1/search endpoint, ignoring any result scoring and only filtering on words and author:xyz qualifiers.

To fully support the [spec](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search) the filtering behaviour would need to be expanded.