### PR TITLE
chore: replace node-fetch by undici hook package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        node_version: [12, 14]
+        node_version: [14]
     name: ${{ matrix.os }} / Node ${{ matrix.node_version }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -140,9 +140,6 @@ jobs:
         run: pnpm recursive install --frozen-lockfile --ignore-scripts 
       - name: Test
         run: pnpm test
-        env: 
-          # just for Node.js 12 temporary until remove v12 support.
-          NODE_OPTIONS: --experimental-vm-modules
   ci-e2e-ui:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   test:
     needs: build
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node_version: [12, 14]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,12 +170,12 @@ jobs:
   ci-e2e-cli:
     needs: build
     runs-on: ubuntu-latest
-    name: CLI Test E2E Node 14
+    name: CLI Test E2E Node 12
     steps:
       - uses: actions/checkout@v2.3.1
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 12
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
   test:
     needs: build
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest]
         node_version: [12, 14]
@@ -141,6 +141,7 @@ jobs:
       - name: Test
         run: pnpm test
         env: 
+          # just for Node.js 12 temporary until remove v12 support.
           NODE_OPTIONS: --experimental-vm-modules
   ci-e2e-ui:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
         run: pnpm recursive install --frozen-lockfile --ignore-scripts 
       - name: Test
         run: pnpm test
+        env: 
+          NODE_OPTIONS: --experimental-vm-modules
   ci-e2e-ui:
     needs: build
     runs-on: ubuntu-latest
@@ -170,12 +172,12 @@ jobs:
   ci-e2e-cli:
     needs: build
     runs-on: ubuntu-latest
-    name: CLI Test E2E Node 12
+    name: CLI Test E2E Node 14
     steps:
       - uses: actions/checkout@v2.3.1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-artifact

--- a/packages/hooks/jest.config.js
+++ b/packages/hooks/jest.config.js
@@ -1,3 +1,5 @@
 const config = require('../../jest/config');
 
-module.exports = Object.assign({}, config, {});
+module.exports = Object.assign({}, config, {
+  testEnvironment: 'node',
+});

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=12",
     "npm": ">=6"
   },
   "dependencies": {
@@ -34,15 +34,14 @@
     "@verdaccio/logger": "workspace:6.0.0-6-next.4",
     "debug": "^4.2.0",
     "handlebars": "4.5.3",
-    "node-fetch": "^2.6.1",
-    "request": "2.87.0"
+    "undici": "^4.0.0-rc.1",
+    "undici-fetch": "^1.0.0-rc.1"
   },
   "devDependencies": {
     "@verdaccio/auth": "workspace:6.0.0-6-next.9",
     "@verdaccio/commons-api": "workspace:11.0.0-alpha.3",
     "@verdaccio/config": "workspace:6.0.0-6-next.7",
-    "@verdaccio/types": "workspace:11.0.0-6-next.7",
-    "nock": "^13.0.4"
+    "@verdaccio/types": "workspace:11.0.0-6-next.7"
   },
   "scripts": {
     "clean": "rimraf ./build",

--- a/packages/hooks/src/notify-request.ts
+++ b/packages/hooks/src/notify-request.ts
@@ -1,13 +1,12 @@
-import fetch, { RequestInit } from 'node-fetch';
 import buildDebug from 'debug';
 
 import { logger } from '@verdaccio/logger';
 import { HTTP_STATUS } from '@verdaccio/commons-api';
 
 const debug = buildDebug('verdaccio:hooks:request');
-export type NotifyRequestOptions = RequestInit;
+const fetch = require('undici-fetch');
 
-export async function notifyRequest(url: string, options: NotifyRequestOptions): Promise<boolean> {
+export async function notifyRequest(url: string, options: any): Promise<boolean> {
   let response;
   try {
     debug('uri %o', url);

--- a/packages/hooks/src/notify-request.ts
+++ b/packages/hooks/src/notify-request.ts
@@ -6,7 +6,13 @@ import { HTTP_STATUS } from '@verdaccio/commons-api';
 const debug = buildDebug('verdaccio:hooks:request');
 const fetch = require('undici-fetch');
 
-export async function notifyRequest(url: string, options: any): Promise<boolean> {
+export type FetchOptions = {
+  body: string;
+  headers?: {};
+  method?: string;
+};
+
+export async function notifyRequest(url: string, options: FetchOptions): Promise<boolean> {
   let response;
   try {
     debug('uri %o', url);

--- a/packages/hooks/src/notify.ts
+++ b/packages/hooks/src/notify.ts
@@ -5,7 +5,7 @@ import Handlebars from 'handlebars';
 import buildDebug from 'debug';
 import { Config, Package, RemoteUser, Notification } from '@verdaccio/types';
 import { logger } from '@verdaccio/logger';
-import { notifyRequest, NotifyRequestOptions } from './notify-request';
+import { notifyRequest, FetchOptions } from './notify-request';
 
 const debug = buildDebug('verdaccio:hooks');
 
@@ -50,7 +50,7 @@ export async function handleNotify(
     content = await compileTemplate(notifyEntry.content, metadata);
   }
 
-  const options: NotifyRequestOptions = {
+  const options: FetchOptions = {
     body: JSON.stringify(content),
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -504,21 +504,19 @@ importers:
       '@verdaccio/types': workspace:11.0.0-6-next.7
       debug: ^4.2.0
       handlebars: 4.5.3
-      nock: ^13.0.4
-      node-fetch: ^2.6.1
-      request: 2.87.0
+      undici: ^4.0.0-rc.1
+      undici-fetch: ^1.0.0-rc.1
     dependencies:
       '@verdaccio/commons-api': link:../core/commons-api
       '@verdaccio/logger': link:../logger
       debug: 4.2.0
       handlebars: 4.5.3
-      node-fetch: 2.6.1
-      request: 2.87.0
+      undici: 4.0.0-rc.7
+      undici-fetch: 1.0.0-rc.1
     devDependencies:
       '@verdaccio/auth': link:../auth
       '@verdaccio/config': link:../config
       '@verdaccio/types': link:../core/types
-      nock: 13.0.4
 
   packages/loaders:
     specifiers:
@@ -13500,16 +13498,6 @@ packages:
       - supports-color
     dev: true
 
-  /nock/13.0.4:
-    resolution: {integrity: sha512-alqTV8Qt7TUbc74x1pKRLSENzfjp4nywovcJgi/1aXDiUxXdt7TkruSTF5MDWPP7UoPVgea4F9ghVdmX0xxnSA==}
-    engines: {node: '>= 10.13'}
-    dependencies:
-      debug: 4.1.1
-      json-stringify-safe: 5.0.1
-      lodash.set: 4.3.2
-      propagate: 2.0.1
-    dev: true
-
   /node-abi/2.19.1:
     resolution: {integrity: sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==}
     dependencies:
@@ -18094,6 +18082,17 @@ packages:
     dependencies:
       debug: 2.6.9
     dev: true
+
+  /undici-fetch/1.0.0-rc.1:
+    resolution: {integrity: sha512-VPMBog6ke/hSABltjVrcq+xc0RSnqfgmufn+5hfKBoIEJJq5nkKWQcWzW/uGlesSC2eKFQ6sPCQesFc7LfqGAg==}
+    dependencies:
+      undici: 4.0.0-rc.7
+    dev: false
+
+  /undici/4.0.0-rc.7:
+    resolution: {integrity: sha512-8vhF9REAH/O+eGh1K942bTznr47JOZHlHMTh9/5XiJvcBk3GqV2qzeRPxwDfAeHNWjm1BZ4EsSgAotHV2EOxeA==}
+    engines: {node: '>=12.18'}
+    dev: false
 
   /unicode-canonical-property-names-ecmascript/1.0.4:
     resolution: {integrity: sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==}


### PR DESCRIPTION
- Learning using `undici` / `undici-fetch` by replacing `node-fetch` on small package.
- Replace `nock` on that package by built in mock client.

https://undici.nodejs.org/#/docs/api/MockPool?id=mockpoolclose
https://undici-fetch.dev/#/

Refers: https://github.com/verdaccio/verdaccio/issues/1807

⚠️ `undify-fetch` target Node.js 14 as minimum, disable test on Node v12 (will be completely deprecated in a follow up). 