### PR TITLE
Fix re-opening log files using SIGUSR2

### DIFF
--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -122,7 +122,9 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
   const pinoConfig = { level: loggerConfig.level };
   if (loggerConfig.type === 'file') {
     debug('logging file enabled');
-    logger = createLogger(pinoConfig, pino.destination(loggerConfig.path), loggerConfig.format);
+    const destination = pino.destination(loggerConfig.path);
+    process.on('SIGUSR2', () => destination.reopen());
+    logger = createLogger(pinoConfig, destination, loggerConfig.format);
   } else if (loggerConfig.type === 'rotating-file') {
     process.emitWarning('rotating-file type is not longer supported, consider use [logrotate] instead');
     debug('logging stdout enabled');


### PR DESCRIPTION
The documentation https://verdaccio.org/docs/logger/ still states that logfiles can be re-opened using SIGUSR2, but since the move to pino, this stopped working. Probably this was removed together with the type "rotating-logfile" and the introduction of the recommendation to use an external tool like logrotate.

However, pino itself has some documentation on how to do it: https://github.com/pinojs/pino/blob/master/docs/help.md#reopening. IMVHO this is a better approach than using copytruncate, and it also supports systems that do not have it (like newsyslog). It is also trivial to implement, so here you go.