### PR TITLE
feat: restore Node 8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   },
   "dependencies": {
     "@verdaccio/commons-api": "9.4.0",
-    "@verdaccio/local-storage": "9.4.0",
-    "@verdaccio/readme": "9.4.0",
+    "@verdaccio/local-storage": "9.5.1",
+    "@verdaccio/readme": "9.5.1",
     "@verdaccio/streams": "9.5.0",
     "@verdaccio/ui-theme": "1.7.1",
     "JSONStream": "1.3.5",
@@ -47,11 +47,11 @@
     "marked": "0.8.2",
     "mime": "2.4.4",
     "minimatch": "3.0.4",
-    "mkdirp": "1.0.4",
+    "mkdirp": "0.5.5",
     "mv": "2.1.1",
     "pkginfo": "0.4.1",
     "request": "2.87.0",
-    "semver": "7.3.2",
+    "semver": "6.3.0",
     "verdaccio-audit": "9.5.0",
     "verdaccio-htpasswd": "9.4.1"
   },
@@ -133,7 +133,7 @@
     "build:docker": "docker build -t verdaccio/verdaccio:local . --no-cache"
   },
   "engines": {
-    "node": ">=10",
+    "node": ">=8",
     "npm": ">=5"
   },
   "preferGlobal": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2271,18 +2271,25 @@
   dependencies:
     lockfile "1.0.4"
 
-"@verdaccio/local-storage@9.4.0":
-  version "9.4.0"
-  resolved "https://registry.verdaccio.org/@verdaccio%2flocal-storage/-/local-storage-9.4.0.tgz#56c6ba6cb0f36b459208a7aecf59c79e8bad10d7"
-  integrity sha512-rhaMJN5vEzQ03BGoAYUcJTdkA6H4y5v3K2anNPJN5dN5GBV1AsYAkOn9RMXKa3WUdeWkWgNkPPeEqsc2gBR+qA==
+"@verdaccio/file-locking@^9.5.0":
+  version "9.5.0"
+  resolved "https://registry.verdaccio.org/@verdaccio%2ffile-locking/-/file-locking-9.5.0.tgz#c8ea8d9d5c5902ee82f08fe1fdcb3d09d8d65946"
+  integrity sha512-Q27WlxeMMFlKxI3x0nNAstiUkn9NfWv7BOFh/Zfvifr4aviNQcDyHincn9d6Pvuy6EBquUoUW0ty3Kv9rt5u5Q==
+  dependencies:
+    lockfile "1.0.4"
+
+"@verdaccio/local-storage@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.verdaccio.org/@verdaccio%2flocal-storage/-/local-storage-9.5.1.tgz#1bf4e16ff6b0820eec5ca4b7c942fd1956958b64"
+  integrity sha512-KghaxOhvjMv57FTxNOIwDX00fy/3lN71POddoX+sEegfmtl2vvalX8WUgerK2H1zZyi9mxS4eD1nTA6alnpyWg==
   dependencies:
     "@verdaccio/commons-api" "^9.4.0"
-    "@verdaccio/file-locking" "^9.4.0"
-    "@verdaccio/streams" "^9.4.0"
+    "@verdaccio/file-locking" "^9.5.0"
+    "@verdaccio/streams" "^9.5.0"
     async "3.2.0"
     level "5.0.1"
     lodash "4.17.15"
-    mkdirp "1.0.3"
+    mkdirp "0.5.5"
 
 "@verdaccio/local-storage@^9.3.4":
   version "9.3.4"
@@ -2297,13 +2304,13 @@
     lodash "4.17.15"
     mkdirp "1.0.3"
 
-"@verdaccio/readme@9.4.0":
-  version "9.4.0"
-  resolved "https://registry.verdaccio.org/@verdaccio%2freadme/-/readme-9.4.0.tgz#7c099bf8f016a88ec76c1412e855e69ce3ce1a44"
-  integrity sha512-d0AIdph9B4S2ULzMM/rBpSWEWnIYH4ENoNlUyc9JVCCQVUc/+dRG4Pk4C3e5Dfoh2lwL0af4WhlOPHis6kCD6g==
+"@verdaccio/readme@9.5.1":
+  version "9.5.1"
+  resolved "https://registry.verdaccio.org/@verdaccio%2freadme/-/readme-9.5.1.tgz#90b02577fafa85ab9a5cf4e03ed2cf2bb4ad5677"
+  integrity sha512-N05DsheI+olcDOtmGYbBR5huP3gZ1QRCS8Yr7LqPQNnrHQn2RqChbVM/lAGcc7Zb9k429cAWWV3KxknZs9M6OQ==
   dependencies:
     dompurify "2.0.8"
-    jsdom "16.2.1"
+    jsdom "15.2.1"
     marked "0.7.0"
 
 "@verdaccio/readme@^9.3.3":
@@ -2315,9 +2322,9 @@
     jsdom "16.2.1"
     marked "0.7.0"
 
-"@verdaccio/streams@9.5.0":
+"@verdaccio/streams@9.5.0", "@verdaccio/streams@^9.5.0":
   version "9.5.0"
-  resolved "https://registry.yarnpkg.com/@verdaccio/streams/-/streams-9.5.0.tgz#01c1e1a654b2085b0711a3e23df5c7b7376d0282"
+  resolved "https://registry.verdaccio.org/@verdaccio%2fstreams/-/streams-9.5.0.tgz#01c1e1a654b2085b0711a3e23df5c7b7376d0282"
   integrity sha512-Z+04XRPbOJCsaY6GyrVJH6/IWqeh81U3kr9E5XBHkCK+NtybF0D0nnZgVTh/q2GOxhvvOgGv9r3Uvg4GkbnXsQ==
 
 "@verdaccio/streams@^9.3.2":
@@ -6258,6 +6265,38 @@ jsbn@~0.1.0:
   resolved "https://registry.verdaccio.org/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
+jsdom@15.2.1, jsdom@^15.2.1:
+  version "15.2.1"
+  resolved "https://registry.verdaccio.org/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
+  integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
+  dependencies:
+    abab "^2.0.0"
+    acorn "^7.1.0"
+    acorn-globals "^4.3.2"
+    array-equal "^1.0.0"
+    cssom "^0.4.1"
+    cssstyle "^2.0.0"
+    data-urls "^1.1.0"
+    domexception "^1.0.1"
+    escodegen "^1.11.1"
+    html-encoding-sniffer "^1.0.2"
+    nwsapi "^2.2.0"
+    parse5 "5.1.0"
+    pn "^1.1.0"
+    request "^2.88.0"
+    request-promise-native "^1.0.7"
+    saxes "^3.1.9"
+    symbol-tree "^3.2.2"
+    tough-cookie "^3.0.1"
+    w3c-hr-time "^1.0.1"
+    w3c-xmlserializer "^1.1.2"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.5"
+    whatwg-mimetype "^2.3.0"
+    whatwg-url "^7.0.0"
+    ws "^7.0.0"
+    xml-name-validator "^3.0.0"
+
 jsdom@16.2.1:
   version "16.2.1"
   resolved "https://registry.verdaccio.org/jsdom/-/jsdom-16.2.1.tgz#df934649ab9175daeeff3e6f1e2b2268ed1470cd"
@@ -6288,38 +6327,6 @@ jsdom@16.2.1:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
     ws "^7.2.1"
-    xml-name-validator "^3.0.0"
-
-jsdom@^15.2.1:
-  version "15.2.1"
-  resolved "https://registry.verdaccio.org/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
-  integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==
-  dependencies:
-    abab "^2.0.0"
-    acorn "^7.1.0"
-    acorn-globals "^4.3.2"
-    array-equal "^1.0.0"
-    cssom "^0.4.1"
-    cssstyle "^2.0.0"
-    data-urls "^1.1.0"
-    domexception "^1.0.1"
-    escodegen "^1.11.1"
-    html-encoding-sniffer "^1.0.2"
-    nwsapi "^2.2.0"
-    parse5 "5.1.0"
-    pn "^1.1.0"
-    request "^2.88.0"
-    request-promise-native "^1.0.7"
-    saxes "^3.1.9"
-    symbol-tree "^3.2.2"
-    tough-cookie "^3.0.1"
-    w3c-hr-time "^1.0.1"
-    w3c-xmlserializer "^1.1.2"
-    webidl-conversions "^4.0.2"
-    whatwg-encoding "^1.0.5"
-    whatwg-mimetype "^2.3.0"
-    whatwg-url "^7.0.0"
-    ws "^7.0.0"
     xml-name-validator "^3.0.0"
 
 jsesc@^2.5.1:
@@ -7163,15 +7170,17 @@ mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mkdirp@0.5.5:
+  version "0.5.5"
+  resolved "https://registry.verdaccio.org/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
+
 mkdirp@1.0.3:
   version "1.0.3"
   resolved "https://registry.verdaccio.org/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
   integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
-
-mkdirp@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
-  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -8661,11 +8670,6 @@ semver@7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.3.tgz#e4345ce73071c53f336445cfc19efb1c311df2a6"
   integrity sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==
-
-semver@7.3.2:
-  version "7.3.2"
-  resolved "https://registry.verdaccio.org/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
 send@0.17.1:
   version "0.17.1"


### PR DESCRIPTION
This restores support I removed in Verdaccio 4.5.0

This means nothing if you were not using Node v8, this support should be removed in a major release.


