### PR TITLE
fix: upgrade to commander v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "3.2.0",
     "body-parser": "1.19.0",
     "bunyan": "1.8.15",
-    "commander": "3.0.2",
+    "commander": "7.2.0",
     "compression": "1.7.4",
     "cookies": "0.8.0",
     "cors": "2.8.5",

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -41,13 +41,15 @@ commander
   .version(pkgVersion)
   .parse(process.argv);
 
+const options = commander.opts();
+
 function init() {
   let verdaccioConfiguration;
   let configPathLocation;
-  const cliListener = commander.listen;
+  const cliListener = options.listen;
 
   try {
-    configPathLocation = findConfigFile(commander.config);
+    configPathLocation = findConfigFile(options.config);
     verdaccioConfiguration = parseConfigFile(configPathLocation);
     process.title = (verdaccioConfiguration.web && verdaccioConfiguration.web.title) || 'verdaccio';
 
@@ -67,7 +69,7 @@ function init() {
   }
 }
 
-if (commander.info) {
+if (options.info) {
   // eslint-disable-next-line no-console
   console.log('\nEnvironment Info:');
   (async () => {
@@ -82,9 +84,9 @@ if (commander.info) {
     console.log(data);
     process.exit(0);
   })();
-} else if (commander.args.length == 1 && !commander.config) {
+} else if (commander.args.length == 1 && !options.config) {
   // handling "verdaccio [config]" case if "-c" is missing in command line
-  commander.config = commander.args.pop();
+  options.config = commander.args.pop();
   init();
 } else if (commander.args.length !== 0) {
   commander.help();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4907,10 +4907,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:3.0.2":
-  version: 3.0.2
-  resolution: "commander@npm:3.0.2"
-  checksum: 28071a49d23606c1e31f1f275d2aac9c03833cb3442e04b798ffbcd5f7fb7a1fbfc6b5bc6a69b862df83f475378665623788118d189c254a173248c452bd77a2
+"commander@npm:7.2.0":
+  version: 7.2.0
+  resolution: "commander@npm:7.2.0"
+  checksum: bdc0eca5e25cd24af8440163d3c9a996785bbac4b49a590365699cdc1ed08cefbac8f268153208ab2bc5dc3cb1d3fb573fd1590c681e36e371342186bd331a4c
   languageName: node
   linkType: hard
 
@@ -14243,7 +14243,7 @@ typescript@3.9.9:
     body-parser: 1.19.0
     bunyan: 1.8.15
     codecov: 3.8.1
-    commander: 3.0.2
+    commander: 7.2.0
     compression: 1.7.4
     cookies: 0.8.0
     cors: 2.8.5


### PR DESCRIPTION
Commander is the library to handle the CLI, --info, --config and --help.

According this migration guide https://github.com/tj/commander.js/blob/master/CHANGELOG.md#700-2021-01-15