### PR TITLE
feat: add dark mode on and chinese translation for web

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -22,7 +22,7 @@ web:
 
 # translate your registry, api i18n not available yet
 # i18n:
-# list if available translations https://github.com/verdaccio/ui/tree/master/i18n/translations
+# list of the available translations https://github.com/verdaccio/ui/tree/master/i18n/translations
 # web: en-US
 
 auth:

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -17,6 +17,13 @@ web:
   # gravatar: false
   # by default packages are ordercer ascendant (asc|desc)
   # sort_packages: asc
+  # convert your UI to the dark side
+  # darkMode: true
+
+# translate your registry, api i18n not available yet
+# i18n:
+# list if available translations https://github.com/verdaccio/ui/tree/master/i18n/translations
+# web: en-US
 
 auth:
   htpasswd:

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -23,7 +23,7 @@ web:
 # translate your registry, api i18n not available yet
 # i18n:
 # list of the available translations https://github.com/verdaccio/ui/tree/master/i18n/translations
-# web: en-US
+#   web: en-US
 
 auth:
   htpasswd:

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -23,6 +23,12 @@ web:
   # gravatar: false
   # by default packages are ordercer ascendant (asc|desc)
   # sort_packages: asc
+  # darkMode: true
+
+# translate your registry, api i18n not available yet
+# i18n:
+# list if available translations https://github.com/verdaccio/ui/tree/master/i18n/translations
+# web: en-US
 
 auth:
   htpasswd:

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -27,7 +27,7 @@ web:
 
 # translate your registry, api i18n not available yet
 # i18n:
-# list if available translations https://github.com/verdaccio/ui/tree/master/i18n/translations
+# list of the available translations https://github.com/verdaccio/ui/tree/master/i18n/translations
 # web: en-US
 
 auth:

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -28,7 +28,7 @@ web:
 # translate your registry, api i18n not available yet
 # i18n:
 # list of the available translations https://github.com/verdaccio/ui/tree/master/i18n/translations
-# web: en-US
+#   web: en-US
 
 auth:
   htpasswd:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@verdaccio/local-storage": "^9.3.4",
     "@verdaccio/readme": "^9.3.3",
     "@verdaccio/streams": "^9.3.2",
-    "@verdaccio/ui-theme": "^1.4.0",
+    "@verdaccio/ui-theme": "^1.5.0",
     "JSONStream": "1.3.5",
     "async": "3.2.0",
     "body-parser": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@verdaccio/local-storage": "^9.3.4",
     "@verdaccio/readme": "^9.3.3",
     "@verdaccio/streams": "^9.3.2",
-    "@verdaccio/ui-theme": "^1.0.0",
+    "@verdaccio/ui-theme": "^1.4.0",
     "JSONStream": "1.3.5",
     "async": "3.2.0",
     "body-parser": "1.19.0",

--- a/src/api/web/index.ts
+++ b/src/api/web/index.ts
@@ -16,6 +16,8 @@ import loadPlugin from '../../lib/plugin-loader';
 const { setSecurityWebHeaders } = require('../middleware');
 const pkgJSON = require('../../../package.json');
 
+const DEFAULT_LANGUAGE = 'es-US';
+
 export function loadTheme(config) {
   if (_.isNil(config.theme) === false) {
     return _.head(
@@ -80,11 +82,23 @@ export default function(config, auth, storage) {
     const { url_prefix } = config;
     const uri = `${protocol}://${host}`;
     const base = combineBaseUrl(protocol, host, url_prefix);
-    const languageWeb = config?.i18n?.web ?? 'es-US';
+    const language = config?.i18n?.web ?? DEFAULT_LANGUAGE;
+    const darkMode = config?.web?.darkMode ?? false;
     const primaryColor = _.get(config, 'web.primary_color') ? config.web.primary_color : '';
     const title = _.get(config, 'web.title') ? config.web.title : WEB_TITLE;
     const scope = _.get(config, 'web.scope') ? config.web.scope : '';
-    const options = { uri, protocol, host, url_prefix, base, primaryColor, title, scope, language: languageWeb };
+    const options = {
+      uri,
+      darkMode,
+      protocol,
+      host,
+      url_prefix,
+      base,
+      primaryColor,
+      title,
+      scope,
+      language,
+    };
 
     const webPage = template
       .replace(/ToReplaceByVerdaccioUI/g, JSON.stringify(options))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,10 +1969,10 @@
   resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.3.9.tgz#6ff0f05315912b4ba39e29eb589ecc8833640990"
   integrity sha512-InTpEowYo6M9TjpQh4cVh/HZH1DW9oyhy8UpC1H4FOwvyknctN0dMavOseKWSrPAj+gPDzUw0IKAvwDI4OcPEg==
 
-"@verdaccio/ui-theme@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-1.4.0.tgz#090127dbbcd5d679993d1e88ef94db00bf7bd5b9"
-  integrity sha512-YAPp3i7L6/a0t7T6xTRlEQi++ijlwcxObh6yo8GaiWsUJf4pUBnv6yOKP5C5fPBBH1PvoDVE3FQZ9GhSEm1nGw==
+"@verdaccio/ui-theme@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-1.5.0.tgz#748e2db1772106a4de64dbed1152e16cd4b34a7c"
+  integrity sha512-OLkTTJPnBgUDsRrGqIg5RC3NBmb7wolQEPrTGE1ScuVe0sO3351fw+TFj/hx5Oepbv4PqxknYossmWcrMaSq6Q==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1969,10 +1969,10 @@
   resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-0.3.9.tgz#6ff0f05315912b4ba39e29eb589ecc8833640990"
   integrity sha512-InTpEowYo6M9TjpQh4cVh/HZH1DW9oyhy8UpC1H4FOwvyknctN0dMavOseKWSrPAj+gPDzUw0IKAvwDI4OcPEg==
 
-"@verdaccio/ui-theme@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-1.0.0.tgz#53706449fdb2e66e06a22867deb3efedf6ddc9d2"
-  integrity sha512-gUggtAV9lOa2SmhYZmRRd/AGR5HmZ+N3uGoXnZXVjPckTetE/fsB8mqkSYZCk0SrO767j82JGhyU8O/JVKM8jw==
+"@verdaccio/ui-theme@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fui-theme/-/ui-theme-1.4.0.tgz#090127dbbcd5d679993d1e88ef94db00bf7bd5b9"
+  integrity sha512-YAPp3i7L6/a0t7T6xTRlEQi++ijlwcxObh6yo8GaiWsUJf4pUBnv6yOKP5C5fPBBH1PvoDVE3FQZ9GhSEm1nGw==
 
 "@yarnpkg/lockfile@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
**Type:** feat

**Description:**

## Web Update

* Dark mode by @priscilawebdev https://github.com/verdaccio/ui/pull/446
* Chinese UI Translation by @JackyChan https://github.com/verdaccio/ui/pull/448

### Dark Mode

In your `config.yaml`

* Add Dark mode UI
* Add `web` property for `darkMode`

```
web:
  darkMode: true
```
![dark-mode](https://user-images.githubusercontent.com/29228205/77254835-c6bc1b00-6c63-11ea-9e92-525e0a4b7fb0.gif)

### Chinese Web Translation

<img width="1283" alt="Screen Shot 2020-04-08 at 11 21 00 PM" src="https://user-images.githubusercontent.com/558752/78835082-d8394d00-79ef-11ea-8a9a-5735597410c9.png">



