### PR TITLE
fix: Upgrade Node from 14.15 to 14.16 for security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.15.4-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.16.0-alpine as builder
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.verdaccio.org
@@ -23,7 +23,7 @@ RUN yarn config set npmRegistryServer $VERDACCIO_BUILD_REGISTRY && \
 
 
 
-FROM node:14.15.4-alpine
+FROM node:14.16.0-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \


### PR DESCRIPTION
Node 14.16 fixed few security vulnerabilities 
Refer - https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/