### PR TITLE
feat:  i18n on web

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,7 @@
 {
-  "presets": [["@verdaccio"]]
+  "presets": [["@verdaccio"]],
+  "plugins": [
+    "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-proposal-nullish-coalescing-operator"
+  ]
 }

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -71,3 +71,7 @@ logs:
 #experiments:
 #  # support for npm token command
 #  token: false
+
+# This affect the web and api (not developed yet)
+#i18n:
+#web: en-US

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@verdaccio/local-storage": "^9.3.4",
     "@verdaccio/readme": "^9.3.3",
     "@verdaccio/streams": "^9.3.2",
-    "@verdaccio/ui-theme": "^0.3.13",
+    "@verdaccio/ui-theme": "^1.0.0",
     "JSONStream": "1.3.5",
     "async": "3.1.1",
     "body-parser": "1.19.0",

--- a/src/api/web/index.ts
+++ b/src/api/web/index.ts
@@ -80,10 +80,11 @@ export default function(config, auth, storage) {
     const { url_prefix } = config;
     const uri = `${protocol}://${host}`;
     const base = combineBaseUrl(protocol, host, url_prefix);
+    const languageWeb = config?.i18n?.web ?? 'es-US';
     const primaryColor = _.get(config, 'web.primary_color') ? config.web.primary_color : '';
     const title = _.get(config, 'web.title') ? config.web.title : WEB_TITLE;
     const scope = _.get(config, 'web.scope') ? config.web.scope : '';
-    const options = { uri, protocol, host, url_prefix, base, primaryColor, title, scope };
+    const options = { uri, protocol, host, url_prefix, base, primaryColor, title, scope, language: languageWeb };
 
     const webPage = template
       .replace(/ToReplaceByVerdaccioUI/g, JSON.stringify(options))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,10 +1969,10 @@
   resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.3.9.tgz#6ff0f05315912b4ba39e29eb589ecc8833640990"
   integrity sha512-InTpEowYo6M9TjpQh4cVh/HZH1DW9oyhy8UpC1H4FOwvyknctN0dMavOseKWSrPAj+gPDzUw0IKAvwDI4OcPEg==
 
-"@verdaccio/ui-theme@^0.3.13":
-  version "0.3.13"
-  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.3.13.tgz#e6f06907b0940c47883f35861723012437b7b958"
-  integrity sha512-3nDT5iJvmIYJe8UwirJbHexy21HU0YUkwvKygVe2KCPUTQu8u23/w6JyOB8reqj8w0xFfJMHI0dArnPsKxYM3Q==
+"@verdaccio/ui-theme@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-1.0.0.tgz#53706449fdb2e66e06a22867deb3efedf6ddc9d2"
+  integrity sha512-gUggtAV9lOa2SmhYZmRRd/AGR5HmZ+N3uGoXnZXVjPckTetE/fsB8mqkSYZCk0SrO767j82JGhyU8O/JVKM8jw==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"
@@ -6577,11 +6577,6 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
-
-mkdirp@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
-  integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
 mkdirp@1.0.3:
   version "1.0.3"


### PR DESCRIPTION
**Type:** feat

**Description:**

* Add i18n on web https://github.com/verdaccio/ui/pull/432 @priscilawebdev 
* feat: spanish translations to UI  https://github.com/verdaccio/ui/pull/440 @juanpicado 
* feat(de-translations): added de-DE translations to the UI  https://github.com/verdaccio/ui/pull/441 @priscilawebdev and @jan-auer
* website docs  https://github.com/verdaccio/website/commit/e241821509bb5dc3308724732430645d15c1b71a

Available translations: `es-ES`, `us-US`, `pt-BR` and `de-DE`.

Thanks @priscilawebdev  for add i18n to the User Interface 👏 👏 👏 👏 

> 🙏  More translations are very welcome.