### PR TITLE
Fix the prefix used to delete from s3 when unpublishing packages

### DIFF
--- a/.changeset/calm-pants-impress.md
+++ b/.changeset/calm-pants-impress.md
@@ -1,0 +1,5 @@
+---
+'verdaccio-aws-s3-storage': patch
+---
+
+Fix the prefix used to delete from s3 when unpublishing packages

--- a/packages/plugins/aws-storage/src/s3PackageManager.ts
+++ b/packages/plugins/aws-storage/src/s3PackageManager.ts
@@ -172,7 +172,7 @@ export default class S3PackageManager implements ILocalPackageManager {
       this.s3,
       {
         Bucket: this.config.bucket,
-        Prefix: `${this.packagePath}`,
+        Prefix: addTrailingSlash(this.packagePath),
       },
       function (err) {
         if (err && is404Error(err as VerdaccioError)) {

--- a/packages/plugins/aws-storage/tests/s3PackageManagerMockedS3.test.ts
+++ b/packages/plugins/aws-storage/tests/s3PackageManagerMockedS3.test.ts
@@ -231,7 +231,7 @@ describe('S3PackageManager with mocked s3', function () {
       expect(mockListObject).toHaveBeenCalledWith(
         {
           Bucket: 'test-bucket',
-          Prefix: 'testKeyPrefix/@company/test-package',
+          Prefix: 'testKeyPrefix/@company/test-package/',
         },
         expect.any(Function)
       );
@@ -270,7 +270,7 @@ describe('S3PackageManager with mocked s3', function () {
       expect(mockListObject).toHaveBeenCalledWith(
         {
           Bucket: 'test-bucket',
-          Prefix: 'testKeyPrefix/customFolder/@company/test-package',
+          Prefix: 'testKeyPrefix/customFolder/@company/test-package/',
         },
         expect.any(Function)
       );


### PR DESCRIPTION
Hi, this PR resolves #1984

##### Description

The `npm unpublish` operation was removing more packages than it should.

This was happening because of a missing trailing slash at the prefix param.