### PR TITLE
fix: doubled request logs in node.js >= 11

### DIFF
--- a/src/api/middleware.ts
+++ b/src/api/middleware.ts
@@ -216,7 +216,13 @@ export function log(req: $RequestExtend, res: $ResponseExtend, next: $NextFuncti
     _write.apply(res, arguments);
   };
 
+  let logHasBeenCalled = false;
   const log = function(): void {
+    if (logHasBeenCalled) {
+      return;
+    }
+    logHasBeenCalled = true;
+
     const forwardedFor = req.headers['x-forwarded-for'];
     const remoteAddress = req.connection.remoteAddress;
     const remoteIP = forwardedFor ? `${forwardedFor} via ${remoteAddress}` : remoteAddress;


### PR DESCRIPTION
```
$ docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio warn --- config file  - /verdaccio/conf/config.yaml
 warn --- Verdaccio started
 warn --- Plugin successfully loaded: verdaccio-htpasswd
 warn --- Plugin successfully loaded: verdaccio-audit
 warn --- http address - http://0.0.0.0:4873/ - verdaccio/4.9.1
 http --> 200, req: 'GET https://registry.npmjs.org/execa' (streaming)
 http --> 200, req: 'GET https://registry.npmjs.org/execa', bytes: 0/119164
 http <-- 200, user: null(172.17.0.1), req: 'GET /execa', bytes: 0/27224
 http <-- 200, user: null(172.17.0.1), req: 'GET /execa', bytes: 0/27224
```