### PR TITLE
feat: allow other password hashing algorithms (#1917)

### DIFF
--- a/.changeset/spicy-frogs-press.md
+++ b/.changeset/spicy-frogs-press.md
@@ -1,0 +1,32 @@
+---
+'verdaccio-htpasswd': major
+---
+
+feat: allow other password hashing algorithms (#1917)
+
+**breaking change**
+
+The current implementation of the `htpasswd` module supports multiple hash formats on verify, but only `crypt` on sign in.
+`crypt` is an insecure old format, so to improve the security of the new `verdaccio` release we introduce the support of multiple hash algorithms on sign in step.
+
+### New hashing algorithms
+
+The new possible hash algorithms to use are `bcrypt`, `md5`, `sha1`. `bcrypt` is chosen as a default, because of its customizable complexity and overall reliability. You can read more about them [here](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html).
+
+Two new properties are added to `auth` section in the configuration file:
+
+- `algorithm` to choose the way you want to hash passwords.
+- `rounds` is used to determine `bcrypt` complexity. So one can improve security according to increasing computational power.
+
+Example of the new `auth` config file section:
+
+```yaml
+auth:
+htpasswd:
+  file: ./htpasswd
+  max_users: 1000
+  # Hash algorithm, possible options are: "bcrypt", "md5", "sha1", "crypt".
+  algorithm: bcrypt
+  # Rounds number for "bcrypt", will be ignored for other algorithms.
+  rounds: 10
+```

--- a/packages/core/htpasswd/README.md
+++ b/packages/core/htpasswd/README.md
@@ -27,6 +27,10 @@ As simple as running:
             # Maximum amount of users allowed to register, defaults to "+infinity".
             # You can set this to -1 to disable registration.
             #max_users: 1000
+            # Hash algorithm, possible options are: "bcrypt", "md5", "sha1", "crypt".
+            #algorithm: bcrypt
+            # Rounds number for "bcrypt", will be ignored for other algorithms.
+            #rounds: 10
 
 ## Logging In
 

--- a/packages/core/htpasswd/package.json
+++ b/packages/core/htpasswd/package.json
@@ -37,7 +37,8 @@
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.2",
-    "@verdaccio/types": "workspace:10.0.0-alpha.3"
+    "@verdaccio/types": "workspace:10.0.0-alpha.3",
+    "mockdate": "^3.0.2"
   },
   "scripts": {
     "clean": "rimraf ./build",

--- a/packages/core/htpasswd/src/crypt3.ts
+++ b/packages/core/htpasswd/src/crypt3.ts
@@ -10,28 +10,37 @@ import crypto from 'crypto';
 
 import crypt from 'unix-crypt-td-js';
 
+export enum EncryptionMethod {
+  md5 = 'md5',
+  sha1 = 'sha1',
+  crypt = 'crypt',
+  blowfish = 'blowfish',
+  sha256 = 'sha256',
+  sha512 = 'sha512',
+}
+
 /**
  * Create salt
- * @param {string} type The type of salt: md5, blowfish (only some linux
+ * @param {EncryptionMethod} type The type of salt: md5, blowfish (only some linux
  * distros), sha256 or sha512. Default is sha512.
  * @returns {string} Generated salt string
  */
-export function createSalt(type = 'crypt'): string {
+export function createSalt(type: EncryptionMethod = EncryptionMethod.crypt): string {
   switch (type) {
-    case 'crypt':
+    case EncryptionMethod.crypt:
       // Legacy crypt salt with no prefix (only the first 2 bytes will be used).
       return crypto.randomBytes(2).toString('base64');
 
-    case 'md5':
+    case EncryptionMethod.md5:
       return '$1$' + crypto.randomBytes(10).toString('base64');
 
-    case 'blowfish':
+    case EncryptionMethod.blowfish:
       return '$2a$' + crypto.randomBytes(10).toString('base64');
 
-    case 'sha256':
+    case EncryptionMethod.sha256:
       return '$5$' + crypto.randomBytes(10).toString('base64');
 
-    case 'sha512':
+    case EncryptionMethod.sha512:
       return '$6$' + crypto.randomBytes(10).toString('base64');
 
     default:

--- a/packages/core/htpasswd/tests/__snapshots__/utils.test.ts.snap
+++ b/packages/core/htpasswd/tests/__snapshots__/utils.test.ts.snap
@@ -1,17 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`addUserToHTPasswd - crypt3 should add new htpasswd to the end 1`] = `
+exports[`addUserToHTPasswd - bcrypt should add new htpasswd to the end 1`] = `
+"username:$2a$10$......................7zqaLmaKtn.i7IjPfuPGY2Ah/mNM6Sy:autocreated 2018-01-14T11:17:40.712Z
+"
+`;
+
+exports[`addUserToHTPasswd - bcrypt should add new htpasswd to the end in multiline input 1`] = `
+"test1:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z
+    test2:$6FrCaT/v0dwE:autocreated 2017-12-14T13:30:20.838Z
+username:$2a$10$......................7zqaLmaKtn.i7IjPfuPGY2Ah/mNM6Sy:autocreated 2018-01-14T11:17:40.712Z
+"
+`;
+
+exports[`addUserToHTPasswd - bcrypt should throw an error for incorrect username with space 1`] = `"username should not contain non-uri-safe characters"`;
+
+exports[`changePasswordToHTPasswd should change the password 1`] = `
+"root:$2a$10$......................0qqDmeqkAfPx68M2ArX8hVzcVNft5Ha:autocreated 2018-01-14T11:17:40.712Z
+"
+`;
+
+exports[`generateHtpasswdLine should correctly generate line for bcrypt 1`] = `
+"username:$2a$04$......................LAtw7/ohmmBAhnXqmkuIz83Rl5Qdjhm:autocreated 2018-01-14T11:17:40.712Z
+"
+`;
+
+exports[`generateHtpasswdLine should correctly generate line for crypt 1`] = `
 "username:$66to3JK5RgZM:autocreated 2018-01-14T11:17:40.712Z
 "
 `;
 
-exports[`addUserToHTPasswd - crypt3 should add new htpasswd to the end in multiline input 1`] = `
-"test1:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z
-    test2:$6FrCaT/v0dwE:autocreated 2017-12-14T13:30:20.838Z
-username:$66to3JK5RgZM:autocreated 2018-01-14T11:17:40.712Z
+exports[`generateHtpasswdLine should correctly generate line for md5 1`] = `
+"username:$apr1$MMMMMMMM$2lGUwLC3NFfN74jH51z1W.:autocreated 2018-01-14T11:17:40.712Z
 "
 `;
 
-exports[`addUserToHTPasswd - crypt3 should throw an error for incorrect username with space 1`] = `"username should not contain non-uri-safe characters"`;
-
-exports[`changePasswordToHTPasswd should change the password 1`] = `"root:$6JaJqI5HUf.Q:autocreated 2018-08-20T13:38:12.164Z"`;
+exports[`generateHtpasswdLine should correctly generate line for sha1 1`] = `
+"username:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=:autocreated 2018-01-14T11:17:40.712Z
+"
+`;

--- a/packages/core/htpasswd/tests/crypt3.test.ts
+++ b/packages/core/htpasswd/tests/crypt3.test.ts
@@ -1,10 +1,10 @@
-import { createSalt } from '../src/crypt3';
+import { createSalt, EncryptionMethod } from '../src/crypt3';
 
 jest.mock('crypto', () => {
   return {
-    randomBytes: (): { toString: () => string } => {
+    randomBytes: (len: number): { toString: () => string } => {
       return {
-        toString: (): string => '/UEGzD0RxSNDZA==',
+        toString: (): string => '/UEGzD0RxSNDZA=='.substring(0, len),
       };
     },
   };
@@ -12,20 +12,20 @@ jest.mock('crypto', () => {
 
 describe('createSalt', () => {
   test('should match with the correct salt type', () => {
-    expect(createSalt('crypt')).toEqual('/UEGzD0RxSNDZA==');
-    expect(createSalt('md5')).toEqual('$1$/UEGzD0RxSNDZA==');
-    expect(createSalt('blowfish')).toEqual('$2a$/UEGzD0RxSNDZA==');
-    expect(createSalt('sha256')).toEqual('$5$/UEGzD0RxSNDZA==');
-    expect(createSalt('sha512')).toEqual('$6$/UEGzD0RxSNDZA==');
+    expect(createSalt(EncryptionMethod.crypt)).toEqual('/U');
+    expect(createSalt(EncryptionMethod.md5)).toEqual('$1$/UEGzD0RxS');
+    expect(createSalt(EncryptionMethod.blowfish)).toEqual('$2a$/UEGzD0RxS');
+    expect(createSalt(EncryptionMethod.sha256)).toEqual('$5$/UEGzD0RxS');
+    expect(createSalt(EncryptionMethod.sha512)).toEqual('$6$/UEGzD0RxS');
   });
 
   test('should fails on unkwon type', () => {
     expect(function () {
-      createSalt('bad');
+      createSalt('bad' as any);
     }).toThrow(/Unknown salt type at crypt3.createSalt: bad/);
   });
 
   test('should generate legacy crypt salt by default', () => {
-    expect(createSalt()).toEqual(createSalt('crypt'));
+    expect(createSalt()).toEqual(createSalt(EncryptionMethod.crypt));
   });
 });

--- a/packages/core/htpasswd/tests/utils.test.ts
+++ b/packages/core/htpasswd/tests/utils.test.ts
@@ -1,5 +1,8 @@
 import crypto from 'crypto';
 
+import MockDate from 'mockdate';
+
+import { DEFAULT_BCRYPT_ROUNDS } from '../src/htpasswd';
 import {
   verifyPassword,
   lockAndRead,
@@ -7,11 +10,27 @@ import {
   addUserToHTPasswd,
   sanityCheck,
   changePasswordToHTPasswd,
-  getCryptoPassword,
+  generateHtpasswdLine,
+  HtpasswdHashAlgorithm,
 } from '../src/utils';
 
 const mockReadFile = jest.fn();
 const mockUnlockFile = jest.fn();
+
+const defaultHashConfig = {
+  algorithm: HtpasswdHashAlgorithm.bcrypt,
+  rounds: DEFAULT_BCRYPT_ROUNDS,
+};
+
+const mockTimeAndRandomBytes = () => {
+  MockDate.set('2018-01-14T11:17:40.712Z');
+  crypto.randomBytes = jest.fn(() => {
+    return {
+      toString: (): string => '$6',
+    };
+  });
+  Math.random = jest.fn(() => 0.38849);
+};
 
 jest.mock('@verdaccio/file-locking', () => ({
   readFile: () => mockReadFile(),
@@ -85,51 +104,53 @@ describe('verifyPassword', () => {
   });
 });
 
-describe('addUserToHTPasswd - crypt3', () => {
-  beforeAll(() => {
-    // @ts-ignore
-    global.Date = jest.fn(() => {
-      return {
-        parse: jest.fn(),
-        toJSON: (): string => '2018-01-14T11:17:40.712Z',
-      };
-    });
+describe('generateHtpasswdLine', () => {
+  beforeAll(mockTimeAndRandomBytes);
 
-    crypto.randomBytes = jest.fn(() => {
-      return {
-        toString: (): string => '$6',
-      };
-    });
+  const [user, passwd] = ['username', 'password'];
+
+  it('should correctly generate line for md5', () => {
+    const md5Conf = { algorithm: HtpasswdHashAlgorithm.md5 };
+    expect(generateHtpasswdLine(user, passwd, md5Conf)).toMatchSnapshot();
   });
+
+  it('should correctly generate line for sha1', () => {
+    const sha1Conf = { algorithm: HtpasswdHashAlgorithm.sha1 };
+    expect(generateHtpasswdLine(user, passwd, sha1Conf)).toMatchSnapshot();
+  });
+
+  it('should correctly generate line for crypt', () => {
+    const cryptConf = { algorithm: HtpasswdHashAlgorithm.crypt };
+    expect(generateHtpasswdLine(user, passwd, cryptConf)).toMatchSnapshot();
+  });
+
+  it('should correctly generate line for bcrypt', () => {
+    const bcryptAlgoConfig = {
+      algorithm: HtpasswdHashAlgorithm.bcrypt,
+      rounds: 2,
+    };
+    expect(generateHtpasswdLine(user, passwd, bcryptAlgoConfig)).toMatchSnapshot();
+  });
+});
+
+describe('addUserToHTPasswd - bcrypt', () => {
+  beforeAll(mockTimeAndRandomBytes);
 
   it('should add new htpasswd to the end', () => {
     const input = ['', 'username', 'password'];
-    expect(addUserToHTPasswd(input[0], input[1], input[2])).toMatchSnapshot();
+    expect(addUserToHTPasswd(input[0], input[1], input[2], defaultHashConfig)).toMatchSnapshot();
   });
 
   it('should add new htpasswd to the end in multiline input', () => {
     const body = `test1:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z
     test2:$6FrCaT/v0dwE:autocreated 2017-12-14T13:30:20.838Z`;
     const input = [body, 'username', 'password'];
-    expect(addUserToHTPasswd(input[0], input[1], input[2])).toMatchSnapshot();
+    expect(addUserToHTPasswd(input[0], input[1], input[2], defaultHashConfig)).toMatchSnapshot();
   });
 
   it('should throw an error for incorrect username with space', () => {
     const [a, b, c] = ['', 'firstname lastname', 'password'];
-    expect(() => addUserToHTPasswd(a, b, c)).toThrowErrorMatchingSnapshot();
-  });
-});
-
-// ToDo: mock crypt3 with false
-describe('addUserToHTPasswd - crypto', () => {
-  it('should create password with crypto', () => {
-    jest.resetModules();
-    jest.doMock('../src/crypt3.ts', () => false);
-    const input = ['', 'username', 'password'];
-    const utils = require('../src/utils.ts');
-    expect(utils.addUserToHTPasswd(input[0], input[1], input[2])).toEqual(
-      'username:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=:autocreated 2018-01-14T11:17:40.712Z\n'
-    );
+    expect(() => addUserToHTPasswd(a, b, c, defaultHashConfig)).toThrowErrorMatchingSnapshot();
   });
 });
 
@@ -224,7 +245,13 @@ describe('changePasswordToHTPasswd', () => {
     const body = 'test:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z';
 
     try {
-      changePasswordToHTPasswd(body, 'test', 'somerandompassword', 'newPassword');
+      changePasswordToHTPasswd(
+        body,
+        'test',
+        'somerandompassword',
+        'newPassword',
+        defaultHashConfig
+      );
     } catch (error) {
       expect(error.message).toEqual('Invalid old Password');
     }
@@ -233,38 +260,8 @@ describe('changePasswordToHTPasswd', () => {
   test('should change the password', () => {
     const body = 'root:$6qLTHoPfGLy2:autocreated 2018-08-20T13:38:12.164Z';
 
-    expect(changePasswordToHTPasswd(body, 'root', 'demo123', 'newPassword')).toMatchSnapshot();
-  });
-
-  test('should generate a different result on salt change', () => {
-    crypto.randomBytes = jest.fn(() => {
-      return {
-        toString: (): string => 'AB',
-      };
-    });
-
-    const body = 'root:$6qLTHoPfGLy2:autocreated 2018-08-20T13:38:12.164Z';
-
-    expect(changePasswordToHTPasswd(body, 'root', 'demo123', 'demo123')).toEqual(
-      'root:ABfaAAjDKIgfw:autocreated 2018-08-20T13:38:12.164Z'
-    );
-  });
-
-  test('should change the password when crypt3 is not available', () => {
-    jest.resetModules();
-    jest.doMock('../src/crypt3.ts', () => false);
-    const utils = require('../src/utils.ts');
-    const body = 'username:{SHA}W6ph5Mm5Pz8GgiULbPgzG37mj9g=:autocreated 2018-01-14T11:17:40.712Z';
-    expect(utils.changePasswordToHTPasswd(body, 'username', 'password', 'newPassword')).toEqual(
-      'username:{SHA}KD1HqTOO0RALX+Klr/LR98eZv9A=:autocreated 2018-01-14T11:17:40.712Z'
-    );
-  });
-});
-
-describe('getCryptoPassword', () => {
-  test('should return the password hash', () => {
-    const passwordHash = `{SHA}y9vkk2zovmMYTZ8uE/wkkjQ3G5o=`;
-
-    expect(getCryptoPassword('demo123')).toBe(passwordHash);
+    expect(
+      changePasswordToHTPasswd(body, 'root', 'demo123', 'newPassword', defaultHashConfig)
+    ).toMatchSnapshot();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,7 @@ importers:
     devDependencies:
       '@types/bcryptjs': 2.4.2
       '@verdaccio/types': link:../types
+      mockdate: 3.0.2
     specifiers:
       '@types/bcryptjs': ^2.4.2
       '@verdaccio/commons-api': workspace:10.0.0-alpha.3
@@ -357,6 +358,7 @@ importers:
       apache-md5: 1.1.2
       bcryptjs: 2.4.3
       http-errors: 1.8.0
+      mockdate: ^3.0.2
       unix-crypt-td-js: 1.1.4
   packages/core/local-storage:
     dependencies:
@@ -19620,6 +19622,10 @@ packages:
     hasBin: true
     resolution:
       integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+  /mockdate/3.0.2:
+    dev: true
+    resolution:
+      integrity: sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
   /modify-values/1.0.1:
     dev: true
     engines:


### PR DESCRIPTION
This PR addresses issue #1917.

Algorithms were chosen according to [this document.](https://httpd.apache.org/docs/2.4/misc/password_encryptions.html)