### PR TITLE
fix: publish with deprecated field

### DIFF
--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -221,14 +221,17 @@ export function publishPackage(storage: IStorageHandler, config: Config, auth: I
         req,
         callback: function (_, packageInfo) {
           const metadata = validateMetadata(req.body, packageName);
-          const metadataVersions = Object.keys(metadata.versions);
           // false: publish new version with package.json#deprecated fields, that will make all old versions miss(local-storage will override package.json)
-          const allowPublishWithDeprecated = packageInfo && Object.keys(packageInfo.versions).every(item =>
-            metadataVersions.includes(item)
-          );
           // treating deprecation as updating a package
+          const checkVersionsMatch = function () {
+            const metadataVersions = Object.keys(metadata.versions);
+
+            return Object.keys(packageInfo.versions).every(item =>
+              metadataVersions.includes(item)
+            );
+          };
           if (
-            req.params._rev || (isRelatedToDeprecation(req.body) && allowPublishWithDeprecated)
+            req.params._rev || (isRelatedToDeprecation(req.body) && checkVersionsMatch())
           ) {
             debug('updating a new version for %o', packageName);
             // we check unpublish permissions, an update is basically remove versions

--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -217,7 +217,7 @@ export function publishPackage(storage: IStorageHandler, config: Config, auth: I
     try {
       storage.getPackage({
         name: packageName,
-        uplinksLook: true,
+        uplinksLook: false,
         req,
         callback: function (_, packageInfo) {
           const metadata = validateMetadata(req.body, packageName);

--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -223,7 +223,7 @@ export function publishPackage(storage: IStorageHandler, config: Config, auth: I
           const metadata = validateMetadata(req.body, packageName);
           const metadataVersions = Object.keys(metadata.versions);
           // false: publish new version with package.json#deprecated fields, that will make all old versions miss(local-storage will override package.json)
-          const allowPublishWithDeprecated = Object.keys(packageInfo.versions).every(item => 
+          const allowPublishWithDeprecated = Object.keys(packageInfo.versions).every(item =>
             metadataVersions.includes(item)
           );
           // treating deprecation as updating a package

--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -223,7 +223,7 @@ export function publishPackage(storage: IStorageHandler, config: Config, auth: I
           const metadata = validateMetadata(req.body, packageName);
           const metadataVersions = Object.keys(metadata.versions);
           // false: publish new version with package.json#deprecated fields, that will make all old versions miss(local-storage will override package.json)
-          const allowPublishWithDeprecated = Object.keys(packageInfo.versions).every(item =>
+          const allowPublishWithDeprecated = packageInfo && Object.keys(packageInfo.versions).every(item =>
             metadataVersions.includes(item)
           );
           // treating deprecation as updating a package

--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -215,44 +215,27 @@ export function publishPackage(storage: IStorageHandler, config: Config, auth: I
     }
 
     try {
-      storage.getPackage({
-        name: packageName,
-        uplinksLook: false,
-        req,
-        callback: function (_, packageInfo) {
-          const metadata = validateMetadata(req.body, packageName);
-          // false: publish new version with package.json#deprecated fields, that will make all old versions miss(local-storage will override package.json)
-          // treating deprecation as updating a package
-          const checkVersionsMatch = function () {
-            const metadataVersions = Object.keys(metadata.versions);
-
-            return Object.keys(packageInfo.versions).every(item =>
-              metadataVersions.includes(item)
-            );
-          };
-          if (
-            req.params._rev || (isRelatedToDeprecation(req.body) && checkVersionsMatch())
-          ) {
-            debug('updating a new version for %o', packageName);
-            // we check unpublish permissions, an update is basically remove versions
-            const remote = req.remote_user;
-            auth.allow_unpublish({ packageName }, remote, (error) => {
-              if (error) {
-                logger.error({ packageName }, `not allowed to unpublish a version for @{packageName}`);
-                return next(error);
-              }
-              storage.changePackage(packageName, metadata, req.params.revision, function (error) {
-                afterChange(error, API_MESSAGE.PKG_CHANGED, metadata);
-              });
-            });
-          } else {
-            debug('adding a new version for %o', packageName);
-            storage.addPackage(packageName, metadata, function (error) {
-              afterChange(error, API_MESSAGE.PKG_CREATED, metadata);
-            });
+      const metadata = validateMetadata(req.body, packageName);
+      // check _attachments to distinguish publish and deprecate
+      if (req.params._rev || (isRelatedToDeprecation(req.body) && _.isEmpty(req.body._attachments))) {
+        debug('updating a new version for %o', packageName);
+        // we check unpublish permissions, an update is basically remove versions
+        const remote = req.remote_user;
+        auth.allow_unpublish({ packageName }, remote, (error) => {
+          if (error) {
+            logger.error({ packageName }, `not allowed to unpublish a version for @{packageName}`);
+            return next(error);
           }
-        }
-      });
+          storage.changePackage(packageName, metadata, req.params.revision, function (error) {
+            afterChange(error, API_MESSAGE.PKG_CHANGED, metadata);
+          });
+        });
+      } else {
+        debug('adding a new version for %o', packageName);
+        storage.addPackage(packageName, metadata, function (error) {
+          afterChange(error, API_MESSAGE.PKG_CREATED, metadata);
+        });
+      }
     } catch (error) {
       logger.error({ packageName }, 'error on publish, bad package data for @{packageName}');
       return next(ErrorCode.getBadData(API_ERROR.BAD_PACKAGE_DATA));

--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -228,7 +228,7 @@ export function publishPackage(storage: IStorageHandler, config: Config, auth: I
           );
           // treating deprecation as updating a package
           if (
-            (req.params._rev || isRelatedToDeprecation(req.body)) && allowPublishWithDeprecated
+            req.params._rev || (isRelatedToDeprecation(req.body) && allowPublishWithDeprecated)
           ) {
             debug('updating a new version for %o', packageName);
             // we check unpublish permissions, an update is basically remove versions

--- a/test/unit/modules/api/__snapshots__/publish.spec.ts.snap
+++ b/test/unit/modules/api/__snapshots__/publish.spec.ts.snap
@@ -2,26 +2,27 @@
 
 exports[`Publish endpoints - publish package should change the existing package 1`] = `[MockFunction]`;
 
-exports[`Publish endpoints - publish package should publish a new a new package 1`] = `[MockFunction] {
-      "calls": Array [
-        Array [
-          "verdaccio",
-          Object {
-            "dist-tags": Object {},
-            "name": "verdaccio",
-            "time": Object {},
-            "versions": Object {},
-          },
-          [Function],
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": undefined,
-        },
-      ],
-    }
+exports[`Publish endpoints - publish package should publish a new a new package 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      "verdaccio",
+      Object {
+        "dist-tags": Object {},
+        "name": "verdaccio",
+        "time": Object {},
+        "versions": Object {},
+      },
+      [Function],
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
 `;
 
 exports[`Publish endpoints - publish package test start should star a package 1`] = `

--- a/test/unit/modules/api/__snapshots__/publish.spec.ts.snap
+++ b/test/unit/modules/api/__snapshots__/publish.spec.ts.snap
@@ -2,7 +2,27 @@
 
 exports[`Publish endpoints - publish package should change the existing package 1`] = `[MockFunction]`;
 
-exports[`Publish endpoints - publish package should publish a new a new package 1`] = `[MockFunction]`;
+exports[`Publish endpoints - publish package should publish a new a new package 1`] = `[MockFunction] {
+      "calls": Array [
+        Array [
+          "verdaccio",
+          Object {
+            "dist-tags": Object {},
+            "name": "verdaccio",
+            "time": Object {},
+            "versions": Object {},
+          },
+          [Function],
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+`;
 
 exports[`Publish endpoints - publish package test start should star a package 1`] = `
 [MockFunction] {

--- a/test/unit/modules/api/__snapshots__/publish.spec.ts.snap
+++ b/test/unit/modules/api/__snapshots__/publish.spec.ts.snap
@@ -2,28 +2,7 @@
 
 exports[`Publish endpoints - publish package should change the existing package 1`] = `[MockFunction]`;
 
-exports[`Publish endpoints - publish package should publish a new a new package 1`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      "verdaccio",
-      Object {
-        "dist-tags": Object {},
-        "name": "verdaccio",
-        "time": Object {},
-        "versions": Object {},
-      },
-      [Function],
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
+exports[`Publish endpoints - publish package should publish a new a new package 1`] = `[MockFunction]`;
 
 exports[`Publish endpoints - publish package test start should star a package 1`] = `
 [MockFunction] {

--- a/test/unit/modules/api/api.spec.ts
+++ b/test/unit/modules/api/api.spec.ts
@@ -1073,7 +1073,7 @@ describe('endpoint unit test', () => {
         expect(res.body.versions['1.0.1'].deprecated).toEqual('get deprecated');
         done();
       });
-      
+
       test('should deprecate when publish new version with deprecate field', async (done) => {
         await Promise.all([
           putPackage(request(app), `/${pkgName}`, generatePackageMetadata(pkgName, '2.0.0'), token),

--- a/test/unit/modules/api/api.spec.ts
+++ b/test/unit/modules/api/api.spec.ts
@@ -1073,6 +1073,28 @@ describe('endpoint unit test', () => {
         expect(res.body.versions['1.0.1'].deprecated).toEqual('get deprecated');
         done();
       });
+      
+      test('should deprecate when publish new version with deprecate field', async (done) => {
+        await Promise.all([
+          putPackage(request(app), `/${pkgName}`, generatePackageMetadata(pkgName, '2.0.0'), token),
+          putPackage(request(app), `/${pkgName}`, generatePackageMetadata(pkgName, '2.0.1'), token),
+          putPackage(request(app), `/${pkgName}`, generatePackageMetadata(pkgName, '2.0.2'), token)
+        ]);
+
+        const pkg = generatePackageMetadata(pkgName, '2.0.3');
+        pkg.versions['2.0.3'].deprecated = 'get deprecated';
+        await putPackage(request(app), `/${encodeScopedUri(pkgName)}`, pkg, token);
+
+        const [, res] = await getPackage(request(app), '', pkgName);
+        const versions = Object.keys(res.body.versions);
+
+        expect(res.body.versions['2.0.3'].deprecated).toEqual('get deprecated');
+        expect(versions).toContain('2.0.0');
+        expect(versions).toContain('2.0.1');
+        expect(versions).toContain('2.0.2');
+        expect(versions).toContain('2.0.3');
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
When publish with deprecated field in `package.json`, that will make all old versions miss.

Examples:

I have package@1.0.0 and package@1.0.1.

When `npm deprecate package@1.0.0 "xxx"`, Verdaccio will recived:

```json
{
  "name": "module_name",
  "version": {
    "1.0.0": {
      "deprecated": "xxx"
    },
    "1.0.1": {}
  }
}
```

⬆️ This make sense

But then publish new version with @1.0.2.

Verdaccio will recived:

```json
{
  "name": "module_name",
  "version": {
    "1.0.2": {
      "deprecated": "xxx" // if we set this field in package.json
    },
  }
}
```

and that metadata will override package.json, make old version miss.

migrate from #2766