### PR TITLE
feat: enable keep alive on configuration by default

### DIFF
--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -36,6 +36,10 @@ auth:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+    agent_options:
+      keepAlive: true
+      maxSockets: 40
+      maxFreeSockets: 10
 
 packages:
   '@*/*':

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -41,6 +41,10 @@ auth:
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+    agent_options:
+      keepAlive: true
+      maxSockets: 40
+      maxFreeSockets: 10
 
 packages:
   '@*/*':


### PR DESCRIPTION
Add by default the keep alive configuration for the newer installations.

Example: https://github.com/verdaccio/verdaccio/commit/cc5d78613386d70c3e76d4b3acb902fdd004e08f

If this goes well, I'd enabled it directly for older installations which upgrade without have to change configuration in the near future if no troubles are reported.

https://github.com/request/request#requestoptions-callback
https://nodejs.org/api/http.html#http_new_agent_options

From docs

```
keepAlive: true,      // Keep sockets around even when there are no outstanding requests, so they can be used for future requests without having to reestablish a TCP connection. Defaults to false
maxSockets: 40, // Maximum number of sockets to allow per host. Defaults to Infinity.
maxFreeSockets: 10   // Maximum number of sockets to leave open in a free state. Only relevant if keepAlive is set to true. Defaults to 256.
```

