### PR TITLE
chore: fix npm version to 6 for gatsby e2e

### DIFF
--- a/.github/workflows/e2e-angular-cli-workflow.yml
+++ b/.github/workflows/e2e-angular-cli-workflow.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           node-version: 14.x
       - name: 'install latest npm'
-        run: npm i -g npm
+        run: npm i -g npm@latest-6
       - name: Install Dependencies
         run: yarn install
       - name: 'Run verdaccio in the background'

--- a/.github/workflows/e2e-gatsbyjs-cli-workflow.yml
+++ b/.github/workflows/e2e-gatsbyjs-cli-workflow.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: 14.x
       - name: 'install latest npm'
-        run: npm i -g npm
+        run: npm i -g npm@latest-6
       - name: Install Dependencies
         run: yarn install
       - name: 'Run verdaccio in the background'

--- a/.github/workflows/e2e-jest-workflow.yml
+++ b/.github/workflows/e2e-jest-workflow.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           node-version: 10.x
       - name: 'install latest npm'
-        run: npm i -g npm
+        run: npm i -g npm@latest-6
       - name: Install Dependencies
         run: yarn install
       - name: 'Run verdaccio in the background'
@@ -117,7 +117,7 @@ jobs:
         with:
           node-version: 10.x
       - name: 'install latest npm'
-        run: npm i -g npm@next-7
+        run: npm i -g npm
       - name: Install Dependencies
         run: yarn install
       - name: 'Run verdaccio in the background'


### PR DESCRIPTION
Fix CLI E2E

- Gatsby seems does not work well with npm7
- Fix npm 6 for previous versions to avoid future failures