### PR TITLE
feature: config control  for colors in logs

### DIFF
--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -46,7 +46,7 @@ $ VERDACCIO_FORWARDED_PROTO=CloudFront-Forwarded-Proto verdaccio --listen 5000
 
 By default, the storage is taken from config file, but using this variable allows to set it from environment variable.
 
-#### EXPERIMENTAL\_\_VERDACCIO_LOGGER_COLORS
+#### EXPERIMENTAL_VERDACCIO_LOGGER_COLORS
 
 Overrides `logs.colors` from the `config.yaml`.
 

--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -46,6 +46,7 @@ $ VERDACCIO_FORWARDED_PROTO=CloudFront-Forwarded-Proto verdaccio --listen 5000
 
 By default, the storage is taken from config file, but using this variable allows to set it from environment variable.
 
+
 #### VERDACCIO_LOGGER_COLORS
 
 Overrides `logs.colors` from the `config.yaml`.

--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -46,7 +46,6 @@ $ VERDACCIO_FORWARDED_PROTO=CloudFront-Forwarded-Proto verdaccio --listen 5000
 
 By default, the storage is taken from config file, but using this variable allows to set it from environment variable.
 
-
 #### VERDACCIO_LOGGER_COLORS
 
 Overrides `logs.colors` from the `config.yaml`.

--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -46,7 +46,7 @@ $ VERDACCIO_FORWARDED_PROTO=CloudFront-Forwarded-Proto verdaccio --listen 5000
 
 By default, the storage is taken from config file, but using this variable allows to set it from environment variable.
 
-#### VERDACCIO_LOGGER_COLORS
+#### EXPERIMENTAL__VERDACCIO_LOGGER_COLORS
 
 Overrides `logs.colors` from the `config.yaml`.
 

--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -50,4 +50,7 @@ By default, the storage is taken from config file, but using this variable allow
 #### VERDACCIO_LOGGER_COLORS
 
 Overrides `logs.colors` from the `config.yaml`.
+**Note:** The value is cast to boolean using `Boolean()` constructor, so any value that is not `false` or explicit empty-string will result in `true`.
+
 When both are not provided - the colors are on by default for TTY processes, and off for processes that are not.
+

--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -46,7 +46,7 @@ $ VERDACCIO_FORWARDED_PROTO=CloudFront-Forwarded-Proto verdaccio --listen 5000
 
 By default, the storage is taken from config file, but using this variable allows to set it from environment variable.
 
-#### EXPERIMENTAL__VERDACCIO_LOGGER_COLORS
+#### EXPERIMENTAL\_\_VERDACCIO_LOGGER_COLORS
 
 Overrides `logs.colors` from the `config.yaml`.
 

--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -45,3 +45,8 @@ $ VERDACCIO_FORWARDED_PROTO=CloudFront-Forwarded-Proto verdaccio --listen 5000
 #### VERDACCIO_STORAGE_PATH
 
 By default, the storage is taken from config file, but using this variable allows to set it from environment variable.
+
+#### VERDACCIO_LOGGER_COLORS
+
+Overrides `logs.colors` from the `config.yaml`.
+When both are not provided - the colors are on by default for TTY processes, and off for processes that are not.

--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -50,6 +50,6 @@ By default, the storage is taken from config file, but using this variable allow
 
 Overrides `logs.colors` from the `config.yaml`.
 
-Note The value is cast to boolean using `Boolean()` constructor, so any value that is not `false` or explicit empty-string will result in `true`.
+Note that any value that other than `false` will result in `true`.
 
 When both are not provided - the colors are on by default for TTY processes, and off for processes that are not.

--- a/docs/env.variables.md
+++ b/docs/env.variables.md
@@ -49,7 +49,7 @@ By default, the storage is taken from config file, but using this variable allow
 #### VERDACCIO_LOGGER_COLORS
 
 Overrides `logs.colors` from the `config.yaml`.
-**Note:** The value is cast to boolean using `Boolean()` constructor, so any value that is not `false` or explicit empty-string will result in `true`.
+
+Note The value is cast to boolean using `Boolean()` constructor, so any value that is not `false` or explicit empty-string will result in `true`.
 
 When both are not provided - the colors are on by default for TTY processes, and off for processes that are not.
-

--- a/src/lib/logger/formatter/index.ts
+++ b/src/lib/logger/formatter/index.ts
@@ -11,7 +11,6 @@ module.exports = function prettyFactory(options: PrettyOptionsExtended): PrettyF
   // the break line must happens in the prettify component
   const breakLike = '\n';
   return (inputData): string => {
-    // FIXME: review colors by default is true
-    return printMessage(inputData, options, true) + breakLike;
+    return printMessage(inputData, options, options.colors) + breakLike;
   };
 };

--- a/src/lib/logger/formatter/prettifier.ts
+++ b/src/lib/logger/formatter/prettifier.ts
@@ -22,6 +22,7 @@ export function formatLoggingDate(time: number, message): string {
 
 export interface PrettyOptionsExtended extends PrettyOptions {
   prettyStamp: boolean;
+  colors: boolean;
 }
 let LEVEL_VALUE_MAX = 0;
 // eslint-disable-next-line guard-for-in

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -120,18 +120,24 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
     );
   }
   const pinoConfig = { level: loggerConfig.level };
+  const prettyPrintOptions = {
+    // we hide warning since the prettifier should not be used in production
+    // https://getpino.io/#/docs/pretty?id=prettifier-api
+    suppressFlushSyncWarning: true,
+    colorsize: 'colors' in loggerConfig ? loggerConfig.colors : process.stdin.isTTY,
+  };  
   if (loggerConfig.type === 'file') {
     debug('logging file enabled');
     const destination = pino.destination(loggerConfig.path);
     process.on('SIGUSR2', () => destination.reopen());
-    logger = createLogger(pinoConfig, destination, loggerConfig.format);
+    logger = createLogger(pinoConfig, destination, loggerConfig.format, prettyPrintOptions);
   } else if (loggerConfig.type === 'rotating-file') {
     process.emitWarning('rotating-file type is not longer supported, consider use [logrotate] instead');
     debug('logging stdout enabled');
-    logger = createLogger(pinoConfig, pino.destination(1), loggerConfig.format);
+    logger = createLogger(pinoConfig, pino.destination(1), loggerConfig.format, prettyPrintOptions);
   } else {
     debug('logging stdout enabled');
-    logger = createLogger(pinoConfig, pino.destination(1), loggerConfig.format);
+    logger = createLogger(pinoConfig, pino.destination(1), loggerConfig.format, prettyPrintOptions);
   }
 
   if (isProd()) {

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -112,8 +112,8 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
   }
   const pinoConfig = { level: loggerConfig.level };
   let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdout.isTTY;
-  if ('EXPERIMENTAL__VERDACCIO_LOGGER_COLORS' in process.env) {
-    colors = Boolean(process.env.EXPERIMENTAL__VERDACCIO_LOGGER_COLORS);
+  if ('EXPERIMENTAL_VERDACCIO_LOGGER_COLORS' in process.env) {
+    colors = Boolean(process.env.EXPERIMENTAL_VERDACCIO_LOGGER_COLORS);
   }
   const prettyPrintOptions = {
     // we hide warning since the prettifier should not be used in production

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -1,9 +1,9 @@
+import { padLeft } from './utils';
 import buildDebug from 'debug';
 import { yellow } from 'kleur';
 import _ from 'lodash';
 import pino from 'pino';
 
-import { padLeft } from './utils';
 
 function isProd() {
   return process.env.NODE_ENV === 'production';
@@ -113,7 +113,7 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
   const pinoConfig = { level: loggerConfig.level };
   let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdout.isTTY;
   if ('EXPERIMENTAL_VERDACCIO_LOGGER_COLORS' in process.env) {
-    colors = process.env.EXPERIMENTAL_VERDACCIO_LOGGER_COLORS != "false";
+    colors = process.env.EXPERIMENTAL_VERDACCIO_LOGGER_COLORS != 'false';
   }
   const prettyPrintOptions = {
     // we hide warning since the prettifier should not be used in production

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -21,12 +21,7 @@ export type LogPlugin = {
 export type LogType = 'file' | 'stdout';
 export type LogFormat = 'json' | 'pretty-timestamped' | 'pretty';
 
-export function createLogger(
-  options = { level: 'http' },
-  destination = pino.destination(1),
-  format: LogFormat = DEFAULT_LOG_FORMAT,
-  prettyPrintOptions
-) {
+export function createLogger(options = { level: 'http' }, destination = pino.destination(1), format: LogFormat = DEFAULT_LOG_FORMAT, prettyPrintOptions) {
   if (_.isNil(format)) {
     format = DEFAULT_LOG_FORMAT;
   }
@@ -123,7 +118,7 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
     // https://getpino.io/#/docs/pretty?id=prettifier-api
     suppressFlushSyncWarning: true,
     colors,
-  };  
+  };
   if (loggerConfig.type === 'file') {
     debug('logging file enabled');
     const destination = pino.destination(loggerConfig.path);

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -25,11 +25,7 @@ export function createLogger(
   options = { level: 'http' },
   destination = pino.destination(1),
   format: LogFormat = DEFAULT_LOG_FORMAT,
-  prettyPrintOptions = {
-    // we hide warning since the prettifier should not be used in production
-    // https://getpino.io/#/docs/pretty?id=prettifier-api
-    suppressFlushSyncWarning: true,
-  }
+  prettyPrintOptions
 ) {
   if (_.isNil(format)) {
     format = DEFAULT_LOG_FORMAT;

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -116,11 +116,13 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
     );
   }
   const pinoConfig = { level: loggerConfig.level };
+  let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdin.isTTY;
+  if ('VERDACCIO_LOGGER_COLORS' in process.env) colors = Boolean(process.env.VERDACCIO_LOGGER_COLORS);
   const prettyPrintOptions = {
     // we hide warning since the prettifier should not be used in production
     // https://getpino.io/#/docs/pretty?id=prettifier-api
     suppressFlushSyncWarning: true,
-    colors: 'colors' in loggerConfig ? loggerConfig.colors : process.stdin.isTTY,
+    colors,
   };  
   if (loggerConfig.type === 'file') {
     debug('logging file enabled');

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -113,7 +113,7 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
   const pinoConfig = { level: loggerConfig.level };
   let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdout.isTTY;
   if ('EXPERIMENTAL_VERDACCIO_LOGGER_COLORS' in process.env) {
-    colors = Boolean(process.env.EXPERIMENTAL_VERDACCIO_LOGGER_COLORS);
+    colors = process.env.EXPERIMENTAL_VERDACCIO_LOGGER_COLORS != "false";
   }
   const prettyPrintOptions = {
     // we hide warning since the prettifier should not be used in production

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -120,7 +120,7 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
     // we hide warning since the prettifier should not be used in production
     // https://getpino.io/#/docs/pretty?id=prettifier-api
     suppressFlushSyncWarning: true,
-    colorsize: 'colors' in loggerConfig ? loggerConfig.colors : process.stdin.isTTY,
+    colors: 'colors' in loggerConfig ? loggerConfig.colors : process.stdin.isTTY,
   };  
   if (loggerConfig.type === 'file') {
     debug('logging file enabled');

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -112,7 +112,9 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
   }
   const pinoConfig = { level: loggerConfig.level };
   let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdout.isTTY;
-  if ('VERDACCIO_LOGGER_COLORS' in process.env) colors = Boolean(process.env.VERDACCIO_LOGGER_COLORS);
+  if ('VERDACCIO_LOGGER_COLORS' in process.env) {
+    colors = Boolean(process.env.VERDACCIO_LOGGER_COLORS);
+  }
   const prettyPrintOptions = {
     // we hide warning since the prettifier should not be used in production
     // https://getpino.io/#/docs/pretty?id=prettifier-api

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -112,8 +112,8 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
   }
   const pinoConfig = { level: loggerConfig.level };
   let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdout.isTTY;
-  if ('VERDACCIO_LOGGER_COLORS' in process.env) {
-    colors = Boolean(process.env.VERDACCIO_LOGGER_COLORS);
+  if ('EXPERIMENTAL__VERDACCIO_LOGGER_COLORS' in process.env) {
+    colors = Boolean(process.env.EXPERIMENTAL__VERDACCIO_LOGGER_COLORS);
   }
   const prettyPrintOptions = {
     // we hide warning since the prettifier should not be used in production

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -116,7 +116,7 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
     );
   }
   const pinoConfig = { level: loggerConfig.level };
-  let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdin.isTTY;
+  let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdout.isTTY;
   if ('VERDACCIO_LOGGER_COLORS' in process.env) colors = Boolean(process.env.VERDACCIO_LOGGER_COLORS);
   const prettyPrintOptions = {
     // we hide warning since the prettifier should not be used in production

--- a/src/lib/logger/logger.ts
+++ b/src/lib/logger/logger.ts
@@ -1,9 +1,7 @@
-import { padLeft } from './utils';
 import buildDebug from 'debug';
 import { yellow } from 'kleur';
 import _ from 'lodash';
 import pino from 'pino';
-
 
 function isProd() {
   return process.env.NODE_ENV === 'production';
@@ -77,6 +75,7 @@ const DEFAULT_LOGGER_CONF: LoggerConfigItem = {
   type: 'stdout',
   format: 'pretty',
   level: 'http',
+  colors: true,
 };
 
 export type LoggerConfigItem = {
@@ -85,6 +84,7 @@ export type LoggerConfigItem = {
   format?: LogFormat;
   path?: string;
   level?: string;
+  colors?: boolean;
 };
 
 export type LoggerConfig = LoggerConfigItem[];
@@ -111,7 +111,7 @@ export function setup(options: LoggerConfig | LoggerConfigItem = [DEFAULT_LOGGER
     );
   }
   const pinoConfig = { level: loggerConfig.level };
-  let colors = 'colors' in loggerConfig ? loggerConfig.colors : process.stdout.isTTY;
+  let colors = loggerConfig?.colors === true ? process.stdout.isTTY : false;
   if ('EXPERIMENTAL_VERDACCIO_LOGGER_COLORS' in process.env) {
     colors = process.env.EXPERIMENTAL_VERDACCIO_LOGGER_COLORS != 'false';
   }


### PR DESCRIPTION
When `VERDACCIO_LOGGER_COLORS` is provided - it's cast to boolean and cascades any config.
When `logs.colors` is provided - it's used.
otherwise - default to `process.stdout.isTTY`

I updated the docs I found, still don't know where to update the site and the reference for the logger config.