### PR TITLE
fix: incorrect primary_color crash the ui

### DIFF
--- a/src/api/web/index.ts
+++ b/src/api/web/index.ts
@@ -35,7 +35,7 @@ export function loadTheme(config) {
 }
 
 export function validatePrimaryColor(primaryColor) {
-  const isHex = /^#[0-9A-F]{6}$/i.test(primaryColor);
+  const isHex = /^#+([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/i.test(primaryColor);
   if (!isHex) {
     return '';
   }

--- a/src/api/web/index.ts
+++ b/src/api/web/index.ts
@@ -34,6 +34,15 @@ export function loadTheme(config) {
   }
 }
 
+export function validatePrimaryColor(primaryColor) {
+  const isHex = /^#[0-9A-F]{6}$/i.test(primaryColor);
+  if (!isHex) {
+    return '';
+  }
+
+  return primaryColor;
+}
+
 const sendFileCallback = next => err => {
   if (!err) {
     return;
@@ -84,7 +93,7 @@ export default function(config, auth, storage) {
     const base = combineBaseUrl(protocol, host, url_prefix);
     const language = config?.i18n?.web ?? DEFAULT_LANGUAGE;
     const darkMode = config?.web?.darkMode ?? false;
-    const primaryColor = _.get(config, 'web.primary_color') ? config.web.primary_color : '';
+    const primaryColor = validatePrimaryColor(config?.web?.primary_color);
     const title = _.get(config, 'web.title') ? config.web.title : WEB_TITLE;
     const scope = _.get(config, 'web.scope') ? config.web.scope : '';
     const options = {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

*  There is a related issue?  No
*  Unit or Functional tests are included in the PR

**Description:**

If the color is wrong, the UI crash

```
web:
  primary_color: 'blue'
```

The hex color representation must be exact, otherwise, it returns to default. Material-UI only supports hex colors and RGB.

```
web:
  primary_color: '#000'
```

<img width="658" alt="Screen Shot 2020-04-08 at 11 49 04 PM" src="https://user-images.githubusercontent.com/558752/78838965-a9bf7000-79f7-11ea-9696-7aa88704ca32.png">

