### PR TITLE
feat: remove support for allow_ prefix

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -38,14 +38,10 @@ export interface StartUpConfig {
 // legacy should be removed in long term
 
 export interface LegacyPackageList {
-  [key: string]: LegacyPackageAccess;
+  [key: string]: PackageAccessAddOn;
 }
 
-export type LegacyPackageAccess = PackageAccess & {
-  allow_publish?: string[];
-  allow_proxy?: string[];
-  allow_access?: string[];
-  proxy_access?: string[];
+export type PackageAccessAddOn = PackageAccess & {
   // FIXME: should be published on @verdaccio/types
   unpublish?: string[];
 }

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -33,11 +33,12 @@ import {
   getCode,
 } from '@verdaccio/commons-api';
 
-import { IncomingHttpHeaders } from 'http2';
+import { IncomingHttpHeaders } from 'http';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 
+// FIXME: this is fixed, should pick the package.json or official version
 const pkgVersion = '5.0.0';
 const pkgName = 'verdaccio';
 

--- a/packages/utils/test/config-utils.spec.ts
+++ b/packages/utils/test/config-utils.spec.ts
@@ -8,7 +8,8 @@ import {parseConfigFile} from '../src/utils';
 import {
   getMatchedPackagesSpec,
   hasProxyTo,
-  normalisePackageAccess, sanityCheckUplinksProps,
+  normalisePackageAccess,
+  sanityCheckUplinksProps,
   uplinkSanityCheck
 } from '../src/config-utils';
 
@@ -132,6 +133,7 @@ describe('Config Utilities', () => {
       const access = normalisePackageAccess(packages);
 
       expect(access).toBeDefined();
+
       const scoped = access[`${PACKAGE_ACCESS.SCOPE}`];
       const all = access[`${PACKAGE_ACCESS.ALL}`];
       const react = access['react-*'];
@@ -141,13 +143,12 @@ describe('Config Utilities', () => {
 
       // Intended checks, Typescript should catch this, we test the runtime part
       // @ts-ignore
-      expect(react.access[0]).toBe(ROLES.$ALL);
-      expect(react.publish).toBeDefined();
+      expect(react.access).toEqual([]);
       // @ts-ignore
       expect(react.publish[0]).toBe('admin');
       expect(react.proxy).toBeDefined();
       // @ts-ignore
-      expect(react.proxy[0]).toBe('uplink2');
+      expect(react.proxy).toEqual([]);
       expect(react.storage).toBeDefined();
 
       expect(react.storage).toBe('react-storage');
@@ -158,9 +159,6 @@ describe('Config Utilities', () => {
       expect(all.storage).not.toBeDefined();
       expect(all.publish).toBeDefined();
       expect(all.proxy).toBeDefined();
-      expect(all.allow_access).toBeUndefined();
-      expect(all.allow_publish).toBeUndefined();
-      expect(all.proxy_access).toBeUndefined();
     });
 
     test('should check not default packages access', ()=> {


### PR DESCRIPTION
**Type:** feat

**Verdaccio 5**

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

`allow_access`, `allow_publish` and `proxy_access` were supported as package access but this commit drop that support and ignore the properties

