### PR TITLE
refactor: graceful shutdown using `process.once()` instead of `process.on()`

### DIFF
--- a/packages/node-api/src/server.ts
+++ b/packages/node-api/src/server.ts
@@ -150,9 +150,10 @@ export async function initServer(
       });
     }
 
-    process.on('SIGINT', handleShutdownGracefully);
-    process.on('SIGTERM', handleShutdownGracefully);
-    process.on('SIGHUP', handleShutdownGracefully);
+    for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+      // Use once() so that receiving double signals exit the app.
+      process.once(signal, handleShutdownGracefully)
+    }
   });
 }
 

--- a/packages/node-api/src/server.ts
+++ b/packages/node-api/src/server.ts
@@ -152,7 +152,7 @@ export async function initServer(
 
     for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
       // Use once() so that receiving double signals exit the app.
-      process.once(signal, handleShutdownGracefully)
+      process.once(signal, handleShutdownGracefully);
     }
   });
 }


### PR DESCRIPTION
Hello.

This PR aims to refactor the way graceful shutdown is handled by using `process.once()` instead of `process.on()` for signals caption so that it exits on double signals (cf. https://nodejs.org/api/events.html#emitteronceeventname-listener).