### PR TITLE
fix: incorrect sanity check for theme plugin

### DIFF
--- a/src/api/web/index.ts
+++ b/src/api/web/index.ts
@@ -19,7 +19,7 @@ export function loadTheme(config) {
         config.theme,
         {},
         function (plugin) {
-          return _.isString(plugin);
+          return plugin.staticPath && plugin.manifest && plugin.manifestFiles;
         },
         'verdaccio-theme'
       )


### PR DESCRIPTION
Custom themes can't be loaded correctly since this [PR](https://github.com/verdaccio/verdaccio/pull/2122
) modified the value of theme plugin.
```
UnhandledPromiseRejectionWarning: Error: sanity check has failed, "xxx" is not a valid plugin
```
```
let { staticPath, manifest, manifestFiles } = loadTheme(config) || require('@verdaccio/ui-theme')();
```