### PR TITLE
build: publish Docker image to GitHub registry (5.x)

### DIFF
--- a/.github/workflows/docker-publish-pre-check.yml
+++ b/.github/workflows/docker-publish-pre-check.yml
@@ -14,3 +14,4 @@ jobs:
         password: ${{ secrets.GITHUB_REGISTRY_TOKEN }}
         registry: docker.pkg.github.com
         repository: verdaccio/verdaccio
+        tags: 5.x

--- a/.github/workflows/docker-publish-pre-check.yml
+++ b/.github/workflows/docker-publish-pre-check.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Build
-      run: yarn docker
-      env:
-        VERDACCIO_BUILD_REGISTRY: https://registry.verdaccio.org
+    - uses: jerray/publish-docker-action@master
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        registry: docker.pkg.github.com
+        repository: verdaccio/verdaccio

--- a/.github/workflows/docker-publish-pre-check.yml
+++ b/.github/workflows/docker-publish-pre-check.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: jerray/publish-docker-action@master
+    - name: Publish to registry
+      uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.GITHUB_REGISTRY_TOKEN }}
-        registry: docker.pkg.github.com
-        repository: verdaccio/verdaccio
-        tags: 5.x
+        name: docker.pkg.github.com/verdaccio/verdaccio/verdaccio
+        username: ${{secrets.DOCKER_USERNAME}}
+        password: ${{secrets.GITHUB_REGISTRY_TOKEN}}
+        registry: docker.pkg.github.com =

--- a/.github/workflows/docker-publish-pre-check.yml
+++ b/.github/workflows/docker-publish-pre-check.yml
@@ -14,4 +14,5 @@ jobs:
         name: docker.pkg.github.com/verdaccio/verdaccio/verdaccio
         username: ${{secrets.DOCKER_USERNAME}}
         password: ${{secrets.GITHUB_REGISTRY_TOKEN}}
-        registry: docker.pkg.github.com =
+        registry: docker.pkg.github.com
+

--- a/.github/workflows/docker-publish-pre-check.yml
+++ b/.github/workflows/docker-publish-pre-check.yml
@@ -1,6 +1,6 @@
-name: Publish docker image 
+name: Docker & Publish Pre-check
 
-on: [push]
+on: [pull_request]
 
 jobs:
   testDocker:
@@ -8,12 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Publish to registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: docker.pkg.github.com/verdaccio/verdaccio/verdaccio
-        username: ${{secrets.DOCKER_USERNAME}}
-        password: ${{secrets.GITHUB_REGISTRY_TOKEN}}
-        registry: docker.pkg.github.com
-        tags: "5.x"
-
+    - name: Build
+      run: yarn docker
+      env:
+        VERDACCIO_BUILD_REGISTRY: https://registry.verdaccio.org

--- a/.github/workflows/docker-publish-pre-check.yml
+++ b/.github/workflows/docker-publish-pre-check.yml
@@ -1,4 +1,4 @@
-name: Docker & Publish Pre-check
+name: Publish docker image 
 
 on: [push]
 
@@ -15,4 +15,5 @@ jobs:
         username: ${{secrets.DOCKER_USERNAME}}
         password: ${{secrets.GITHUB_REGISTRY_TOKEN}}
         registry: docker.pkg.github.com
+        tags: "5.x"
 

--- a/.github/workflows/docker-publish-pre-check.yml
+++ b/.github/workflows/docker-publish-pre-check.yml
@@ -1,6 +1,6 @@
 name: Docker & Publish Pre-check
 
-on: [pull_request]
+on: [push]
 
 jobs:
   testDocker:

--- a/.github/workflows/docker-publish-pre-check.yml
+++ b/.github/workflows/docker-publish-pre-check.yml
@@ -11,6 +11,6 @@ jobs:
     - uses: jerray/publish-docker-action@master
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        password: ${{ secrets.GITHUB_REGISTRY_TOKEN }}
         registry: docker.pkg.github.com
         repository: verdaccio/verdaccio

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,19 @@
+name: Publish docker image 
+
+on: [push]
+
+jobs:
+  testDocker:
+    name: Test Docker Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish to registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: docker.pkg.github.com/verdaccio/verdaccio/verdaccio
+        username: ${{secrets.DOCKER_USERNAME}}
+        password: ${{secrets.GITHUB_REGISTRY_TOKEN}}
+        registry: docker.pkg.github.com
+        tags: "5.x"
+


### PR DESCRIPTION
**Type:** build

**Description:**
Updates GitHub action to publish the Docker file under `5.x`. This a first try 🙃 to use more GitHub Registry.

```
docker pull docker.pkg.github.com/verdaccio/verdaccio/verdaccio:5.x
```

https://github.com/verdaccio/verdaccio/packages/13531