### PR TITLE
fix: update docs to support minimum node v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Install with npm:
 npm install --global verdaccio
 ```
 
+> ⚠️ After v4.5.0 Node v8 is not longer supported. **Node v10** is the minimum supported version.
+
 ## Donations
 
 Verdaccio is run by **volunteers**; nobody is working full-time on it. If you find this project to be useful and would like to support its development, consider making a donation - **your logo might end up in this readme.** 😉

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -71,3 +71,7 @@ logs:
 #experiments:
 #  # support for npm token command
 #  token: false
+
+# This affect the web and api (not developed yet)
+#i18n:
+#web: en-US

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "build:docker": "docker build -t verdaccio/verdaccio:local . --no-cache"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=10",
     "npm": ">=5"
   },
   "preferGlobal": true,


### PR DESCRIPTION
**Type:** fix

The following has been addressed in the PR:

*  There is a related issue?
*  Unit or Functional tests are included in the PR

**Description:**

At v4.5.0 we shipped some security releases, one of them is JSDOM https://github.com/jsdom/jsdom/releases/tag/16.0.0 and only supports Node.js v10

[Node v8 is out of maintenance so we don't consider this a breaking change.](https://blog.risingstack.com/update-nodejs-8-end-of-life-no-support/)

### Errors on Node v8

⚠️  If you are using Node v8 and you have this issue, have on mind you can use only `verdaccio@4.4.4` or less if you cannot upgrade to Node v10.

```
➜ verdaccio
/Users/user/.nvm/versions/node/v8.17.0/lib/node_modules/verdaccio/node_modules/jsdom/lib/jsdom/living/helpers/dates-and-times.js:235
  } catch {
          ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/user/.nvm/versions/node/v8.17.0/lib/node_modules/verdaccio/node_modules/jsdom/lib/jsdom/living/helpers/form-controls.js:18:5)
```



