### PR TITLE
feat: user agent is the client by default

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -30,10 +30,12 @@ const defineAPI = function (config: IConfig, storage: IStorageHandler): any {
   // Router setup
   app.use(log(config));
   app.use(errorReportingMiddleware);
-  app.use(function (req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer): void {
-    res.setHeader('X-Powered-By', config.user_agent);
-    next();
-  });
+  if (config.user_agent) {
+    app.use(function (req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer): void {
+      res.setHeader('X-Powered-By', config.user_agent);
+      next();
+    });
+  }
 
   app.use(compression());
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -35,6 +35,8 @@ const defineAPI = function (config: IConfig, storage: IStorageHandler): any {
       res.setHeader('X-Powered-By', config.user_agent);
       next();
     });
+  } else {
+    app.disable('x-powered-by');
   }
 
   app.use(compression());

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,12 +4,7 @@ import _ from 'lodash';
 import { PackageList, Config as AppConfig, Security, Logger } from '@verdaccio/types';
 import { MatchedPackage, StartUpConfig } from '../../types';
 import { generateRandomHexString } from './crypto-utils';
-import {
-  getMatchedPackagesSpec,
-  normalisePackageAccess,
-  sanityCheckUplinksProps,
-  uplinkSanityCheck
-} from './config-utils';
+import { getMatchedPackagesSpec, normalisePackageAccess, sanityCheckUplinksProps, uplinkSanityCheck } from './config-utils';
 import { getUserAgent, isObject } from './utils';
 import { APP_ERROR } from './constants';
 
@@ -22,6 +17,7 @@ const allowedEnvConfig = ['http_proxy', 'https_proxy', 'no_proxy'];
  */
 class Config implements AppConfig {
   public logger: Logger;
+  // @ts-ignore
   public user_agent: string;
   // @ts-ignore
   public secret: string;
@@ -49,7 +45,7 @@ class Config implements AppConfig {
     }
 
     // @ts-ignore
-    if (_.isNil(this.user_agent)) {
+    if (config?.user_agent) {
       this.user_agent = getUserAgent();
     }
 

--- a/src/lib/up-storage.ts
+++ b/src/lib/up-storage.ts
@@ -278,7 +278,7 @@ class ProxyStorage implements IProxy {
     headers[accept] = headers[accept] || contentTypeAccept;
     headers[acceptEncoding] = headers[acceptEncoding] || 'gzip';
     // registry.npmjs.org will only return search result if user-agent include string 'npm'
-    headers[userAgent] = this.userAgent ? `npm (${this.userAgent})` : options.req.get('user-agent');
+    headers[userAgent] = this.userAgent ? `npm (${this.userAgent})` : options.req?.get('user-agent');
 
     return this._setAuth(headers);
   }

--- a/src/lib/up-storage.ts
+++ b/src/lib/up-storage.ts
@@ -278,7 +278,7 @@ class ProxyStorage implements IProxy {
     headers[accept] = headers[accept] || contentTypeAccept;
     headers[acceptEncoding] = headers[acceptEncoding] || 'gzip';
     // registry.npmjs.org will only return search result if user-agent include string 'npm'
-    headers[userAgent] = headers[userAgent] || `npm (${this.userAgent})`;
+    headers[userAgent] = this.userAgent ? `npm (${this.userAgent})` : options.req.get('user-agent');
 
     return this._setAuth(headers);
   }


### PR DESCRIPTION
To avoid send the version of verdaccio on every request the user agent set is the one declared by client one, furthermore  disable `X-Powered-By` header on web by default unless is enabled by configuration like:

```yaml
// config.yaml

user_agent: true

```

If is enabled the proxy request would be `User-Agent:'npm (verdaccio/5.3.2)` and Web UI request would be have the header `x-powered-by: verdaccio/5.3.2`' otherwise the `x-powered-by` would be disabled and the proxy request would use the client `user-agent` instead.