### PR TITLE
Refactor: move BodyParser to upper level

### DIFF
--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -3,7 +3,6 @@ import { Config } from '@verdaccio/types';
 import _ from 'lodash';
 
 import express from 'express';
-import bodyParser from 'body-parser';
 import whoami from './api/whoami';
 import ping from './api/ping';
 import user from './api/user';
@@ -42,7 +41,6 @@ export default function(config: Config, auth: IAuth, storage: IStorageHandler) {
   app.param('anything', match(/.*/));
 
   app.use(auth.apiJWTmiddleware());
-  app.use(bodyParser.json({ strict: false, limit: config.max_body_size || '10mb' }));
   app.use(antiLoop(config));
   // encode / in a scoped package name to be matched as a single parameter in routes
   app.use(encodeScopePackage);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import express, { Application } from 'express';
+import bodyParser from 'body-parser';
 import compression from 'compression';
 import cors from 'cors';
 import { HttpError } from 'http-errors';
@@ -45,6 +46,8 @@ const defineAPI = function(config: IConfig, storage: IStorageHandler): any {
   if (config._debug) {
     hookDebug(app, config.self_path);
   }
+
+  app.use(bodyParser.json({ strict: false, limit: config.max_body_size || '10mb' }));
 
   // register middleware plugins
   const plugin_params = {


### PR DESCRIPTION
This can be useful when the middleware plugin has to get access to the request's body.

I tried to make publication and add some field "on the fly" and didn't get access to the request's body. ([link to my example plugin](https://github.com/hydra13/verdaccio-example-plugin))

The reason for this problem was that body-parser was used in `src/api/endpoint/index.ts` and middleware plugins registered before ones.

My PR just moves the call of body-parser from `src/api/endpoint/index.ts` to `src/api/index.ts` (above registration middleware plugins)