### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/benckmark.yml
+++ b/.github/workflows/benckmark.yml
@@ -6,12 +6,12 @@ on:
   schedule:
     # 3 times day
     # collecting enough data to draw some graphics
-    - cron: '0 1 * * *'
+    - cron: "0 1 * * *"
   # push:
   #   branches:
   #     - master
 jobs:
-  prepare: 
+  prepare:
     name: Prepare build
     runs-on: ubuntu-latest
     steps:
@@ -19,12 +19,13 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: npm
       - name: install pnpm
         run: sudo npm i pnpm@6.6.1 -g
       - name: set store
-        run: | 
+        run: |
           mkdir ~/.pnpm-store
-          pnpm config set store-dir ~/.pnpm-store     
+          pnpm config set store-dir ~/.pnpm-store
       - name: setup pnpm config registry
         run: pnpm config set registry https://registry.verdaccio.org
       - name: install dependencies
@@ -35,11 +36,11 @@ jobs:
           path: ~/.pnpm-store
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            pnpm-              
+            pnpm-
       - name: build
         run: pnpm build
       - name: tar packages
-        run: |      
+        run: |
           tar -czvf ${{ github.workspace }}/pkg.tar.gz -C ${{ github.workspace }}/packages .
       - uses: actions/upload-artifact@v2
         with:
@@ -66,33 +67,34 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: npm
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-artifact
       - name: untar packages
-        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages          
+        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages
       - name: install pnpm
         # require fixed version
         run: sudo npm i pnpm@6.6.1 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}   
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: install dependencies
-        run: pnpm install    
+        run: pnpm install
       - name: start registry
-        run: ./scripts/benchmark-prepare.sh ${{matrix.verdaccioVersion}}        
-      - name: benchmark        
-        run: pnpm benchmark:api -- -v ${{matrix.verdaccioVersion}} -f ${{matrix.benchmark}}       
+        run: ./scripts/benchmark-prepare.sh ${{matrix.verdaccioVersion}}
+      - name: benchmark
+        run: pnpm benchmark:api -- -v ${{matrix.verdaccioVersion}} -f ${{matrix.benchmark}}
         shell: bash
         env:
           DEBUG: metrics*
       - uses: actions/upload-artifact@v2
         with:
           name: verdaccio-metrics-api
-          path: ./api-results-${{matrix.verdaccioVersion}}-${{matrix.benchmark}}.json  
+          path: ./api-results-${{matrix.verdaccioVersion}}-${{matrix.benchmark}}.json
           if-no-files-found: error
-          retention-days: 10 
+          retention-days: 10
       - name: submit metrics
         run: pnpm benchmark:submit
         env:
@@ -103,7 +105,7 @@ jobs:
           METRICS_BENCHMARK: ${{matrix.benchmark}}
           METRICS_VERSION: ${{matrix.verdaccioVersion}}
           METRICS_COMMIT_HASH: ${{ github.sha }}
-          METRICS_FILE_NAME: 'api-results'   
+          METRICS_FILE_NAME: "api-results"
   benchmark:
     needs: prepare
     strategy:
@@ -127,18 +129,19 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14.x
+          cache: npm
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-artifact
       - name: untar packages
-        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages          
+        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages
       - name: install pnpm
         # require fixed version
         run: sudo npm i pnpm@6.6.1 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}   
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: install dependencies
         run: pnpm install
       - name: install hyperfine
@@ -147,7 +150,7 @@ jobs:
           sudo dpkg -i hyperfine_1.11.0_amd64.deb
       - name: start registry
         run: ./scripts/benchmark-prepare.sh ${{matrix.verdaccioVersion}}
-      - name: benchmark        
+      - name: benchmark
         run: ./scripts/benchmark-run.sh ${{matrix.benchmark}}
         # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
         shell: bash
@@ -156,9 +159,9 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           name: verdaccio-metrics
-          path: ./hyper-results-${{matrix.verdaccioVersion}}-${{matrix.benchmark}}.json  
+          path: ./hyper-results-${{matrix.verdaccioVersion}}-${{matrix.benchmark}}.json
           if-no-files-found: error
-          retention-days: 10 
+          retention-days: 10
       - name: submit metrics
         run: pnpm benchmark:submit
         env:

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -2,7 +2,7 @@ name: Changesets
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
   push:
     branches:
@@ -28,7 +28,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
+          cache: npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_AUTH_TOKEN }}
 
@@ -51,7 +52,7 @@ jobs:
           CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
           CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
           CONTEXT: production
-        run: pnpm crowdin:download       
+        run: pnpm crowdin:download
       - name: build
         run: pnpm build
 
@@ -59,8 +60,8 @@ jobs:
         uses: verdaccio/changeset-action@master
         with:
           version: pnpm ci:version
-          commit: 'chore: update versions'
-          title: 'chore: update versions'
+          commit: "chore: update versions"
+          title: "chore: update versions"
           publish: pnpm ci:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,15 @@ on:
   push:
     branches:
       - master
-      - 'changeset-release/master'
+      - "changeset-release/master"
   pull_request:
     paths:
       - .changeset/**
       - .github/workflows/ci.yml
-      - 'packages/**'
-      - 'jest/**'
-      - 'package.json'
-      - 'pnpm-workspace.yaml'
+      - "packages/**"
+      - "jest/**"
+      - "package.json"
+      - "pnpm-workspace.yaml"
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -23,26 +23,27 @@ jobs:
         ports:
           - 4873:4873
     steps:
-    - uses: actions/checkout@v2.3.1
-    - name: Use Node 14
-      uses: actions/setup-node@v1
-      with:
-        node-version: 14 
-    - name: Install pnpm
-      run: npm i pnpm@6.10.3 -g
-    - name: set store
-      run: | 
-        mkdir ~/.pnpm-store
-        pnpm config set store-dir ~/.pnpm-store
-    - name: Install
-      run: pnpm recursive install --frozen-lockfile --registry http://localhost:4873
-    - name: Cache .pnpm-store
-      uses: actions/cache@v2
-      with:
-        path: ~/.pnpm-store
-        key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          pnpm-
+      - uses: actions/checkout@v2.3.1
+      - name: Use Node 14
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          cache: npm
+      - name: Install pnpm
+        run: npm i pnpm@6.10.3 -g
+      - name: set store
+        run: |
+          mkdir ~/.pnpm-store
+          pnpm config set store-dir ~/.pnpm-store
+      - name: Install
+        run: pnpm recursive install --frozen-lockfile --registry http://localhost:4873
+      - name: Cache .pnpm-store
+        uses: actions/cache@v2
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-
   lint:
     runs-on: ubuntu-latest
     name: Lint
@@ -50,15 +51,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Use Node 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16
+          cache: npm
       - name: Install pnpm
         run: npm i pnpm@6.10.3 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}     
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: Lint
@@ -70,15 +72,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Use Node 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16
+          cache: npm
       - name: Install pnpm
         run: npm i pnpm@6.10.3 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}     
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: Lint
@@ -91,15 +94,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Use Node 16
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16
+          cache: npm
       - name: Install pnpm
         run: npm i pnpm@6.10.3 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}     
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
         run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: crowdin download
@@ -110,16 +114,16 @@ jobs:
         run: pnpm crowdin:download
         ## this step is optional, translations are not mandatory for PR
         ## secrets keys are not available on forks, the failure here is guaranteed
-        continue-on-error: true  
+        continue-on-error: true
       - name: build
         run: pnpm build
       - name: tar packages
-        run: |      
+        run: |
           tar -czvf ${{ github.workspace }}/pkg.tar.gz -C ${{ github.workspace }}/packages .
       - uses: actions/upload-artifact@v2
         with:
           name: verdaccio-artifact
-          path: pkg.tar.gz            
+          path: pkg.tar.gz
   test:
     needs: build
     strategy:
@@ -133,22 +137,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Use Node ${{ matrix.node_version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
+          cache: npm
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-artifact
       - name: untar packages
-        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages    
+        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages
       - name: Install pnpm
         run: npm i pnpm@6.10.3 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}                                          
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
-        run: pnpm recursive install --frozen-lockfile --ignore-scripts 
+        run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: Test
         run: pnpm test
   ci-e2e-ui:
@@ -157,54 +162,56 @@ jobs:
     name: UI Test E2E Node 14
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-artifact
       - name: untar packages
-        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages    
+        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages
       - name: Install pnpm
         run: npm i pnpm@6.10.3 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}                                          
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
         ## we need scripts, pupetter downloads aditional content
-        run: pnpm recursive install --frozen-lockfile 
+        run: pnpm recursive install --frozen-lockfile
       - name: Test UI
         run: pnpm test:e2e:ui
         # env:
-        #  DEBUG: verdaccio:e2e*       
+        #  DEBUG: verdaccio:e2e*
   ci-e2e-cli:
     needs: build
     runs-on: ubuntu-latest
     name: CLI Test E2E Node 14
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-artifact
       - name: untar packages
-        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages    
+        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages
       - name: Install pnpm
         run: npm i pnpm@6.10.3 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}                                          
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
         ## we need scripts, pupetter downloads aditional content
         run: pnpm recursive install --frozen-lockfile
       - name: Test CLI
         run: pnpm test:e2e:cli
         # env:
-        #   DEBUG: verdaccio* 
+        #   DEBUG: verdaccio*
   test-windows:
     needs: [format, lint]
     runs-on: windows-latest
@@ -212,18 +219,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Use Node 14
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - name: Install pnpm
         run: npm i pnpm@6.10.3 -g
-       # pnpm cache is not working for windows (we need a solution)
+      # pnpm cache is not working for windows (we need a solution)
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}                                            
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
-        run: pnpm recursive install --frozen-lockfile --ignore-scripts 
+        run: pnpm recursive install --frozen-lockfile --ignore-scripts
       - name: build
         run: pnpm build
       - name: Test
@@ -235,28 +243,29 @@ jobs:
     if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v2.3.1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
       - uses: actions/download-artifact@v2
         with:
           name: verdaccio-artifact
       - name: untar packages
-        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages    
+        run: tar -xzvf pkg.tar.gz -C ${{ github.workspace }}/packages
       - name: Install pnpm
         run: npm i pnpm@6.10.3 -g
       - uses: actions/cache@v2
         with:
           path: ~/.pnpm-store
-          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}                                          
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install
         ## we need scripts, pupetter downloads aditional content
         run: pnpm recursive install --frozen-lockfile
       - name: generate website translations
-        run: pnpm write-translations --filter ...@verdaccio/website       
+        run: pnpm write-translations --filter ...@verdaccio/website
       - name: sync
         env:
           CROWDIN_VERDACCIO_PROJECT_ID: ${{ secrets.CROWDIN_VERDACCIO_PROJECT_ID }}
           CROWDIN_VERDACCIO_API_KEY: ${{ secrets.CROWDIN_VERDACCIO_API_KEY }}
           CONTEXT: production
-        run: pnpm crowdin:sync              
+        run: pnpm crowdin:sync

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,16 +7,16 @@ on:
       - opened
       - synchronize
     paths:
-      - 'website/**'
-      - 'package.json'
-      - './.github/workflows/website.yml'
+      - "website/**"
+      - "package.json"
+      - "./.github/workflows/website.yml"
   push:
     branches:
-      - 'master'
+      - "master"
     paths:
-      - 'website/**'
-      - 'package.json'
-      - './.github/workflows/website.yml'
+      - "website/**"
+      - "package.json"
+      - "./.github/workflows/website.yml"
 
 jobs:
   build:
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: npm
 
       - name: Cache pnpm modules
         uses: actions/cache@v2
@@ -59,8 +60,7 @@ jobs:
           path: website/node_modules/.cache/webpack
           key: cache/webpack-${{github.ref}}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: cache/webpack-${{github.ref}}
-
-      # Will deploy to production on:
+        # Will deploy to production on:
         # 1st: When a push occurs on master branch
         # 2nd: When we force the worflow dispatch through the UI
       - name: Build Production
@@ -78,7 +78,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
-          build-dir: './website/build'
+          build-dir: "./website/build"
 
       # Will deploy to Preview URL, only when a pull request is open with changes on the website
       - name: Build Deployment Preview
@@ -99,7 +99,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_SITE_ID }}
-          build-dir: './website/build'
+          build-dir: "./website/build"
 
       - name: Audit preview URL with Lighthouse
         if: github.event_name == 'pull_request' && github.ref != 'refs/heads/master' && github.event.label.name == 'trigger-preview'


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
