### PR TITLE
fix(docker): add permissions to config and plugins folder to the $VERDACCIO_USER_UID user

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,6 +14,7 @@ on:
       - '.yarn/**'
       - '.yarnrc.yaml'
       - '.pnp.js'
+      - 'Dockerfile'
     branches:
       - '**'
     tags:

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,8 @@ ADD conf/docker.yaml /verdaccio/conf/config.yaml
 RUN adduser -u $VERDACCIO_USER_UID -S -D -h $VERDACCIO_APPDIR -g "$VERDACCIO_USER_NAME user" -s /sbin/nologin $VERDACCIO_USER_NAME && \
     chmod -R +x $VERDACCIO_APPDIR/bin $VERDACCIO_APPDIR/docker-bin && \
     chown -R $VERDACCIO_USER_UID:root /verdaccio/storage && \
+    chown -R $VERDACCIO_USER_UID:root /verdaccio/conf && \
+    chown -R $VERDACCIO_USER_UID:root /verdaccio/plugins && \
     chmod -R g=u /verdaccio/storage /etc/passwd
 
 USER $VERDACCIO_USER_UID


### PR DESCRIPTION
- Apply permissions for`/verdaccio/conf` and ` /verdaccio/plugins ` to the $VERDACCIO_USER_UID user
```
    chown -R $VERDACCIO_USER_UID:root /verdaccio/conf && \
    chown -R $VERDACCIO_USER_UID:root /verdaccio/plugins && \
```

fix https://github.com/verdaccio/verdaccio/issues/2196