### PR TITLE
fix: add contextualSearch to Algolia Search

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -61,7 +61,8 @@ module.exports = {
     },
     algolia: {
       apiKey: 'a8b4d117e513cd8d71d6a95e3d9d4a91',
-      indexName: 'verdaccio'
+      indexName: 'verdaccio',
+      contextualSearch: true
     },
     googleAnalytics: isProductionDeployment ? {
       trackingID: 'UA-2527438-21'


### PR DESCRIPTION
This fixes the issue of displaying results in the search bar that doesn't correspond to the current locale.

If you're in x/es-es/, will return the results from es-es