### PR TITLE
fix: remove token experiment flag

### DIFF
--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -15,13 +15,7 @@ import profile from './api/v1/profile';
 import token from './api/v1/token';
 import v1Search from './api/v1/search';
 
-const {
-  match,
-  validateName,
-  validatePackage,
-  encodeScopePackage,
-  antiLoop
-} = require('../middleware');
+const { match, validateName, validatePackage, encodeScopePackage, antiLoop } = require('../middleware');
 
 export default function (config: Config, auth: IAuth, storage: IStorageHandler) {
   /* eslint new-cap:off */
@@ -58,8 +52,6 @@ export default function (config: Config, auth: IAuth, storage: IStorageHandler) 
   ping(app);
   stars(app, storage);
   v1Search(app, auth, storage);
-  if (_.get(config, 'experiments.token') === true) {
-    token(app, auth, storage, config);
-  }
+  token(app, auth, storage, config);
   return app;
 }


### PR DESCRIPTION
Over the chat was reported the `npm token` was giving 404.
https://discordapp.com/channels/388674437219745793/388675051710447616/864052734457937962

It was forgotten remove the experiment flag.