### PR TITLE
Remove Node 12 support (v6.x)

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,7 @@
         "version": 3, "proposals": true
       },
       "targets": {
-        "node": 12
+        "node": 14
       }
     }
   ],

--- a/.changeset/eleven-spoons-matter.md
+++ b/.changeset/eleven-spoons-matter.md
@@ -1,0 +1,39 @@
+---
+'@verdaccio/api': major
+'@verdaccio/auth': major
+'@verdaccio/cli': major
+'@verdaccio/config': major
+'@verdaccio/core': major
+'@verdaccio/file-locking': major
+'verdaccio-htpasswd': major
+'@verdaccio/readme': major
+'@verdaccio/fastify-migration': major
+'@verdaccio/streams': major
+'@verdaccio/tarball': major
+'@verdaccio/types': major
+'@verdaccio/url': major
+'@verdaccio/hooks': major
+'@verdaccio/loaders': major
+'@verdaccio/logger': major
+'@verdaccio/middleware': major
+'@verdaccio/mock': major
+'@verdaccio/node-api': major
+'@verdaccio/active-directory': major
+'verdaccio-audit': major
+'verdaccio-auth-memory': major
+'verdaccio-aws-s3-storage': major
+'verdaccio-google-cloud': major
+'verdaccio-memory': major
+'@verdaccio/ui-theme': major
+'@verdaccio/server': major
+'@verdaccio/cli-standalone': major
+'@verdaccio/store': major
+'@verdaccio/dev-types': major
+'@verdaccio/utils': major
+'verdaccio': major
+'@verdaccio/web': major
+---
+
+Remove Node 12 support
+
+- We need move to the new `undici` and does not support Node.js 12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.17.6-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.18.1-alpine as builder
 
 ENV NODE_ENV=development \
     VERDACCIO_BUILD_REGISTRY=https://registry.verdaccio.org
@@ -19,7 +19,7 @@ RUN npm -g i pnpm@6.10.3 && \
 # FIXME: need to remove devDependencies from the build
 # RUN pnpm install --prod --ignore-scripts
 
-FROM node:14.17.6-alpine
+FROM node:14.18.1-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Google Cloud Storage** or create your own plugin.
 
 ## Install
 
+> Latest Node.js v14
+
 Install with npm:
 
 ```bash

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -25,7 +25,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "scripts": {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -25,7 +25,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "description": "verdaccio CLI",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "scripts": {

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "homepage": "https://verdaccio.org",
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "repository": {

--- a/packages/core/file-locking/package.json
+++ b/packages/core/file-locking/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "homepage": "https://verdaccio.org",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "repository": {

--- a/packages/core/htpasswd/package.json
+++ b/packages/core/htpasswd/package.json
@@ -30,7 +30,7 @@
     "build"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/core/readme/package.json
+++ b/packages/core/readme/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "homepage": "https://verdaccio.org",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "repository": {

--- a/packages/core/server/package.json
+++ b/packages/core/server/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "homepage": "https://verdaccio.org",
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "repository": {

--- a/packages/core/streams/package.json
+++ b/packages/core/streams/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "homepage": "https://verdaccio.org",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "repository": {

--- a/packages/core/tarball/package.json
+++ b/packages/core/tarball/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "homepage": "https://verdaccio.org",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "repository": {

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "homepage": "https://verdaccio.org",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "repository": {

--- a/packages/core/url/package.json
+++ b/packages/core/url/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "homepage": "https://verdaccio.org",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "repository": {

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -36,7 +36,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "license": "MIT",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "scripts": {

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "scripts": {

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -23,7 +23,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "description": "mock server for testing",

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -25,7 +25,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "scripts": {

--- a/packages/plugins/active-directory/package.json
+++ b/packages/plugins/active-directory/package.json
@@ -30,7 +30,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/plugins/audit/package.json
+++ b/packages/plugins/audit/package.json
@@ -27,7 +27,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/plugins/auth-memory/package.json
+++ b/packages/plugins/auth-memory/package.json
@@ -27,7 +27,7 @@
   "main": "build/index.js",
   "types": "build/src/index.d.ts",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/plugins/aws-storage/package.json
+++ b/packages/plugins/aws-storage/package.json
@@ -14,7 +14,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "author": "Juan Picado <juanpicado19@gmail.com>",

--- a/packages/plugins/google-cloud-storage/package.json
+++ b/packages/plugins/google-cloud-storage/package.json
@@ -27,7 +27,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/plugins/memory/package.json
+++ b/packages/plugins/memory/package.json
@@ -27,7 +27,7 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/plugins/ui-theme/package.json
+++ b/packages/plugins/ui-theme/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://verdaccio.org",
   "main": "index.js",
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -52,7 +52,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "preferGlobal": true,

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "scripts": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,7 +29,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "dependencies": {

--- a/packages/verdaccio/package.json
+++ b/packages/verdaccio/package.json
@@ -66,7 +66,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "preferGlobal": true,

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -20,7 +20,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=10",
+    "node": ">=14",
     "npm": ">=6"
   },
   "license": "MIT",


### PR DESCRIPTION
Reasons:

- Node.js has better support for AbortController (even experimental, but worth trying)
- Node.js 14 goes to Active in October and Node 12 LTS ends on April 2022) 
- Only affect v6.x alpha (which might be early released by March 2022)