### PR TITLE
publishing multi-arch image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,53 @@
+name: Docker publish to docker.io
+
+on:
+  push:
+    paths:
+      - .github/workflows/docker-publish.yml
+      - 'src/**'
+      - 'conf/**'
+      - 'types/**',
+      - 'docker-bin/**'
+      - 'bin/**'
+      - 'package.json'
+      - 'yarn.lock'
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: network=host
+      - uses: docker/login-action@v1
+        name: Login docker.io
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Prepare docker image tags
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ github.repository }}
+          tag-custom: 4.x-next
+          tag-custom-only: ${{ github.ref == 'refs/heads/master' }}
+          tag-semver: |
+            {{version}}
+            {{major}}
+            {{major}}.{{minor}}
+      - name: Build & Push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.15.1-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.15.1-alpine as builder
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.verdaccio.org


### PR DESCRIPTION
example:  https://hub.docker.com/r/morlay/verdaccio/tags?page=1&ordering=last_updated
```
docker buildx build --push --platform=linux/amd64,linux/arm64 --tag morlay/verdaccio .
```

github actions setup 
https://github.com/docker/setup-buildx-action

I haven't found the publish workflow.