### PR TITLE
feat: fastify search endpoint v1 without auth and format

### DIFF
--- a/packages/core/server/src/endpoints/search.ts
+++ b/packages/core/server/src/endpoints/search.ts
@@ -3,12 +3,22 @@
 import { logger } from '@verdaccio/logger';
 
 async function searchRoute(fastify) {
-  fastify.get('/-/v1/search', async () => {
+  fastify.get('/-/v1/search', async (request, reply) => {
+    // TODO: apply security layer here like in
+    // packages/api/src/v1/search.ts
+    // TODO: add validations for query, some parameters are mandatory
+    // TODO: review which query fields are mandatory
+
+    const { url, query } = request;
+    const storage = fastify.storage;
+
+    const data = await storage.searchManager?.search({
+      query: query,
+      url: url,
+    });
+
     logger.http('search endpoint');
-    // @ts-ignore
-    console.log('-storage->', fastify.storage);
-    console.log('-config->', fastify.config);
-    return {};
+    reply.code(200).send(data);
   });
 }
 


### PR DESCRIPTION
Add some logic for the npm search fastify endpoint, not enough to make it work with `npm search`

```
npm debug -- new
curl http://localhost:4873/-/v1/search?text=npm7&size=2000&from=0&quality=1&popularity=0.1&maintenance=0.1
```