### PR TITLE
Fix dns config in cloudformation template

### DIFF
--- a/contrib/aws/cloudformation-ec2-efs.yaml
+++ b/contrib/aws/cloudformation-ec2-efs.yaml
@@ -22,11 +22,6 @@ Parameters:
     Description: >
       The route 53 hosted zone name to create the `npm.<zone>` record in. Do not
       include the trailing dot!
-  Route53RecordHostedZoneId:
-    Type: String
-    Description: >
-      Hosted Zone ID for the load balancer. Find it here:
-      https://docs.aws.amazon.com/general/latest/gr/rande.html
   Vpc:
     Type: AWS::EC2::VPC::Id
     Description: VPC to create this stack inside
@@ -261,7 +256,9 @@ Resources:
             - Lb
             - DNSName
         HostedZoneId:
-          Ref: Route53RecordHostedZoneId
+          Fn::GetAtt:
+            - Lb
+            - CanonicalHostedZoneID
       HostedZoneName:
         Fn::Sub: ${DnsHostedZoneName}.
       Name:


### PR DESCRIPTION
While trying to use the cloudformation template I noticed a small issue that can be avoided with the DNS configuration. The zone id for the alias target (the load balancer) should be taken from the load balancer, it's not a template parameter.

See relevant [doc](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget-1.html#cfn-route53-aliastarget-hostedzoneid).
