### PR TITLE
feat: npm deprecation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Verdaccio aims to support all features of a standard npm client that make sense 
 
 - Unpublishing packages (npm unpublish) - **supported**
 - Tagging (npm tag) - **supported**
-- Deprecation (npm deprecate) - not supported - *PR-welcome*
+- Deprecation (npm deprecate) - supported
 
 ### User management
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,16 +9,7 @@ import YAML from 'js-yaml';
 import URL from 'url';
 import sanitizyReadme from '@verdaccio/readme';
 
-import {
-  APP_ERROR,
-  DEFAULT_PORT,
-  DEFAULT_DOMAIN,
-  DEFAULT_PROTOCOL,
-  CHARACTER_ENCODING,
-  HEADERS,
-  DIST_TAGS,
-  DEFAULT_USER,
-} from './constants';
+import { APP_ERROR, DEFAULT_PORT, DEFAULT_DOMAIN, DEFAULT_PROTOCOL, CHARACTER_ENCODING, HEADERS, DIST_TAGS, DEFAULT_USER } from './constants';
 import { generateGravatarUrl, GENERIC_AVATAR } from '../utils/user';
 
 import { Package, Version, Author } from '@verdaccio/types';
@@ -188,12 +179,7 @@ export function convertDistRemoteToLocalTarballUrls(pkg: Package, req: Request, 
  * @param {*} uri
  * @return {String} a parsed url
  */
-export function getLocalRegistryTarballUri(
-  uri: string,
-  pkgName: string,
-  req: Request,
-  urlPrefix: string | void
-): string {
+export function getLocalRegistryTarballUri(uri: string, pkgName: string, req: Request, urlPrefix: string | void): string {
   const currentHost = req.headers.host;
 
   if (!currentHost) {
@@ -634,4 +620,14 @@ export function isVersionValid(packageMeta, packageVersion): boolean {
 
   const hasMatchVersion = Object.keys(packageMeta.versions).includes(packageVersion);
   return hasMatchVersion;
+}
+
+export function isRelatedToDeprecation(pkgInfo: Package): boolean {
+  const { versions } = pkgInfo;
+  for (const version in versions) {
+    if (Object.prototype.hasOwnProperty.call(versions[version], 'deprecated')) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -9,7 +9,16 @@ import YAML from 'js-yaml';
 import URL from 'url';
 import sanitizyReadme from '@verdaccio/readme';
 
-import { APP_ERROR, DEFAULT_PORT, DEFAULT_DOMAIN, DEFAULT_PROTOCOL, CHARACTER_ENCODING, HEADERS, DIST_TAGS, DEFAULT_USER } from './constants';
+import {
+  APP_ERROR,
+  DEFAULT_PORT,
+  DEFAULT_DOMAIN,
+  DEFAULT_PROTOCOL,
+  CHARACTER_ENCODING,
+  HEADERS,
+  DIST_TAGS,
+  DEFAULT_USER,
+} from './constants';
 import { generateGravatarUrl, GENERIC_AVATAR } from '../utils/user';
 
 import { Package, Version, Author } from '@verdaccio/types';
@@ -179,7 +188,12 @@ export function convertDistRemoteToLocalTarballUrls(pkg: Package, req: Request, 
  * @param {*} uri
  * @return {String} a parsed url
  */
-export function getLocalRegistryTarballUri(uri: string, pkgName: string, req: Request, urlPrefix: string | void): string {
+export function getLocalRegistryTarballUri(
+  uri: string,
+  pkgName: string,
+  req: Request,
+  urlPrefix: string | void
+): string {
   const currentHost = req.headers.host;
 
   if (!currentHost) {

--- a/test/unit/__helper/api.ts
+++ b/test/unit/__helper/api.ts
@@ -68,7 +68,8 @@ export function getPackage(
   return new Promise((resolve) => {
     let getRequest = request.get(`/${pkgName}`);
 
-    if (_.isNil(token) === false || _.isEmpty(token) === false) {
+    // token is a string
+    if (token !== '') {
       getRequest.set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token));
     }
 

--- a/test/unit/__helper/utils.ts
+++ b/test/unit/__helper/utils.ts
@@ -158,3 +158,12 @@ export function generatePackageMetadata(pkgName: string, version = '1.0.0'): Pac
 		}
 	}
 }
+
+export function generateDeprecateMetadata(pkgName: string, version = '1.0.0', deprecated:string = ''): Package {
+  const res = {
+    ...generatePackageMetadata(pkgName, version),
+    _attachments: {},
+  };
+  res.versions[version].deprecated = deprecated;
+  return res;
+}

--- a/test/unit/modules/api/api.spec.ts
+++ b/test/unit/modules/api/api.spec.ts
@@ -20,10 +20,16 @@ import {DOMAIN_SERVERS} from '../../../functional/config.functional';
 import {buildToken, encodeScopedUri} from '../../../../src/lib/utils';
 import {
   getNewToken,
+  getPackage,
   putPackage,
   verifyPackageVersionDoesExist, generateUnPublishURI
 } from '../../__helper/api';
-import {generatePackageMetadata, generatePackageUnpublish, generateStarMedatada} from '../../__helper/utils';
+import {
+  generatePackageMetadata,
+  generatePackageUnpublish,
+  generateStarMedatada,
+  generateDeprecateMetadata,
+} from '../../__helper/utils';
 
 require('../../../../src/lib/logger').setup([
   { type: 'stdout', format: 'pretty', level: 'warn' }
@@ -902,6 +908,60 @@ describe('endpoint unit test', () => {
                     });
             });
         });
+    });
+
+    describe('should test (un)deprecate api', () => {
+      const pkgName = '@scope/deprecate';
+      const credentials = { name: 'jota_deprecate', password: 'secretPass' };
+      const version = '1.0.0'
+      let token = '';
+      beforeAll(async (done) =>{
+        token = await getNewToken(request(app), credentials);
+        await putPackage(request(app), `/${pkgName}`, generatePackageMetadata(pkgName, version), token);
+        done();
+      });
+
+      test('should deprecate a package', async (done) => {
+        const pkg = generateDeprecateMetadata(pkgName, version, 'get deprecated');
+        const [err] = await putPackage(request(app), `/${encodeScopedUri(pkgName)}`, pkg, token);
+        if (err) {
+          expect(err).toBeNull();
+          return done(err);
+        }
+        const [,res] = await getPackage(request(app), '', pkgName)
+        expect(res.body.versions[version].deprecated).toEqual('get deprecated');
+        done();
+      });
+
+      test('should undeprecate a package', async (done) => {
+        let pkg = generateDeprecateMetadata(pkgName, version, 'get deprecated');
+        await putPackage(request(app), `/${encodeScopedUri(pkgName)}`, pkg, token);
+        pkg = generateDeprecateMetadata(pkgName, version, '');
+        const [err] = await putPackage(request(app), `/${encodeScopedUri(pkgName)}`, pkg, token);
+        if (err) {
+          expect(err).toBeNull();
+          return done(err);
+        }
+        const [,res] = await getPackage(request(app), '', pkgName)
+        expect(res.body.versions[version].deprecated).not.toBeDefined();
+        done();
+      });
+
+      test('should require both publish and unpublish access to (un)deprecate a package', async () => {
+        let credentials = { name: 'only_publish', password: 'secretPass' };
+        let token = await getNewToken(request(app), credentials);
+        const pkg = generateDeprecateMetadata(pkgName, version, 'get deprecated');
+        const [err, res] = await putPackage(request(app), `/${encodeScopedUri(pkgName)}`, pkg, token);
+        expect(err).not.toBeNull();
+        expect(res.body.error).toBeDefined();
+        expect(res.body.error).toMatch(/user only_publish is not allowed to unpublish package @scope\/deprecate/);
+        credentials = { name: 'only_unpublish', password: 'secretPass' };
+        token = await getNewToken(request(app), credentials);
+        const [err2, res2] = await putPackage(request(app), `/${encodeScopedUri(pkgName)}`, pkg, token);
+        expect(err2).not.toBeNull();
+        expect(res2.body.error).toBeDefined();
+        expect(res2.body.error).toMatch(/user only_unpublish is not allowed to publish package @scope\/deprecate/);
+      })
     });
   });
 });

--- a/test/unit/modules/api/api.spec.ts
+++ b/test/unit/modules/api/api.spec.ts
@@ -29,6 +29,7 @@ import {
   generatePackageUnpublish,
   generateStarMedatada,
   generateDeprecateMetadata,
+  generateVersion,
 } from '../../__helper/utils';
 
 require('../../../../src/lib/logger').setup([
@@ -928,7 +929,7 @@ describe('endpoint unit test', () => {
           expect(err).toBeNull();
           return done(err);
         }
-        const [,res] = await getPackage(request(app), '', pkgName)
+        const [,res] = await getPackage(request(app), '', pkgName);
         expect(res.body.versions[version].deprecated).toEqual('get deprecated');
         done();
       });
@@ -942,7 +943,7 @@ describe('endpoint unit test', () => {
           expect(err).toBeNull();
           return done(err);
         }
-        const [,res] = await getPackage(request(app), '', pkgName)
+        const [,res] = await getPackage(request(app), '', pkgName);
         expect(res.body.versions[version].deprecated).not.toBeDefined();
         done();
       });
@@ -961,6 +962,20 @@ describe('endpoint unit test', () => {
         expect(err2).not.toBeNull();
         expect(res2.body.error).toBeDefined();
         expect(res2.body.error).toMatch(/user only_unpublish is not allowed to publish package @scope\/deprecate/);
+      })
+
+      test('should deprecate multiple packages', async (done) => {
+        await putPackage(request(app), `/${pkgName}`, generatePackageMetadata(pkgName, '1.0.1'), token);
+        const pkg = generateDeprecateMetadata(pkgName, version, 'get deprecated');
+        pkg.versions['1.0.1'] = {
+          ...generateVersion(pkgName, '1.0.1'),
+          deprecated: 'get deprecated',
+        };
+        await putPackage(request(app), `/${encodeScopedUri(pkgName)}`, pkg, token);
+        const [,res] = await getPackage(request(app), '', pkgName);
+        expect(res.body.versions[version].deprecated).toEqual('get deprecated');
+        expect(res.body.versions['1.0.1'].deprecated).toEqual('get deprecated');
+        done()
       })
     });
   });

--- a/test/unit/partials/config/yaml/api.spec.yaml
+++ b/test/unit/partials/config/yaml/api.spec.yaml
@@ -7,6 +7,14 @@ packages:
     access: $anonymous jota_unpublish
     publish: $anonymous jota_unpublish
     unpublish: $anonymous jota_unpublish
+  '@scope/deprecate':
+    access: $all
+    publish:
+      - jota_deprecate
+      - only_publish
+    unpublish:
+      - jota_deprecate
+      - only_unpublish
   '@scope/starPackage':
     access: $all
     publish: jota_star


### PR DESCRIPTION
This is a successor of #1308, so this is highly referenced that PR but with some differences:
- treating deprecation as updating a package so it requires publish and unpublish access
- the way to distinguish a deprecate request: #1308 is done by an empty `_attachements` but this one is by checking if there is any `deprecated` key presented in any version(ref for the implementation of [npm cli](https://github.com/npm/cli/blob/latest/lib/deprecate.js#L63))
- fixed a comment related to starring a package
- fixed a small thing in `getPackage` for the testing utils

Please review, thanks!