### PR TITLE
fix: update @verdaccio/ui-theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@verdaccio/local-storage": "10.0.1",
     "@verdaccio/readme": "10.0.0",
     "@verdaccio/streams": "10.0.0",
-    "@verdaccio/ui-theme": "3.0.1",
+    "@verdaccio/ui-theme": "3.1.0",
     "JSONStream": "1.3.5",
     "async": "3.2.0",
     "body-parser": "1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3326,10 +3326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@verdaccio/ui-theme@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@verdaccio/ui-theme@npm:3.0.1"
-  checksum: c50cba018e3d63823f97bd4b982c24dbeb9087ebbe4843b4034727a420b2b6992c83245a590fe1dfa7608255048b590565ab9b67600e9051e9bac7aa00098d1a
+"@verdaccio/ui-theme@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@verdaccio/ui-theme@npm:3.1.0"
+  checksum: f6371875fa14cf149c91589deed9ab1527c74eec9619fa8dd5ae8eafedeff61714ab89236f3cf4be531b23e900a281ea1b5483c608431d02aa871c230958e447
   languageName: node
   linkType: hard
 
@@ -14255,7 +14255,7 @@ typescript@4.1.3:
     "@verdaccio/readme": 10.0.0
     "@verdaccio/streams": 10.0.0
     "@verdaccio/types": ^9.7.2
-    "@verdaccio/ui-theme": 3.0.1
+    "@verdaccio/ui-theme": 3.1.0
     JSONStream: 1.3.5
     all-contributors-cli: 6.20.0
     async: 3.2.0


### PR DESCRIPTION
## [3.1.0](https://github.com/verdaccio/ui/compare/v3.0.1...v3.1.0) (2021-04-27)


### Features

* expand allowed protocols for URLs in repository component ([#412](https://github.com/verdaccio/ui/issues/412)) ([b0c5bf8](https://github.com/verdaccio/ui/commit/b0c5bf8556188d5fbaa3f225d4819c3a68e68d59))
* update dependencies ([#615](https://github.com/verdaccio/ui/issues/615)) ([227e8a0](https://github.com/verdaccio/ui/commit/227e8a04db47c530cfe3f8f13ba3db9a2806bf21))


### Bug Fixes

* markdown lists don't render bullet points ([#614](https://github.com/verdaccio/ui/issues/614)) ([990f749](https://github.com/verdaccio/ui/commit/990f749f984a9aa440f75d36a945a2487798e43e))
* package detail sidebar overflow ([#613](https://github.com/verdaccio/ui/issues/613)) ([c12f18f](https://github.com/verdaccio/ui/commit/c12f18feea69b597def802e11369ca91924a8621))