### PR TITLE
fix: move search v1 endpoint as experimental

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -78,6 +78,8 @@ logs:
 #experiments:
 #  # support for npm token command
 #  token: false
+#  # support for the new v1 search endpoint, functional by incomplete read more on ticket 1732
+#  search: false
 
 # This affect the web and api (not developed yet)
 #i18n:

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -77,6 +77,8 @@ logs:
 #experiments:
 #  # support for npm token command
 #  token: false
+#  # support for the new v1 search endpoint, functional by incomplete read more on ticket 1732
+#  search: false
 
 # This affect the web and api (not developed yet)
 #i18n:

--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -55,7 +55,9 @@ export default function(config: Config, auth: IAuth, storage: IStorageHandler) {
   ping(app);
   stars(app, storage);
 
-  v1Search(app, auth, storage)
+  if (_.get(config, 'experiments.search') === true) {
+    v1Search(app, auth, storage)
+  }
 
   if (_.get(config, 'experiments.token') === true) {
     token(app, auth, storage, config);


### PR DESCRIPTION
the current one has not auth implemented, to avoid the lack of fallback to the original one now is required to be used it by default until the v1 is on shape production ready.

relates https://github.com/verdaccio/verdaccio/pull/1732

If you are using from `v4.5.0` to `v4.7.0` I recommend you update to this patch release. Always backward compatible. 

To force `v1` search endpoint just add the following in your config file.

```
experiments:
   search: true
```