### PR TITLE
feat: add new options to the web disable login and pkg managers

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -7840,14 +7840,14 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["core-js", [
         ["npm:2.6.9", {
-          "packageLocation": "./.yarn/cache/core-js-npm-2.6.9-f821bf686c-00c30207eb.zip/node_modules/core-js/",
+          "packageLocation": "./.yarn/unplugged/core-js-npm-2.6.9-f821bf686c/node_modules/core-js/",
           "packageDependencies": [
             ["core-js", "npm:2.6.9"]
           ],
           "linkType": "HARD",
         }],
         ["npm:3.20.2", {
-          "packageLocation": "./.yarn/cache/core-js-npm-3.20.2-656ea79cc8-642927e21a.zip/node_modules/core-js/",
+          "packageLocation": "./.yarn/unplugged/core-js-npm-3.20.2-656ea79cc8/node_modules/core-js/",
           "packageDependencies": [
             ["core-js", "npm:3.20.2"]
           ],
@@ -14898,7 +14898,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
       ]],
       ["puppeteer", [
         ["npm:5.5.0", {
-          "packageLocation": "./.yarn/cache/puppeteer-npm-5.5.0-bba75ba998-08ba8a7da5.zip/node_modules/puppeteer/",
+          "packageLocation": "./.yarn/unplugged/puppeteer-npm-5.5.0-bba75ba998/node_modules/puppeteer/",
           "packageDependencies": [
             ["puppeteer", "npm:5.5.0"],
             ["debug", "virtual:65523936f66795efc0bd6f7ca9a755f1be9f9bb998dc7cd39f5d823ea185c793a03b3f329f921a146569ee8bdffdd22dd15c2e08d286539b118e1cbbab91f8cf#npm:4.1.1"],

--- a/src/api/web/endpoint/index.ts
+++ b/src/api/web/endpoint/index.ts
@@ -1,5 +1,6 @@
 import { Response, Router } from 'express';
 
+import { hasLogin } from '../../../lib/utils';
 import { limiter } from '../../rate-limiter';
 import packageApi from './package';
 import search from './search';
@@ -18,6 +19,8 @@ export default (auth, storage, config) => {
   route.use('/data/', packageApi(storage, auth, config));
   route.use('/data/', search(storage, auth));
   route.use('/sec/', limiter(config?.userRateLimit));
-  route.use('/sec/', user(auth, storage));
+  if (hasLogin(config)) {
+    route.use('/sec/', user(auth, storage));
+  }
   return route;
 };

--- a/src/api/web/html/renderHTML.ts
+++ b/src/api/web/html/renderHTML.ts
@@ -6,7 +6,7 @@ import { URL } from 'url';
 import { HEADERS } from '@verdaccio/commons-api';
 
 import { WEB_TITLE } from '../../../lib/constants';
-import { getPublicUrl, isHTTPProtocol } from '../../../lib/utils';
+import { getPublicUrl, hasLogin, isHTTPProtocol } from '../../../lib/utils';
 import renderTemplate from './template';
 
 const pkgJSON = require('../../../../package.json');
@@ -50,7 +50,9 @@ export default function renderHTML(config, manifest, manifestFiles, req, res) {
   const darkMode = config?.web?.darkMode ?? false;
   const title = config?.web?.title ?? WEB_TITLE;
   const scope = config?.web?.scope ?? '';
+  const login = hasLogin(config);
   const logoURI = resolveLogo(config, req);
+  const pkgManagers = config?.web?.pkgManagers ?? ['yarn', 'pnpm', 'npm'];
   const version = pkgJSON.version;
   const primaryColor = validatePrimaryColor(config?.web?.primary_color) ?? '#4b5e40';
   const { scriptsBodyAfter, metaScripts, scriptsbodyBefore } = Object.assign(
@@ -69,6 +71,8 @@ export default function renderHTML(config, manifest, manifestFiles, req, res) {
     base,
     primaryColor,
     version,
+    pkgManagers,
+    login,
     logo: logoURI,
     title,
     scope,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -12,7 +12,7 @@ import validator from 'validator';
 // eslint-disable-next-line max-len
 import { getBadData, getBadRequest, getCode, getConflict, getForbidden, getInternalError, getNotFound, getServiceUnavailable, getUnauthorized } from '@verdaccio/commons-api';
 import sanitizyReadme from '@verdaccio/readme';
-import { Author, Package, Version } from '@verdaccio/types';
+import { Author, Config, Package, Version } from '@verdaccio/types';
 
 import { AuthorAvatar, StringValue } from '../../types';
 import { GENERIC_AVATAR, generateGravatarUrl } from '../utils/user';
@@ -688,4 +688,10 @@ export function wrapPrefix(prefix: string | void): string {
   } else {
     return prefix;
   }
+}
+
+export function hasLogin(config: Config) {
+  // FIXME: types are not yet on the library verdaccio/monorepo
+  // @ts-ignore
+  return _.isNil(config?.web?.login) || config?.web?.login === true;
 }


### PR DESCRIPTION
This is something already available on v6, now on v5 
- able to select which package managers you want to enableo on the web and
- disable login on web and endpoints option
```yaml
web:
  pkgManagers:
    - npm
    - yarn
    - pnpm
  login: true      
```