### PR TITLE
feat: allow configuring VERDACCIO_USER_UID as docker build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,10 @@ RUN yarn config set registry $VERDACCIO_BUILD_REGISTRY && \
 FROM node:12.13.1-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
+ARG VERDACCIO_USER_UID=10001
+ARG VERDACCIO_USER_NAME=verdaccio
+
 ENV VERDACCIO_APPDIR=/opt/verdaccio \
-    VERDACCIO_USER_NAME=verdaccio \
-    VERDACCIO_USER_UID=10001 \
     VERDACCIO_PORT=4873 \
     VERDACCIO_PROTOCOL=http
 ENV PATH=$VERDACCIO_APPDIR/docker-bin:$PATH \


### PR DESCRIPTION
**Type:** build

**The following has been addressed in the PR**:

Allow setting `VERDACCIO_USER_UID` and `VERDACCIO_USER_NAME` as build args, e.g. by supplying them via docker build, or via compose config:
```yaml
build:
  context: .
  args:
    - VERDACCIO_USER_UID: 1234
```

`VERDACCIO_USER_UID` affects the user the container runs under, and the permissions of the created folders. allowing to configure this helps when using bind mounts (and avoid permissions issues).

afaict we don't need the env vars to be available at runtime??

The current docs mention `VERDACCIO_USER_UID` [here](https://verdaccio.org/docs/en/docker#running-verdaccio-using-docker), but it's not clear how to change it. (but maybe i am missing something obvious here?)



*  There is a related issue? no
*  Unit or Functional tests are included in the PR? no

