### PR TITLE
migrate docker-apache v4 to V6

### DIFF
--- a/docker-examples/v6/apache-verdaccio/README.md
+++ b/docker-examples/v6/apache-verdaccio/README.md
@@ -1,0 +1,93 @@
+# Verdaccio and Apache2
+
+Running `verdaccio` via reverse proxy is a common practice. This configuration provides a quick way to run the application through **apache2** as reverse proxy.
+
+To run the containers, run the following command in this folder, it should start the containers in detach mode.
+
+```bash
+ docker-compose up -d
+```
+
+To recreate the nginx image you can force the build.
+
+```bash
+ docker-compose up --build -d
+
+ Building apacheproxy
+Step 1/5 : FROM eboraas/apache
+ ---> 1ba66e3f5580
+Step 2/5 : MAINTAINER Juan Picado <juanpicado19@gmail.com>
+ ---> Using cache
+ ---> 4317b29c20ec
+Step 3/5 : RUN a2enmod proxy
+ ---> Using cache
+ ---> b9334b33e2f1
+Step 4/5 : COPY ./conf/000-default.conf /etc/apache2/sites-enabled/000-default.conf
+ ---> Using cache
+ ---> 6d464388db8f
+Step 5/5 : COPY ./conf/env.load /etc/apache2/mods-enabled/env.load
+ ---> Using cache
+ ---> 66740b6ffb97
+Successfully built 66740b6ffb97
+Recreating verdaccio
+Recreating apacheverdaccio_apacheproxy_1
+```
+
+To force recreate the images.
+
+```bash
+docker-compose up --build --force-recreate -d
+```
+
+To stop all containers
+
+```bash
+docker-compose stop
+```
+
+To display container logs
+
+```bash
+$> docker-compose logs
+Attaching to apacheverdaccio_apacheproxy_1, verdaccio
+verdaccio    |  warn --- config file  - /verdaccio/conf/config.yaml
+verdaccio    |  warn --- http address - http://0.0.0.0:4873/ - verdaccio/2.1.7
+verdaccio    |  http <-- 304, user: undefined, req: 'GET /', bytes: 0/0
+verdaccio    |  http <-- 304, user: undefined, req: 'GET /-/static/jquery.min.js', bytes: 0/0
+verdaccio    |  http <-- 304, user: undefined, req: 'GET /-/static/main.css', bytes: 0/0
+verdaccio    |  http <-- 304, user: undefined, req: 'GET /-/static/main.js', bytes: 0/0
+verdaccio    |  http <-- 304, user: undefined, req: 'GET /-/logo', bytes: 0/0
+verdaccio    |  http <-- 304, user: undefined, req: 'GET /-/static/fontello.woff?10872183', bytes: 0/0
+verdaccio    |  http <-- 200, user: undefined, req: 'GET /-/static/favicon.png', bytes: 0/315
+```
+
+To access the apache logs
+
+```bash
+&> docker exec -it {ID} /bin/bash
+
+root@da8ee3cb484c:~# tail -f /var/log/apache2/verdaccio-access.log
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /xmlhttprequest-ssl HTTP/1.1" 200 2616 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /yeast HTTP/1.1" 200 2706 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /has-cors HTTP/1.1" 200 1347 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /parsejson HTTP/1.1" 200 1234 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /better-assert HTTP/1.1" 200 2462 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /callsite HTTP/1.1" 200 1369 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /dot-access HTTP/1.1" 200 1477 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /skipper-disk HTTP/1.1" 200 3801 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /native-or-bluebird HTTP/1.1" 200 2257 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+172.20.0.1 - - [31/May/2017:21:16:37 +0000] "GET /foreachasync HTTP/1.1" 200 2742 "install sails" "npm/5.0.0 node/v4.6.1 darwin x64"
+tail: unrecognized file system type 0x794c7630 for '/var/log/apache2/verdaccio-access.log'. please report this to bug-coreutils@gnu.org. reverting to polling
+```
+
+### Display Information
+
+To display the containers running
+
+```bash
+&> docker-compose ps
+            Name                           Command               State              Ports
+----------------------------------------------------------------------------------------------------
+apacheverdaccio_apacheproxy_1   /usr/sbin/apache2ctl -D FO ...   Up      443/tcp, 0.0.0.0:80->80/tcp
+verdaccio                       /usr/src/app/bin/verdaccio ...   Up      0.0.0.0:4873->4873/tcp
+```

--- a/docker-examples/v6/apache-verdaccio/apache_proxy/Dockerfile
+++ b/docker-examples/v6/apache-verdaccio/apache_proxy/Dockerfile
@@ -1,0 +1,6 @@
+FROM eboraas/apache
+MAINTAINER Juan Picado <juanpicado19@gmail.com>
+# http://pierrecaserta.com/apache-proxy-one-docker-server-many-domains/
+RUN a2enmod proxy
+COPY ./conf/000-default.conf /etc/apache2/sites-enabled/000-default.conf
+COPY ./conf/env.load /etc/apache2/mods-enabled/env.load

--- a/docker-examples/v6/apache-verdaccio/apache_proxy/conf/000-default.conf
+++ b/docker-examples/v6/apache-verdaccio/apache_proxy/conf/000-default.conf
@@ -1,0 +1,17 @@
+ServerName localhost:80
+ServerAdmin admin@localhost
+
+<VirtualHost *:80>
+    ServerName localhost
+    <Proxy *>
+        Allow from localhost
+    </Proxy>
+    SSLProxyEngine          On
+    ProxyRequests           Off
+    ProxyPreserveHost       On
+    AllowEncodedSlashes     NoDecode
+    ProxyPass               /       http://verdaccio:4873/ nocanon
+    ProxyPassReverse        /       http://verdaccio:4873/
+    CustomLog /var/log/apache2/verdaccio-access.log combined
+    ErrorLog /var/log/apache2/verdaccio-error.log
+</VirtualHost>

--- a/docker-examples/v6/apache-verdaccio/apache_proxy/conf/env.load
+++ b/docker-examples/v6/apache-verdaccio/apache_proxy/conf/env.load
@@ -1,0 +1,4 @@
+LoadModule env_module /usr/lib/apache2/modules/mod_env.so
+LoadModule proxy_module /usr/lib/apache2/modules/mod_proxy.so
+LoadModule proxy_http_module /usr/lib/apache2/modules/mod_proxy_http.so
+LoadModule socache_shmcb_module /usr/lib/apache2/modules/mod_socache_shmcb.so

--- a/docker-examples/v6/apache-verdaccio/docker-compose.yaml
+++ b/docker-examples/v6/apache-verdaccio/docker-compose.yaml
@@ -1,0 +1,21 @@
+services:
+  verdaccio:
+    image: verdaccio/verdaccio:nightly-master
+    container_name: verdaccio
+    ports:
+      - '4873:4873'
+    volumes:
+      - verdaccio:/verdaccio
+
+  apacheproxy:
+    build: apache_proxy/
+    links:
+      - verdaccio
+    ports:
+      - '80:80'
+    volumes_from:
+      - verdaccio
+
+volumes:
+  verdaccio:
+    driver: local


### PR DESCRIPTION
Migrate docker-apache example to run with the V6 verdaccio image(verdaccio:nightly-master)