### PR TITLE
fix: update python dependency on docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV NODE_ENV=production \
     HUSKY_DEBUG=1
 
 RUN apk --no-cache add openssl ca-certificates wget && \
-    apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python && \
+    apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python2 && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
     apk add glibc-2.25-r0.apk


### PR DESCRIPTION
The image was using `python` instead `python2` which seems not to be longer available.

Ref 
- https://github.com/nodejs/docker-node/issues/1605
- https://github.com/fossasia/open-event-frontend/pull/8048