### PR TITLE
feat: skip log static content from web

### DIFF
--- a/src/api/middleware.ts
+++ b/src/api/middleware.ts
@@ -190,7 +190,10 @@ export function log(config: Config) {
     }
 
     req.url = req.originalUrl;
-    req.log.info({ req: req, ip: req.ip }, "@{ip} requested '@{req.method} @{req.url}'");
+    // avoid log noise data from static content
+    if (req.originalUrl.match(/static/) === null) {
+      req.log.info({req: req, ip: req.ip}, "@{ip} requested '@{req.method} @{req.url}'");
+    }
     req.originalUrl = req.url;
 
     if (_.isNil(_auth) === false) {
@@ -237,26 +240,29 @@ export function log(config: Config) {
       }
 
       req.url = req.originalUrl;
-      req.log.warn(
-        {
-          request: {
-            method: req.method,
-            url: req.url,
-          },
-          level: 35, // http
-          user: (req.remote_user && req.remote_user.name) || null,
-          remoteIP,
-          status: res.statusCode,
-          error: res._verdaccio_error,
-          bytes: {
-            in: bytesin,
-            out: bytesout,
-          },
-        },
-        message
-      );
-      req.originalUrl = req.url;
-    };
+      // avoid log noise data from static content
+      if (req.url.match(/static/) === null) {
+        req.log.warn(
+            {
+              request: {
+                method: req.method,
+                url: req.url,
+              },
+              level: 35, // http
+              user: (req.remote_user && req.remote_user.name) || null,
+              remoteIP,
+              status: res.statusCode,
+              error: res._verdaccio_error,
+              bytes: {
+                in: bytesin,
+                out: bytesout,
+              },
+            },
+            message
+        );
+        req.originalUrl = req.url;
+      }
+    }
 
     req.on('close', function(): void {
       log();


### PR DESCRIPTION
After #2026 the log will create more noise because the static content is smaller and segmented, this PR skip all those entries to the log.

```
 warn --- Plugin successfully loaded: verdaccio-htpasswd
 warn --- Plugin successfully loaded: verdaccio-audit
 warn --- http address - http://localhost:4873/ - verdaccio/4.10.0
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/web/detail/@juanpicado/pnpmInit', bytes: 0/564
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/main.d8631d8e33c2a8ee0307.css', bytes: 0/1180
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/runtime.2f30ad14d8bc2c72f5e5.js', bytes: 0/2236
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/main.2f30ad14d8bc2c72f5e5.js', bytes: 0/46404
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/fonts/roboto-latin-500.woff2', bytes: 0/15872
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/fonts/roboto-latin-400.woff2', bytes: 0/15736
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/vendors.2f30ad14d8bc2c72f5e5.js', bytes: 0/209470
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/Provider.2f30ad14d8bc2c72f5e5.js', bytes: 0/1426
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/93df1ce974e744e7d98f5d842da74ba0.svg', bytes: 0/753
 http <-- 200, user: null(127.0.0.1), req: 'GET /-/static/221.2f30ad14d8bc2c72f5e5.js', bytes: 0/7362
```