### PR TITLE
fix: do not throw multiple logger deprecation warning if using default logger config

### DIFF
--- a/.changeset/shaggy-carrots-unite.md
+++ b/.changeset/shaggy-carrots-unite.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/logger': patch
+---
+
+do not show deprecation warning on default logger config

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -98,7 +98,7 @@ export type LoggerConfigItem = {
 
 export type LoggerConfig = LoggerConfigItem[];
 
-export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER_CONF]) {
+export function setup(options: LoggerConfig | LoggerConfigItem = DEFAULT_LOGGER_CONF) {
   debug('setup logger');
   const isLegacyConf = Array.isArray(options);
   if (isLegacyConf) {

--- a/packages/logger/test/logger.spec.ts
+++ b/packages/logger/test/logger.spec.ts
@@ -13,4 +13,29 @@ describe('logger', () => {
     // FIXME: check expect
     // expect(spyOn).toHaveBeenCalledTimes(2);
   });
+
+  test('throw deprecation warning if multiple loggers configured', () => {
+    const spy = jest.spyOn(process, 'emitWarning');
+    setup([
+      {
+        level: 'info',
+      },
+      {
+        level: 'http',
+      },
+    ]);
+    expect(spy).toHaveBeenCalledWith(
+      'deprecate: multiple logger configuration is deprecated, please check the migration guide.'
+    );
+    spy.mockRestore();
+  });
+
+  test('regression: do not throw deprecation warning if no logger config is provided', () => {
+    const spy = jest.spyOn(process, 'emitWarning');
+    setup();
+    expect(spy).not.toHaveBeenCalledWith(
+      'deprecate: multiple logger configuration is deprecated, please check the migration guide.'
+    );
+    spy.mockRestore();
+  });
 });


### PR DESCRIPTION
fixes: #2300

changes default logger from `[DEFAULT_LOGGER_CONF]` to `DEFAULT_LOGGER_CONF` in logger setup to fix the multiple logger deprecation warning thrown when not providing any logger configs in setup call