### PR TITLE
fix: fatal exception and crash when logrotate signal event is called

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -150,7 +150,15 @@ function setup(logs, { logStart } = { logStart: true }) {
   }
 
   process.on('SIGUSR2', function() {
-    Logger.reopenFileStreams();
+    // https://github.com/trentm/node-bunyan#stream-type-rotating-file
+    if (logger) {
+      /**
+       * Note on log rotation: Often you may be using external log rotation utilities like logrotate on Linux or logadm
+       * on SmartOS/Illumos. In those cases, unless your are ensuring "copy and truncate" semantics
+       * (via copytruncate with logrotate or -c with logadm) then the fd for your 'file' stream will change.
+       */
+      logger.reopenFileStreams();
+    }
   });
 }
 


### PR DESCRIPTION
fix #1709
**Type:**

The following has been addressed in the PR:

*  There is a related issue? #1709

**Description:**

When using https://linux.die.net/man/8/logrotate and the **copytruncate** property is not provided, crash the app. Example of good configuration previous `v4.5.1`, after that the event `SIGUSR2` won't be triggered anymore.

Read more her https://github.com/trentm/node-bunyan#stream-type-rotating-file

```
/root/verdaccio-server.log {
    daily
    maxsize 100M
    create
    rotate 100
    maxage 90
    delaycompress
    compress
    copytruncate
    notifempty
    missingok
}
```
