### PR TITLE
fix: docker build missing modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,16 +10,20 @@
 # e.g.
 !.babelrc
 !.eslintrc
-!.prettierrc
+!.prettierrc.json
+!.prettierignore
 !.eslintignore
 !.stylelintrc
-!.flowconfig
-!.jest.config.js
-!.jestEnvironment.js
 
-# do not copy over node_modules we will run `npm install` anyway
+# do not copy over node_modules we will run `pnpm install` anyway
 node_modules
 website
+jest
+docs
+contrib
+docker-examples
+website
+systemd
 
 # output from test runs and similar things
 *.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18.4-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.15.1-alpine as builder
 
 ENV NODE_ENV=development \
     VERDACCIO_BUILD_REGISTRY=https://registry.verdaccio.org
@@ -12,14 +12,14 @@ RUN apk --no-cache add openssl ca-certificates wget && \
 WORKDIR /opt/verdaccio-build
 COPY . .
 
-RUN npm -g i pnpm@5.5.12 && \
+RUN npm -g i pnpm@latest && \
     pnpm config set registry $VERDACCIO_BUILD_REGISTRY && \
     pnpm recursive install --frozen-lockfile --ignore-scripts && \
-    pnpm run build && \
-    pnpm run lint && \
-    pnpm install --prod --ignore-scripts
+    pnpm run build
+# FIXME: need to remove devDependencies from the build
+# RUN pnpm install --prod --ignore-scripts
 
-FROM node:12.18.4-alpine
+FROM node:14.15.1-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \


### PR DESCRIPTION
error on `docker run -it --rm --name verdaccio5x -p 4873:4873 verdaccio/verdaccio:5.x-next`

```
Error: Cannot find module 'kleur'
Require stack:
- /opt/verdaccio/packages/cli/build/cli.js
- /opt/verdaccio/packages/cli/build/index.js
- /opt/verdaccio/packages/verdaccio/bin/verdaccio
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:965:15)
    at Function.Module._load (internal/modules/cjs/loader.js:841:27)
    at Module.require (internal/modules/cjs/loader.js:1025:19)
    at require (internal/modules/cjs/helpers.js:72:18)
    at Object.<anonymous> (/opt/verdaccio/packages/cli/build/cli.js:5:14)
    at Module._compile (internal/modules/cjs/loader.js:1137:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1157:10)
    at Module.load (internal/modules/cjs/loader.js:985:32)
    at Function.Module._load (internal/modules/cjs/loader.js:878:14)
    at Module.require (internal/modules/cjs/loader.js:1025:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/opt/verdaccio/packages/cli/build/cli.js',
    '/opt/verdaccio/packages/cli/build/index.js',
    '/opt/verdaccio/packages/verdaccio/bin/verdaccio'
  ]
}
```