### PR TITLE
Upgrade to husky@7.0.2

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+#./node_modules/.bin/lint-staged
+npm run husky:pre-commit

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "detect-secrets": "1.0.6",
     "eslint": "7.32.0",
     "fs-extra": "10.0.0",
-    "husky": "4.3.5",
+    "husky": "7.0.2",
     "in-publish": "2.0.1",
     "jest": "27.1.0",
     "jest-environment-jsdom": "27.1.0",
@@ -107,6 +107,7 @@
     "verdaccio-memory": "workspace:*"
   },
   "scripts": {
+    "husky:pre-commit": "lint-staged",
     "clean": "pnpm recursive run clean",
     "build": "pnpm recursive run build --filter=!@verdaccio/website",
     "docker": "docker build -t verdaccio/verdaccio:local . --no-cache",
@@ -138,14 +139,10 @@
     "website": "pnpm build --filter ...@verdaccio/website",
     "crowdin:upload": "crowdin upload sources --auto-update --config ./crowdin.yaml",
     "crowdin:download": "crowdin download --config ./crowdin.yaml",
-    "crowdin:sync": "pnpm crowdin:upload && pnpm crowdin:download --verbose"
+    "crowdin:sync": "pnpm crowdin:upload && pnpm crowdin:download --verbose",
+    "postinstall": "husky install"
   },
   "license": "MIT",
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,yml,yaml,md}": "prettier --write",
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
       detect-secrets: 1.0.6
       eslint: 7.32.0
       fs-extra: 10.0.0
-      husky: 4.3.5
+      husky: 7.0.2
       in-publish: 2.0.1
       jest: 27.1.0
       jest-environment-jsdom: 27.1.0
@@ -159,7 +159,7 @@ importers:
       detect-secrets: 1.0.6
       eslint: 7.32.0
       fs-extra: 10.0.0
-      husky: 4.3.5
+      husky: 7.0.2
       in-publish: 2.0.1
       jest: 27.1.0_ts-node@10.2.1
       jest-environment-jsdom: 27.1.0
@@ -6559,6 +6559,7 @@ packages:
 
   /@types/yauzl/2.9.1:
     resolution: {integrity: sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==}
+    requiresBuild: true
     dependencies:
       '@types/node': 15.12.4
     dev: true
@@ -8697,6 +8698,7 @@ packages:
   /colors/1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
     engines: {node: '>=0.1.90'}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -8748,10 +8750,6 @@ packages:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
-    dev: true
-
-  /compare-versions/3.6.0:
-    resolution: {integrity: sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==}
     dev: true
 
   /component-emitter/1.3.0:
@@ -10945,6 +10943,7 @@ packages:
   /fast-crc32c/1.0.4:
     resolution: {integrity: sha1-qLVm6aouI7a0EWzz2NB/X1ItVOM=}
     engines: {node: '>= 0.10.0'}
+    requiresBuild: true
     optionalDependencies:
       sse4_crc32: 5.4.0
     dev: false
@@ -11148,6 +11147,7 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     optional: true
 
   /filesize/3.6.1:
@@ -11242,13 +11242,6 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-
-  /find-versions/3.2.0:
-    resolution: {integrity: sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==}
-    engines: {node: '>=6'}
-    dependencies:
-      semver-regex: 2.0.0
-    dev: true
 
   /find-yarn-workspace-root2/1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
@@ -11446,6 +11439,7 @@ packages:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+    requiresBuild: true
     optional: true
 
   /function-bind/1.1.1:
@@ -12409,22 +12403,10 @@ packages:
     resolution: {integrity: sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ=}
     dev: true
 
-  /husky/4.3.5:
-    resolution: {integrity: sha512-E5S/1HMoDDaqsH8kDF5zeKEQbYqe3wL9zJDyqyYqc8I4vHBtAoxkDBGXox0lZ9RI+k5GyB728vZdmnM4bYap+g==}
-    engines: {node: '>=10'}
+  /husky/7.0.2:
+    resolution: {integrity: sha512-8yKEWNX4z2YsofXAMT7KvA1g8p+GxtB1ffV8XtpAEGuXNAbCV5wdNKH+qTpw8SM9fh4aMPDR+yQuKfgnreyZlg==}
+    engines: {node: '>=12'}
     hasBin: true
-    requiresBuild: true
-    dependencies:
-      chalk: 4.1.1
-      ci-info: 2.0.0
-      compare-versions: 3.6.0
-      cosmiconfig: 7.0.0
-      find-versions: 3.2.0
-      opencollective-postinstall: 2.0.3
-      pkg-dir: 4.2.0
-      please-upgrade-node: 3.2.0
-      slash: 3.0.0
-      which-pm-runs: 1.0.0
     dev: true
 
   /hyperid/2.1.0:
@@ -15641,11 +15623,6 @@ packages:
       is-wsl: 2.2.0
     dev: false
 
-  /opencollective-postinstall/2.0.3:
-    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
-    hasBin: true
-    dev: true
-
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
@@ -18213,11 +18190,6 @@ packages:
     dependencies:
       semver: 6.3.0
 
-  /semver-regex/2.0.0:
-    resolution: {integrity: sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==}
-    engines: {node: '>=6'}
-    dev: true
-
   /semver-store/0.3.0:
     resolution: {integrity: sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==}
 
@@ -19881,6 +19853,7 @@ packages:
     resolution: {integrity: sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+    requiresBuild: true
     optional: true
 
   /unbox-primitive/1.0.1:


### PR DESCRIPTION
This PR upgrades `husky` to `v7.0.2` in the `devDependencies` of the root `package.json`.

The only git commit hook that husky is using is currently using is `pre-commit` which is responsible for invoking `lint-staged`.

To make this upgrade work a `postinstall` script has also been added to invoke `husky install` which is more-or-less what the Husky v7 docs indicate.

As a result a new `.husky` directory in introduced at the same level as the `.git` directory and git is configured with `[core]` property `hooksPath = .husky`.

The pre-commit shell script in the new `.husky` directory uses `npm` to run the new `husky:pre-commit` script in the root `package.json`.

That's all Folks! (tm) Looney Tunes & Bugs Bunny