### PR TITLE
feat: add rate limit to user api endpoints

### DIFF
--- a/src/api/endpoint/api/user.ts
+++ b/src/api/endpoint/api/user.ts
@@ -14,10 +14,6 @@ import { limiter } from '../../user-rate-limit';
 export default function (route: Router, auth: IAuth, config: Config): void {
   /* eslint new-cap:off */
   const userRouter = express.Router();
-
-  // we limit max 100 request per 15 minutes on user endpoints
-  // @ts-ignore
-
   userRouter.use(limiter);
 
   userRouter.get('/-/user/:org_couchdb_user', function (req: $RequestExtend, res: Response, next: $NextFunctionVer): void {

--- a/src/api/endpoint/api/user.ts
+++ b/src/api/endpoint/api/user.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import Cookies from 'cookies';
-import RateLimit from 'express-rate-limit';
 
 import { Config, RemoteUser } from '@verdaccio/types';
 import express, { Response, Router } from 'express';
@@ -10,6 +9,7 @@ import { createRemoteUser, createSessionToken, getApiToken, getAuthenticatedMess
 import { logger } from '../../../lib/logger';
 
 import { $RequestExtend, $ResponseExtend, $NextFunctionVer, IAuth } from '../../../../types';
+import { limiter } from '../../user-rate-limit';
 
 export default function (route: Router, auth: IAuth, config: Config): void {
   /* eslint new-cap:off */
@@ -17,10 +17,7 @@ export default function (route: Router, auth: IAuth, config: Config): void {
 
   // we limit max 100 request per 15 minutes on user endpoints
   // @ts-ignore
-  const limiter = new RateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 1000,
-  });
+
   userRouter.use(limiter);
 
   userRouter.get('/-/user/:org_couchdb_user', function (req: $RequestExtend, res: Response, next: $NextFunctionVer): void {

--- a/src/api/endpoint/api/v1/index.ts
+++ b/src/api/endpoint/api/v1/index.ts
@@ -1,0 +1,11 @@
+import { Response, Router } from 'express';
+import profile from './profile';
+import token from './token';
+import v1Search from './search';
+
+export default (auth, storage, config) => {
+  const route = Router(); /* eslint new-cap: 0 */
+  route.use(profile(auth));
+  route.use(token(auth, storage, config));
+  return route;
+};

--- a/src/api/endpoint/api/v1/index.ts
+++ b/src/api/endpoint/api/v1/index.ts
@@ -1,11 +1,13 @@
 import { Response, Router } from 'express';
+import { limiter } from '../../../user-rate-limit';
 import profile from './profile';
 import token from './token';
 import v1Search from './search';
 
 export default (auth, storage, config) => {
   const route = Router(); /* eslint new-cap: 0 */
-  route.use(profile(auth));
-  route.use(token(auth, storage, config));
+  route.use(limiter);
+  route.use('/-/npm/v1/', profile(auth));
+  route.use('/-/npm/v1/', token(auth, storage, config));
   return route;
 };

--- a/src/api/endpoint/api/v1/profile.ts
+++ b/src/api/endpoint/api/v1/profile.ts
@@ -18,7 +18,7 @@ export interface Profile {
   fullname: string;
 }
 
-export default function (route: Router, auth: IAuth): void {
+export default function (auth: IAuth): Router {
   const profileRoute = Router(); /* eslint new-cap: 0 */
   profileRoute.use(limiter);
   function buildProfile(name: string): Profile {
@@ -80,5 +80,5 @@ export default function (route: Router, auth: IAuth): void {
     }
   });
 
-  route.use('/-/npm/v1', profileRoute);
+  return profileRoute;
 }

--- a/src/api/endpoint/api/v1/profile.ts
+++ b/src/api/endpoint/api/v1/profile.ts
@@ -5,7 +5,6 @@ import { ErrorCode } from '../../../../lib/utils';
 import { validatePassword } from '../../../../lib/auth-utils';
 
 import { $NextFunctionVer, $RequestExtend, IAuth } from '../../../../../types';
-import { limiter } from '../../../user-rate-limit';
 
 export interface Profile {
   tfa: boolean;
@@ -20,7 +19,6 @@ export interface Profile {
 
 export default function (auth: IAuth): Router {
   const profileRoute = Router(); /* eslint new-cap: 0 */
-  profileRoute.use(limiter);
   function buildProfile(name: string): Profile {
     return {
       tfa: false,

--- a/src/api/endpoint/api/v1/profile.ts
+++ b/src/api/endpoint/api/v1/profile.ts
@@ -5,6 +5,7 @@ import { ErrorCode } from '../../../../lib/utils';
 import { validatePassword } from '../../../../lib/auth-utils';
 
 import { $NextFunctionVer, $RequestExtend, IAuth } from '../../../../../types';
+import { limiter } from '../../../user-rate-limit';
 
 export interface Profile {
   tfa: boolean;
@@ -18,6 +19,8 @@ export interface Profile {
 }
 
 export default function (route: Router, auth: IAuth): void {
+  const profileRoute = Router(); /* eslint new-cap: 0 */
+  profileRoute.use(limiter);
   function buildProfile(name: string): Profile {
     return {
       tfa: false,
@@ -27,68 +30,55 @@ export default function (route: Router, auth: IAuth): void {
       created: '',
       updated: '',
       cidr_whitelist: null,
-      fullname: ''
+      fullname: '',
     };
   }
 
-  route.get(
-    '/-/npm/v1/user',
-    function (req: $RequestExtend, res: Response, next: $NextFunctionVer): void {
-      if (_.isNil(req.remote_user.name) === false) {
-        return next(buildProfile(req.remote_user.name));
-      }
+  profileRoute.get('/user', function (req: $RequestExtend, res: Response, next: $NextFunctionVer): void {
+    if (_.isNil(req.remote_user.name) === false) {
+      return next(buildProfile(req.remote_user.name));
+    }
 
+    res.status(HTTP_STATUS.UNAUTHORIZED);
+    return next({
+      message: API_ERROR.MUST_BE_LOGGED,
+    });
+  });
+
+  profileRoute.post('/user', function (req: $RequestExtend, res: Response, next: $NextFunctionVer): void {
+    if (_.isNil(req.remote_user.name)) {
       res.status(HTTP_STATUS.UNAUTHORIZED);
       return next({
-        message: API_ERROR.MUST_BE_LOGGED
+        message: API_ERROR.MUST_BE_LOGGED,
       });
     }
-  );
 
-  route.post(
-    '/-/npm/v1/user',
-    function (req: $RequestExtend, res: Response, next: $NextFunctionVer): void {
-      if (_.isNil(req.remote_user.name)) {
-        res.status(HTTP_STATUS.UNAUTHORIZED);
-        return next({
-          message: API_ERROR.MUST_BE_LOGGED
-        });
+    const { password, tfa } = req.body;
+    const { name } = req.remote_user;
+
+    if (_.isNil(password) === false) {
+      if (validatePassword(password.new) === false) {
+        /* eslint new-cap:off */
+        return next(ErrorCode.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.PASSWORD_SHORT()));
+        /* eslint new-cap:off */
       }
 
-      const { password, tfa } = req.body;
-      const { name } = req.remote_user;
-
-      if (_.isNil(password) === false) {
-        if (validatePassword(password.new) === false) {
-          /* eslint new-cap:off */
-          return next(ErrorCode.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.PASSWORD_SHORT()));
-          /* eslint new-cap:off */
+      auth.changePassword(name, password.old, password.new, (err, isUpdated): $NextFunctionVer => {
+        if (_.isNull(err) === false) {
+          return next(ErrorCode.getCode(err.status, err.message) || ErrorCode.getConflict(err.message));
         }
 
-        auth.changePassword(
-          name,
-          password.old,
-          password.new,
-          (err, isUpdated): $NextFunctionVer => {
-            if (_.isNull(err) === false) {
-              return next(
-                ErrorCode.getCode(err.status, err.message) || ErrorCode.getConflict(err.message)
-              );
-            }
-
-            if (isUpdated) {
-              return next(buildProfile(req.remote_user.name));
-            }
-            return next(ErrorCode.getInternalError(API_ERROR.INTERNAL_SERVER_ERROR));
-          }
-        );
-      } else if (_.isNil(tfa) === false) {
-        return next(
-          ErrorCode.getCode(HTTP_STATUS.SERVICE_UNAVAILABLE, SUPPORT_ERRORS.TFA_DISABLED)
-        );
-      } else {
-        return next(ErrorCode.getCode(HTTP_STATUS.INTERNAL_ERROR, APP_ERROR.PROFILE_ERROR));
-      }
+        if (isUpdated) {
+          return next(buildProfile(req.remote_user.name));
+        }
+        return next(ErrorCode.getInternalError(API_ERROR.INTERNAL_SERVER_ERROR));
+      });
+    } else if (_.isNil(tfa) === false) {
+      return next(ErrorCode.getCode(HTTP_STATUS.SERVICE_UNAVAILABLE, SUPPORT_ERRORS.TFA_DISABLED));
+    } else {
+      return next(ErrorCode.getCode(HTTP_STATUS.INTERNAL_ERROR, APP_ERROR.PROFILE_ERROR));
     }
-  );
+  });
+
+  route.use('/-/npm/v1', profileRoute);
 }

--- a/src/api/endpoint/api/v1/token.ts
+++ b/src/api/endpoint/api/v1/token.ts
@@ -26,7 +26,7 @@ function normalizeToken(token: Token): NormalizeToken {
 // https://github.com/npm/npm-profile/blob/latest/lib/index.js
 export default function (auth: IAuth, storage: IStorageHandler, config: Config): Router {
   const tokenRoute = Router(); /* eslint new-cap: 0 */
-  tokenRoute.use(limiter);
+  // tokenRoute.use(limiter);
   tokenRoute.get('/tokens', async function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
     const { name } = req.remote_user;
 

--- a/src/api/endpoint/api/v1/token.ts
+++ b/src/api/endpoint/api/v1/token.ts
@@ -24,10 +24,10 @@ function normalizeToken(token: Token): NormalizeToken {
 }
 
 // https://github.com/npm/npm-profile/blob/latest/lib/index.js
-export default function (route: Router, auth: IAuth, storage: IStorageHandler, config: Config): void {
+export default function (auth: IAuth, storage: IStorageHandler, config: Config): Router {
   const tokenRoute = Router(); /* eslint new-cap: 0 */
   tokenRoute.use(limiter);
-  tokenRoute.get('/', async function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
+  tokenRoute.get('/tokens', async function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
     const { name } = req.remote_user;
 
     if (_.isNil(name) === false) {
@@ -50,7 +50,7 @@ export default function (route: Router, auth: IAuth, storage: IStorageHandler, c
     return next(ErrorCode.getUnauthorized());
   });
 
-  tokenRoute.post('/', function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
+  tokenRoute.post('/tokens', function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
     const { password, readonly, cidr_whitelist } = req.body;
     const { name } = req.remote_user;
 
@@ -110,7 +110,7 @@ export default function (route: Router, auth: IAuth, storage: IStorageHandler, c
     });
   });
 
-  tokenRoute.delete('/token/:tokenKey', async (req: $RequestExtend, res: Response, next: $NextFunctionVer) => {
+  tokenRoute.delete('/tokens/token/:tokenKey', async (req: $RequestExtend, res: Response, next: $NextFunctionVer) => {
     const {
       params: { tokenKey },
     } = req;
@@ -130,5 +130,5 @@ export default function (route: Router, auth: IAuth, storage: IStorageHandler, c
     return next(ErrorCode.getUnauthorized());
   });
 
-  route.use('/-/npm/v1/tokens', tokenRoute);
+  return tokenRoute;
 }

--- a/src/api/endpoint/api/v1/token.ts
+++ b/src/api/endpoint/api/v1/token.ts
@@ -9,6 +9,7 @@ import { stringToMD5 } from '../../../../lib/crypto-utils';
 import { logger } from '../../../../lib/logger';
 
 import { $NextFunctionVer, $RequestExtend, IAuth, IStorageHandler } from '../../../../../types';
+import { limiter } from '../../../user-rate-limit';
 
 const debug = buildDebug('verdaccio:token');
 export type NormalizeToken = Token & {
@@ -24,7 +25,9 @@ function normalizeToken(token: Token): NormalizeToken {
 
 // https://github.com/npm/npm-profile/blob/latest/lib/index.js
 export default function (route: Router, auth: IAuth, storage: IStorageHandler, config: Config): void {
-  route.get('/-/npm/v1/tokens', async function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
+  const tokenRoute = Router(); /* eslint new-cap: 0 */
+  tokenRoute.use(limiter);
+  tokenRoute.get('/', async function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
     const { name } = req.remote_user;
 
     if (_.isNil(name) === false) {
@@ -47,7 +50,7 @@ export default function (route: Router, auth: IAuth, storage: IStorageHandler, c
     return next(ErrorCode.getUnauthorized());
   });
 
-  route.post('/-/npm/v1/tokens', function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
+  tokenRoute.post('/', function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
     const { password, readonly, cidr_whitelist } = req.body;
     const { name } = req.remote_user;
 
@@ -107,7 +110,7 @@ export default function (route: Router, auth: IAuth, storage: IStorageHandler, c
     });
   });
 
-  route.delete('/-/npm/v1/tokens/token/:tokenKey', async (req: $RequestExtend, res: Response, next: $NextFunctionVer) => {
+  tokenRoute.delete('/token/:tokenKey', async (req: $RequestExtend, res: Response, next: $NextFunctionVer) => {
     const {
       params: { tokenKey },
     } = req;
@@ -126,4 +129,6 @@ export default function (route: Router, auth: IAuth, storage: IStorageHandler, c
     }
     return next(ErrorCode.getUnauthorized());
   });
+
+  route.use('/-/npm/v1/tokens', tokenRoute);
 }

--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -44,14 +44,14 @@ export default function (config: Config, auth: IAuth, storage: IStorageHandler) 
   // for "npm whoami"
   whoami(app);
   pkg(app, auth, storage, config);
-  profile(app, auth);
   search(app, auth, storage);
-  user(app, auth, config);
   distTags(app, auth, storage);
   publish(app, auth, storage, config);
   ping(app);
   stars(app, storage);
   v1Search(app, auth, storage);
+  profile(app, auth);
   token(app, auth, storage, config);
+  user(app, auth, config);
   return app;
 }

--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -49,7 +49,7 @@ export default function (config: Config, auth: IAuth, storage: IStorageHandler) 
   ping(app);
   stars(app, storage);
   v1Search(app, auth, storage);
-  app.use('/-/npm/v1/', npmV1(auth, storage, config));
+  app.use(npmV1(auth, storage, config));
   user(app, auth, config);
   return app;
 }

--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -11,8 +11,7 @@ import publish from './api/publish';
 import search from './api/search';
 import pkg from './api/package';
 import stars from './api/stars';
-import profile from './api/v1/profile';
-import token from './api/v1/token';
+import npmV1 from './api/v1';
 import v1Search from './api/v1/search';
 
 const { match, validateName, validatePackage, encodeScopePackage, antiLoop } = require('../middleware');
@@ -50,8 +49,7 @@ export default function (config: Config, auth: IAuth, storage: IStorageHandler) 
   ping(app);
   stars(app, storage);
   v1Search(app, auth, storage);
-  profile(app, auth);
-  token(app, auth, storage, config);
+  app.use('/-/npm/v1/', npmV1(auth, storage, config));
   user(app, auth, config);
   return app;
 }

--- a/src/api/user-rate-limit.ts
+++ b/src/api/user-rate-limit.ts
@@ -1,0 +1,11 @@
+import RateLimit from 'express-rate-limit';
+
+// we limit max 1000 request per 15 minutes on user endpoints
+const defaultUserRateLimiting = {
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 1000,
+};
+// @ts-ignore
+const limiter = new RateLimit(defaultUserRateLimiting);
+
+export { limiter };

--- a/src/api/web/api.ts
+++ b/src/api/web/api.ts
@@ -15,12 +15,9 @@ const route = Router(); /* eslint new-cap: 0 */
 */
 export default function (config: Config, auth: IAuth, storage: IStorageHandler): Router {
   Search.configureStorage(storage);
-
   // validate all of these params as a package name
   // this might be too harsh, so ask if it causes trouble
-  // $FlowFixMe
   route.param('package', validatePackage);
-  // $FlowFixMe
   route.param('filename', validateName);
   route.param('version', validateName);
   route.param('anything', match(/.*/));
@@ -32,11 +29,5 @@ export default function (config: Config, auth: IAuth, storage: IStorageHandler):
   addPackageWebApi(route, storage, auth, config);
   addSearchWebApi(route, storage, auth);
   addUserAuthApi(route, auth, config);
-
-  // What are you looking for? logout? client side will remove token when user click logout,
-  // or it will auto expire after 24 hours.
-  // This token is different with the token send to npm client.
-  // We will/may replace current token with JWT in next major release, and it will not expire at all(configurable).
-
   return route;
 }

--- a/src/api/web/endpoint/user.ts
+++ b/src/api/web/endpoint/user.ts
@@ -20,11 +20,9 @@ function addUserAuthApi(route: Router, auth: IAuth, config: Config): void {
   const limiter = new RateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100,
-    // @ts-ignore
-    ...config?.web?.rateLimit,
   });
-  route.use(limiter);
-  route.post('/login', function (req: Request, res: Response, next: $NextFunctionVer): void {
+  userRouter.use(limiter);
+  userRouter.post('/login', function (req: Request, res: Response, next: $NextFunctionVer): void {
     const { username, password } = req.body;
 
     auth.authenticate(username, password, async (err, user: RemoteUser): Promise<void> => {
@@ -43,7 +41,7 @@ function addUserAuthApi(route: Router, auth: IAuth, config: Config): void {
     });
   });
 
-  route.put('/reset_password', function (req: Request, res: Response, next: $NextFunctionVer): void {
+  userRouter.put('/reset_password', function (req: Request, res: Response, next: $NextFunctionVer): void {
     if (_.isNil(req.remote_user.name)) {
       res.status(HTTP_STATUS.UNAUTHORIZED);
       return next({

--- a/src/api/web/endpoint/user.ts
+++ b/src/api/web/endpoint/user.ts
@@ -2,7 +2,6 @@
  * @prettier
  */
 import _ from 'lodash';
-import RateLimit from 'express-rate-limit';
 
 import express, { Router, Response, Request } from 'express';
 import { Config, RemoteUser, JWTSignOptions } from '@verdaccio/types';
@@ -10,19 +9,11 @@ import { API_ERROR, APP_ERROR, HEADERS, HTTP_STATUS } from '../../../lib/constan
 import { IAuth, $NextFunctionVer } from '../../../../types';
 import { ErrorCode } from '../../../lib/utils';
 import { getSecurity, validatePassword } from '../../../lib/auth-utils';
+import { limiter } from '../../user-rate-limit';
 
 function addUserAuthApi(route: Router, auth: IAuth, config: Config): void {
-  /* eslint new-cap:off */
-  const userRouter = express.Router();
-
-  // we limit max 100 request per 15 minutes on user endpoints
-  // @ts-ignore
-  const limiter = new RateLimit({
-    windowMs: 15 * 60 * 1000, // 15 minutes
-    max: 100,
-  });
-  userRouter.use(limiter);
-  userRouter.post('/login', function (req: Request, res: Response, next: $NextFunctionVer): void {
+  route.use(limiter);
+  route.post('/login', function (req: Request, res: Response, next: $NextFunctionVer): void {
     const { username, password } = req.body;
 
     auth.authenticate(username, password, async (err, user: RemoteUser): Promise<void> => {
@@ -41,7 +32,7 @@ function addUserAuthApi(route: Router, auth: IAuth, config: Config): void {
     });
   });
 
-  userRouter.put('/reset_password', function (req: Request, res: Response, next: $NextFunctionVer): void {
+  route.put('/reset_password', function (req: Request, res: Response, next: $NextFunctionVer): void {
     if (_.isNil(req.remote_user.name)) {
       res.status(HTTP_STATUS.UNAUTHORIZED);
       return next({
@@ -67,8 +58,6 @@ function addUserAuthApi(route: Router, auth: IAuth, config: Config): void {
       return next(ErrorCode.getCode(HTTP_STATUS.BAD_REQUEST, APP_ERROR.PASSWORD_VALIDATION));
     }
   });
-
-  route.use(userRouter);
 }
 
 export default addUserAuthApi;


### PR DESCRIPTION
Follow up of https://github.com/verdaccio/verdaccio/pull/2799

Refactor and add more limit to key endpoints, update default limits for following endpoints to 1k request peer 15 min.

-  API endpoints
   - login or add user
   - list token
   - delete token
   - create token
   - npm profile (change password)

-  Web endpoints
   - login
   - update password

We could parametrize this later, for now let's see how it goes.