### PR TITLE
Fix broken Docker Example Links

### DIFF
--- a/docker-examples/v4/README.md
+++ b/docker-examples/v4/README.md
@@ -2,23 +2,23 @@
 
 #### Proxies
 
-- [Docker + Apache + Verdaccio](v4/apache-verdaccio/README.md)
-- [Docker + Nginx + Verdaccio](v4/reverse_proxy/nginx/README.md)
-- [Docker + https-portal Example](v4/https-portal-example/README.md)
+- [Docker + Apache + Verdaccio](apache-verdaccio/README.md)
+- [Docker + Nginx + Verdaccio](reverse_proxy/nginx/README.md)
+- [Docker + https-portal Example](https-portal-example/README.md)
 
 #### Plugins
 
-- [Docker + Uplinks Multi Registry](v4/multi-registry-uplink/README.md)
-- [Docker + Local Storage](v4/docker-local-storage-volume/readme.md)
-- [Docker + External Plugins](v4/docker-plugin-external/README.md)
+- [Docker + Uplinks Multi Registry](multi-registry-uplink/README.md)
+- [Docker + Local Storage](docker-local-storage-volume/readme.md)
+- [Docker + External Plugins](docker-plugin-external/README.md)
 
 #### Auth
 
-- [Docker + LDAP (OpenLDAP) Server + Verdaccio 4](v4/ldap-verdaccio/readme.md) by **@kopax**
+- [Docker + LDAP (OpenLDAP) Server + Verdaccio 4](ldap-verdaccio/readme.md) by **@kopax**
 - [Docker + Gitlab](gitlab-verdaccio/README.md)
 - [Docker + Active Directory](https://github.com/Mateus-Oli/verdaccio-ad-docker)
 
 #### Storage
 
-- [Docker + AWS S3 Plugin(localstack) + Verdaccio 4](v4/amazon-s3-docker-example/v4/README.md)
+- [Docker + AWS S3 Plugin(localstack) + Verdaccio 4](amazon-s3-docker-example/v4/README.md)
 - [Docker + Minio](https://github.com/barolab/verdaccio-minio/tree/master/example)

--- a/docker-examples/v4/README.md
+++ b/docker-examples/v4/README.md
@@ -20,5 +20,5 @@
 
 #### Storage
 
-- [Docker + AWS S3 Plugin(localstack) + Verdaccio 4](amazon-s3-docker-example/v4/README.md)
+- [Docker + AWS S3 Plugin(localstack) + Verdaccio 4](amazon-s3-docker-example/README.md)
 - [Docker + Minio](https://github.com/barolab/verdaccio-minio/tree/master/example)


### PR DESCRIPTION
Some of the links in the readme are broken because of the `v4` prefix.
This PR fixes these links.