### PR TITLE
fix: hydrate template placeholders in JSON log messages

### DIFF
--- a/.changeset/fair-lemons-beam.md
+++ b/.changeset/fair-lemons-beam.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/logger-prettify': minor
+'@verdaccio/logger': patch
+---
+
+hydrate template placeholders in log messages when format is set to 'json'

--- a/packages/logger-prettify/src/index.ts
+++ b/packages/logger-prettify/src/index.ts
@@ -1,5 +1,7 @@
-import { printMessage } from './formatter';
+import { fillInMsgTemplate, printMessage } from './formatter';
 import { PrettyOptionsExtended } from './types';
+
+export { fillInMsgTemplate };
 
 export type PrettyFactory = (param) => string;
 
@@ -8,11 +10,11 @@ export type PrettyFactory = (param) => string;
  { messageKey: 'msg', levelFirst: true, prettyStamp: false }
  */
 
-module.exports = function prettyFactory(options: PrettyOptionsExtended): PrettyFactory {
+export default function prettyFactory(options: PrettyOptionsExtended): PrettyFactory {
   // the break line must happens in the prettify component
   const breakLike = '\n';
   return (inputData): string => {
     // FIXME: review colors by default is true
     return printMessage(inputData, options, true) + breakLike;
   };
-};
+}


### PR DESCRIPTION
Closes #2649
Related to discussion #2286 

This change fixes the issue where the `msg` property in JSON format logs does not have the template placeholders hydrated with values.

**Without this fix**
```text
{"level":25,"time":1636481904624,"pid":133492,"hostname":"workstation","sub":"in","request":{"method":"GET","url":"/-/verdaccio/packages"},"user":null,"remoteIP":"127.0.0.1","status":200,"bytes":{"in":0,"out":3},"msg":"@{status}, user: @{user}(@{remoteIP}), req: '@{request.method} @{request.url}', bytes: @{bytes.in}/@{bytes.out}"}
```

**With this fix**
```
{"level":25,"time":1636482057018,"pid":135963,"hostname":"workstation","sub":"in","request":{"method":"GET","url":"/-/verdaccio/packages"},"user":null,"remoteIP":"127.0.0.1","status":304,"bytes":{"in":0,"out":0},"msg":"304, user: null(127.0.0.1), req: 'GET /-/verdaccio/packages', bytes: 0/0"}
```

This is my first contribution and I believe I properly followed the [Contributing Guidelines](https://github.com/verdaccio/verdaccio/blob/master/CONTRIBUTING.md#contributing-guidelines). If I missed something please let me know.

Unit tests were not added since the code changes effect `pino` logger configuration. There are currently no _direct_ unit tests for `fillinMsgTemplate` from the `@verdaccio/logger-prettify` package.