### PR TITLE
fix: resolves several issues of audit plugin

### DIFF
--- a/.changeset/little-stingrays-rule.md
+++ b/.changeset/little-stingrays-rule.md
@@ -1,0 +1,5 @@
+---
+'verdaccio-audit': patch
+---
+
+fix: several issues which caused the audit to fail (#2335)


### PR DESCRIPTION
In an effort to fix #2335 I found some issues with the audit plugin. With these changes, `npm audit` works again (tested locally against `npm@6.14.12`, `npm@6.14.15` and `npm@7.21.0`). 

* fixes an ssl error by correcting the host header
* fixes an `413 - entity too large` / `400 -Invalid compressed payload` error by
  explicitly setting the content-encoding header
* sends json body to remote registry
* adds new `/advisories/bulk` endpoint
* respects `strict_ssl` setting

I also added some logging output in case the audit fails.