### PR TITLE
fix: Upgrade handlebars packagee from 4.7.6 to 4.7.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dayjs": "1.10.3",
     "envinfo": "7.7.3",
     "express": "4.17.1",
-    "handlebars": "4.7.6",
+    "handlebars": "4.7.7",
     "http-errors": "1.8.0",
     "js-yaml": "3.14.1",
     "jsonwebtoken": "8.5.1",


### PR DESCRIPTION
Upgrade handlebars from 4.7.6 to 4.7.7

handlebars 4.7.6 is vulnerable to Remote Code Execution.

Link: https://snyk.io/vuln/SNYK-JS-HANDLEBARS-1056767