### PR TITLE
docs: Fix README.md install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Google Cloud Storage** or create your own plugin.
 Install with npm:
 
 ```bash
-npm install --global verdaccio@6-next --https://registry.verdaccio.org/
+npm install --global verdaccio@6-next --registry https://registry.verdaccio.org/
 ```
 
 > Published on a temporary registry while setup is ready to publish on npmjs


### PR DESCRIPTION
**Type:** docs

Fixed bash command to install verdaccio in the main README.md.

**Description:**

The original bash command to install verdaccio didn't work:
```bash
npm install --global verdaccio@6-next --https://registry.verdaccio.org/
```

The command should be with the registry scope options:
```bash
npm install --global verdaccio@6-next --registry https://registry.verdaccio.org/
```