### PR TITLE
ci: avoid crowdin step is mandatory

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -46,7 +46,12 @@ jobs:
         run: pnpm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_AUTH_TOKEN }}
-
+      - name: crowdin download
+        env:
+          CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
+          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
+          CONTEXT: production
+        run: pnpm crowdin:download       
       - name: build
         run: pnpm build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: crowdin download
         env:
           CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
-          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
+          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY___ }}
           CONTEXT: production
         run: pnpm crowdin:download
         ## this step is optional, translations are not mandatory for PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
           CONTEXT: production
         run: pnpm crowdin:download
         ## this step is optional, translations are not mandatory for PR
-        ## secrets keys are not accesible on PR, the failure here is guaranteed
+        ## secrets keys are not available on forks, the failure here is guaranteed
         if: success() || failure()     
       - name: build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
           CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
           CONTEXT: production
         run: pnpm crowdin:download
+        ## this step is optional, translations are not mandatory for PR
+        ## secrets keys are not accesible on PR, the failure here is guaranteed
         if: success() || failure()     
       - name: build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         if: always()
         env:
           CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
-          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
+          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY____ }}
           CONTEXT: production
         run: pnpm crowdin:download        
       - name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: crowdin download
         env:
           CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
-          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY___ }}
+          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
           CONTEXT: production
         run: pnpm crowdin:download
         ## this step is optional, translations are not mandatory for PR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,32 @@ jobs:
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: Lint
         run: pnpm format:check
-
+  crowdin:
+      runs-on: ubuntu-latest
+      ## forks cannot access to crowdin secrets
+      if: always()      
+      name: Format
+      needs: [format, lint]
+      steps:
+        - uses: actions/checkout@v2.3.1
+        - name: Use Node 16
+          uses: actions/setup-node@v1
+          with:
+            node-version: 16
+        - name: Install pnpm
+          run: npm i pnpm@6.10.3 -g
+        - uses: actions/cache@v2
+          with:
+            path: ~/.pnpm-store
+            key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}     
+        - name: Install
+          run: pnpm recursive install --frozen-lockfile --ignore-scripts
+        - name: crowdin download
+          env:
+            CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
+            CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
+            CONTEXT: production
+          run: pnpm crowdin:download        
   build:
     runs-on: ubuntu-latest
     name: build
@@ -102,14 +127,6 @@ jobs:
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}     
       - name: Install
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
-      - name: crowdin download
-        ## forks cannot access to crowdin secrets
-        if: always()
-        env:
-          CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
-          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY____ }}
-          CONTEXT: production
-        run: pnpm crowdin:download        
       - name: build
         run: pnpm build
       - name: tar packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,35 +83,7 @@ jobs:
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: Lint
         run: pnpm format:check
-  # this step is need it to include translations to the project
-  # but if fails is ok, project should build anyway but throw warnings the
-  # language could not be found and fallback to the default (english)
-  crowdin:
-      runs-on: ubuntu-latest
-      ## forks cannot access to crowdin secrets
-      if: always()      
-      name: crowdin
-      needs: [prepare]
-      steps:
-        - uses: actions/checkout@v2.3.1
-        - name: Use Node 16
-          uses: actions/setup-node@v1
-          with:
-            node-version: 16
-        - name: Install pnpm
-          run: npm i pnpm@6.10.3 -g
-        - uses: actions/cache@v2
-          with:
-            path: ~/.pnpm-store
-            key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}     
-        - name: Install
-          run: pnpm recursive install --frozen-lockfile --ignore-scripts
-        - name: crowdin download
-          env:
-            CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
-            CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY__ }}
-            CONTEXT: production
-          run: pnpm crowdin:download        
+
   build:
     runs-on: ubuntu-latest
     name: build
@@ -130,6 +102,13 @@ jobs:
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}     
       - name: Install
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
+      - name: crowdin download
+        env:
+          CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
+          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
+          CONTEXT: production
+        run: pnpm crowdin:download
+        if: success() || failure()     
       - name: build
         run: pnpm build
       - name: tar packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,12 +83,15 @@ jobs:
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: Lint
         run: pnpm format:check
+  # this step is need it to include translations to the project
+  # but if fails is ok, project should build anyway but throw warnings the
+  # language could not be found and fallback to the default (english)
   crowdin:
       runs-on: ubuntu-latest
       ## forks cannot access to crowdin secrets
       if: always()      
-      name: Format
-      needs: [format, lint]
+      name: crowdin
+      needs: [prepare]
       steps:
         - uses: actions/checkout@v2.3.1
         - name: Use Node 16
@@ -106,7 +109,7 @@ jobs:
         - name: crowdin download
           env:
             CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
-            CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
+            CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY__ }}
             CONTEXT: production
           run: pnpm crowdin:download        
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: crowdin download
         env:
           CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
-          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
+          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY__ }}
           CONTEXT: production
         run: pnpm crowdin:download
         if: success() || failure()     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,8 @@ jobs:
       - name: Install
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: crowdin download
+        ## forks cannot access to crowdin secrets
+        if: always()
         env:
           CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
           CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
       - name: crowdin download
         env:
           CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
-          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY__ }}
+          CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
           CONTEXT: production
         run: pnpm crowdin:download
         if: success() || failure()     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: pnpm crowdin:download
         ## this step is optional, translations are not mandatory for PR
         ## secrets keys are not available on forks, the failure here is guaranteed
-        if: success() || failure()     
+        continue-on-error: true  
       - name: build
         run: pnpm build
       - name: tar packages

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "ts:ref": "update-ts-references --discardComments",
     "website": "pnpm build --filter ...@verdaccio/website",
     "crowdin:upload": "crowdin upload sources --auto-update --config ./crowdin.yaml",
-    "crowdin:download": "crowdin download --verbose --config ./crowdin.yaml",
+    "crowdin:download": "crowdin download --verbose --config ./crowdin.yaml || :",
     "crowdin:sync": "pnpm crowdin:upload && pnpm crowdin:download --verbose",
     "postinstall": "husky install"
   },

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "ts:ref": "update-ts-references --discardComments",
     "website": "pnpm build --filter ...@verdaccio/website",
     "crowdin:upload": "crowdin upload sources --auto-update --config ./crowdin.yaml",
-    "crowdin:download": "crowdin download --verbose --config ./crowdin.yaml || :",
+    "crowdin:download": "crowdin download --verbose --config ./crowdin.yaml",
     "crowdin:sync": "pnpm crowdin:upload && pnpm crowdin:download --verbose",
     "postinstall": "husky install"
   },


### PR DESCRIPTION
- crowdin step is irrelevant for builds are not meant to be for prod, so could be skipped (unique side effect is the UI will fallback all languages to english)
- add crowding step missing to the changeset steps