### PR TITLE
fix: ui readme missing css

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@verdaccio/local-storage": "10.0.1",
     "@verdaccio/readme": "10.0.0",
     "@verdaccio/streams": "10.0.0",
-    "@verdaccio/ui-theme": "3.0.0",
+    "@verdaccio/ui-theme": "3.0.1",
     "JSONStream": "1.3.5",
     "async": "3.2.0",
     "body-parser": "1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,10 +3326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@verdaccio/ui-theme@npm:3.0.0":
-  version: 3.0.0
-  resolution: "@verdaccio/ui-theme@npm:3.0.0"
-  checksum: a78252728755bec9f561048f5f70eb22967c4dea824736d1cbe0d3baf0cbf02e264234ce7e3d1c0f427d6010107a0b68193e6c9020459f07d123a7cf90ebeb75
+"@verdaccio/ui-theme@npm:3.0.1":
+  version: 3.0.1
+  resolution: "@verdaccio/ui-theme@npm:3.0.1"
+  checksum: c50cba018e3d63823f97bd4b982c24dbeb9087ebbe4843b4034727a420b2b6992c83245a590fe1dfa7608255048b590565ab9b67600e9051e9bac7aa00098d1a
   languageName: node
   linkType: hard
 
@@ -14255,7 +14255,7 @@ typescript@4.1.3:
     "@verdaccio/readme": 10.0.0
     "@verdaccio/streams": 10.0.0
     "@verdaccio/types": ^9.7.2
-    "@verdaccio/ui-theme": 3.0.0
+    "@verdaccio/ui-theme": 3.0.1
     JSONStream: 1.3.5
     all-contributors-cli: 6.20.0
     async: 3.2.0


### PR DESCRIPTION
Fix broken CSS ok README section at UI

<img width="1094" alt="Screenshot 2021-04-08 at 22 07 20" src="https://user-images.githubusercontent.com/558752/114089748-d205d700-98b6-11eb-9c29-787aa1bfb51f.png">


Version: v5 alpha