### PR TITLE
fix: update docker base image node 14.15.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.15.1-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.15.4-alpine as builder
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.verdaccio.org
@@ -23,7 +23,7 @@ RUN yarn config set npmRegistryServer $VERDACCIO_BUILD_REGISTRY && \
 
 
 
-FROM node:14.15.1-alpine
+FROM node:14.15.4-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \


### PR DESCRIPTION
Update docker base image due Node.js security updates

https://nodejs.org/en/blog/vulnerability/january-2021-security-releases/