### PR TITLE
feat: custom protocol header

### DIFF
--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -15,7 +15,7 @@ Define a specific public url for your server, it overrules the `Host` and `X-For
 
 This is handy in such situations where a dynamic url is required.
 
-eg: 
+eg:
 
 ```
 VERDACCIO_PUBLIC_URL='https://somedomain.org';
@@ -32,4 +32,12 @@ VERDACCIO_PUBLIC_URL='https://somedomain.org/first_prefix';
 url_prefix: '/second_prefix'
 
 // url -> https://somedomain.org/second_prefix/'
+```
+
+#### VERDACCIO_FORWARDED_PROTO
+
+The default header to identify the protocol is `X-Forwarded-Proto`, but there are some environments which [uses something different](https://github.com/verdaccio/verdaccio/issues/990), to change it use the variable `VERDACCIO_FORWARDED_PROTO`
+
+```
+$ VERDACCIO_FORWARDED_PROTO=CloudFront-Forwarded-Proto verdaccio --listen 5000
 ```

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -641,7 +641,8 @@ export function getPublicUrl(url_prefix: string = '', req): string {
     if (!isHost(host)) {
       throw new Error('invalid host');
     }
-    const protocol = getWebProtocol(req.get(HEADERS.FORWARDED_PROTO), req.protocol);
+    const protoHeader = process.env.VERDACCIO_FORWARDED_PROTO ?? HEADERS.FORWARDED_PROTO;
+    const protocol = getWebProtocol(req.get(protoHeader), req.protocol);
     const combinedUrl = combineBaseUrl(protocol, host, url_prefix);
     debug('public url by request %o', combinedUrl);
     return combinedUrl;

--- a/test/unit/modules/utils/utils.spec.ts
+++ b/test/unit/modules/utils/utils.spec.ts
@@ -871,5 +871,21 @@ describe('Utilities', () => {
       expect(getPublicUrl(undefined, req)).toEqual('http://some/');
       delete process.env.VERDACCIO_PUBLIC_URL;
     });
+
+    test('with the VERDACCIO_FORWARDED_PROTO to override valid X-Forwarded-Proto https', () => {
+      process.env.VERDACCIO_FORWARDED_PROTO = 'http';
+      const req = httpMocks.createRequest({
+        method: 'GET',
+        headers: {
+          host: 'some.com',
+          'CloudFront-Forwarded-Proto': 'http',
+          [HEADERS.FORWARDED_PROTO]: 'https',
+        },
+        url: '/',
+      });
+
+      expect(getPublicUrl(undefined, req)).toEqual('http://some.com/');
+      delete process.env.VERDACCIO_FORWARDED_PROTO;
+    });
   });
 });


### PR DESCRIPTION
fix https://github.com/verdaccio/verdaccio/issues/990

#### VERDACCIO_FORWARDED_PROTO

The default header to identify the protocol is `X-Forwarded-Proto`, but there are some environments which [uses something different](https://github.com/verdaccio/verdaccio/issues/990), to change it use the variable `VERDACCIO_FORWARDED_PROTO`

```
$ VERDACCIO_FORWARDED_PROTO=CloudFront-Forwarded-Proto verdaccio --listen 5000
```