### PR TITLE
chore: add node 17 to ci 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: [12, 14, 15, 16, 17]
+        node_version: [17]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
https://nodejs.org/en/blog/release/v17.0.0/