### PR TITLE
Updated config map param name in helm example

### DIFF
--- a/website/docs/kubernetes.md
+++ b/website/docs/kubernetes.md
@@ -99,7 +99,7 @@ Now you can deploy the Verdaccio Helm chart and specify which configuration to
 use:
 
 ```bash
-helm install npm --set customConfigMap=verdaccio-config verdaccio/verdaccio
+helm install npm --set existingConfigMap=verdaccio-config verdaccio/verdaccio
 ```
 
 #### NGINX proxy body-size limit {#nginx-proxy-body-size-limit}


### PR DESCRIPTION
The config map parameter is now called "existingConfigMap", using this value worked when I installed the helm chart today. 
When using customConfigMap as per this example, the install worked but the default internal config map was used instead.