### PR TITLE
Refactor htpasswd plugin to use use bcryptjs async API

### DIFF
--- a/.changeset/swift-pumpkins-knock.md
+++ b/.changeset/swift-pumpkins-knock.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/auth': patch
+'verdaccio-htpasswd': patch
+---
+
+Refactor htpasswd plugin to use the bcryptjs 'compare' api call instead of 'comparSync'. Add a new configuration value named 'slow_verify_ms' to the htpasswd plugin that when exceeded during password verification will log a warning message.

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -111,7 +111,7 @@ class Auth implements IAuth {
     };
     let authPlugin;
     try {
-      authPlugin = new HTPasswd(plugingConf, pluginOptions);
+      authPlugin = new HTPasswd(plugingConf, pluginOptions as any as PluginOptions<HTPasswdConfig>);
     } catch (error: any) {
       debug('error on loading auth htpasswd plugin stack: %o', error);
       return [];

--- a/packages/plugins/htpasswd/README.md
+++ b/packages/plugins/htpasswd/README.md
@@ -30,7 +30,26 @@ As simple as running:
             # Hash algorithm, possible options are: "bcrypt", "md5", "sha1", "crypt".
             #algorithm: bcrypt
             # Rounds number for "bcrypt", will be ignored for other algorithms.
+            # Setting this value higher will result in password verification taking longer.
             #rounds: 10
+            # Log a warning if the password takes more then this duration in milliseconds to verify.
+            #slow_verify_ms: 200
+
+### Bcrypt rounds
+
+It is important to note that when using the default `bcrypt` algorithm and setting
+the `rounds` configuration value to a higher number then the default of `10`, that
+verification of a user password can cause significantly increased CPU usage and
+additional latency in processing requests.
+
+If your Verdaccio instance handles a large number of authenticated requests using
+username and password for authentication, the `rounds` configuration value may need
+to be decreased to prevent excessive CPU usage and request latency.
+
+Also note that setting the `rounds` configuration value to a value that is too small
+increases the risk of successful brute force attack. Auth0 has a
+[blog article](https://auth0.com/blog/hashing-in-action-understanding-bcrypt)
+that provides an overview of how `bcrypt` hashing works and some best practices.
 
 ## Logging In
 

--- a/packages/plugins/htpasswd/tests/__fixtures__/htpasswd
+++ b/packages/plugins/htpasswd/tests/__fixtures__/htpasswd
@@ -1,2 +1,3 @@
 test:$6FrCaT/v0dwE:autocreated 2018-01-17T03:40:22.958Z
 username:$66to3JK5RgZM:autocreated 2018-01-17T03:40:46.315Z
+bcrypt:$2y$04$K2Cn3StiXx4CnLmcTW/ymekOrj7WlycZZF9xgmoJ/U0zGPqSLPVBe

--- a/packages/plugins/htpasswd/tests/__mocks__/Logger.ts
+++ b/packages/plugins/htpasswd/tests/__mocks__/Logger.ts
@@ -1,1 +1,0 @@
-export default class Logger {}

--- a/packages/plugins/htpasswd/tests/utils.test.ts
+++ b/packages/plugins/htpasswd/tests/utils.test.ts
@@ -1,3 +1,4 @@
+// @ts-ignore: Module has no default export
 import crypto from 'crypto';
 import MockDate from 'mockdate';
 
@@ -66,40 +67,40 @@ user4:$6FrCasdvppdwE:autocreated 2017-12-14T13:30:20.838Z`;
 });
 
 describe('verifyPassword', () => {
-  it('should verify the MD5/Crypt3 password with true', () => {
+  it('should verify the MD5/Crypt3 password with true', async () => {
     const input = ['test', '$apr1$sKXK9.lG$rZ4Iy63Vtn8jF9/USc4BV0'];
-    expect(verifyPassword(input[0], input[1])).toBeTruthy();
+    expect(await verifyPassword(input[0], input[1])).toBeTruthy();
   });
-  it('should verify the MD5/Crypt3 password with false', () => {
+  it('should verify the MD5/Crypt3 password with false', async () => {
     const input = ['testpasswordchanged', '$apr1$sKXK9.lG$rZ4Iy63Vtn8jF9/USc4BV0'];
-    expect(verifyPassword(input[0], input[1])).toBeFalsy();
+    expect(await verifyPassword(input[0], input[1])).toBeFalsy();
   });
-  it('should verify the plain password with true', () => {
+  it('should verify the plain password with true', async () => {
     const input = ['testpasswordchanged', '{PLAIN}testpasswordchanged'];
-    expect(verifyPassword(input[0], input[1])).toBeTruthy();
+    expect(await verifyPassword(input[0], input[1])).toBeTruthy();
   });
-  it('should verify the plain password with false', () => {
+  it('should verify the plain password with false', async () => {
     const input = ['testpassword', '{PLAIN}testpasswordchanged'];
-    expect(verifyPassword(input[0], input[1])).toBeFalsy();
+    expect(await verifyPassword(input[0], input[1])).toBeFalsy();
   });
-  it('should verify the crypto SHA password with true', () => {
+  it('should verify the crypto SHA password with true', async () => {
     const input = ['testpassword', '{SHA}i7YRj4/Wk1rQh2o740pxfTJwj/0='];
-    expect(verifyPassword(input[0], input[1])).toBeTruthy();
+    expect(await verifyPassword(input[0], input[1])).toBeTruthy();
   });
-  it('should verify the crypto SHA password with false', () => {
+  it('should verify the crypto SHA password with false', async () => {
     const input = ['testpasswordchanged', '{SHA}i7YRj4/Wk1rQh2o740pxfTJwj/0='];
-    expect(verifyPassword(input[0], input[1])).toBeFalsy();
+    expect(await verifyPassword(input[0], input[1])).toBeFalsy();
   });
-  it('should verify the bcrypt password with true', () => {
+  it('should verify the bcrypt password with true', async () => {
     const input = ['testpassword', '$2y$04$Wqed4yN0OktGbiUdxSTwtOva1xfESfkNIZfcS9/vmHLsn3.lkFxJO'];
-    expect(verifyPassword(input[0], input[1])).toBeTruthy();
+    expect(await verifyPassword(input[0], input[1])).toBeTruthy();
   });
-  it('should verify the bcrypt password with false', () => {
+  it('should verify the bcrypt password with false', async () => {
     const input = [
       'testpasswordchanged',
       '$2y$04$Wqed4yN0OktGbiUdxSTwtOva1xfESfkNIZfcS9/vmHLsn3.lkFxJO',
     ];
-    expect(verifyPassword(input[0], input[1])).toBeFalsy();
+    expect(await verifyPassword(input[0], input[1])).toBeFalsy();
   });
 });
 
@@ -170,58 +171,58 @@ describe('sanityCheck', () => {
     users = { test: '$6FrCaT/v0dwE' };
   });
 
-  test('should throw error for user already exists', () => {
+  test('should throw error for user already exists', async () => {
     const verifyFn = jest.fn();
-    const input = sanityCheck('test', users.test, verifyFn, users, Infinity);
+    const input = await sanityCheck('test', users.test, verifyFn, users, Infinity);
     expect(input.status).toEqual(401);
     expect(input.message).toEqual('unauthorized access');
     expect(verifyFn).toHaveBeenCalled();
   });
 
-  test('should throw error for registration disabled of users', () => {
+  test('should throw error for registration disabled of users', async () => {
     const verifyFn = (): void => {};
-    const input = sanityCheck('username', users.test, verifyFn, users, -1);
+    const input = await sanityCheck('username', users.test, verifyFn, users, -1);
     expect(input.status).toEqual(409);
     expect(input.message).toEqual('user registration disabled');
   });
 
-  test('should throw error max number of users', () => {
+  test('should throw error max number of users', async () => {
     const verifyFn = (): void => {};
-    const input = sanityCheck('username', users.test, verifyFn, users, 1);
+    const input = await sanityCheck('username', users.test, verifyFn, users, 1);
     expect(input.status).toEqual(403);
     expect(input.message).toEqual('maximum amount of users reached');
   });
 
-  test('should not throw anything and sanity check', () => {
+  test('should not throw anything and sanity check', async () => {
     const verifyFn = (): void => {};
-    const input = sanityCheck('username', users.test, verifyFn, users, 2);
+    const input = await sanityCheck('username', users.test, verifyFn, users, 2);
     expect(input).toBeNull();
   });
 
-  test('should throw error for required username field', () => {
+  test('should throw error for required username field', async () => {
     const verifyFn = (): void => {};
-    const input = sanityCheck(undefined, users.test, verifyFn, users, 2);
+    const input = await sanityCheck(undefined, users.test, verifyFn, users, 2);
     expect(input.message).toEqual('username and password is required');
     expect(input.status).toEqual(400);
   });
 
-  test('should throw error for required password field', () => {
+  test('should throw error for required password field', async () => {
     const verifyFn = (): void => {};
-    const input = sanityCheck('username', undefined, verifyFn, users, 2);
+    const input = await sanityCheck('username', undefined, verifyFn, users, 2);
     expect(input.message).toEqual('username and password is required');
     expect(input.status).toEqual(400);
   });
 
-  test('should throw error for required username & password fields', () => {
+  test('should throw error for required username & password fields', async () => {
     const verifyFn = (): void => {};
-    const input = sanityCheck(undefined, undefined, verifyFn, users, 2);
+    const input = await sanityCheck(undefined, undefined, verifyFn, users, 2);
     expect(input.message).toEqual('username and password is required');
     expect(input.status).toEqual(400);
   });
 
-  test('should throw error for existing username and password', () => {
+  test('should throw error for existing username and password', async () => {
     const verifyFn = jest.fn(() => true);
-    const input = sanityCheck('test', users.test, verifyFn, users, 2);
+    const input = await sanityCheck('test', users.test, verifyFn, users, 2);
     expect(input.status).toEqual(409);
     expect(input.message).toEqual('username is already registered');
     expect(verifyFn).toHaveBeenCalledTimes(1);
@@ -229,9 +230,9 @@ describe('sanityCheck', () => {
 
   test(
     'should throw error for existing username and password with max number ' + 'of users reached',
-    () => {
+    async () => {
       const verifyFn = jest.fn(() => true);
-      const input = sanityCheck('test', users.test, verifyFn, users, 1);
+      const input = await sanityCheck('test', users.test, verifyFn, users, 1);
       expect(input.status).toEqual(409);
       expect(input.message).toEqual('username is already registered');
       expect(verifyFn).toHaveBeenCalledTimes(1);
@@ -240,11 +241,11 @@ describe('sanityCheck', () => {
 });
 
 describe('changePasswordToHTPasswd', () => {
-  test('should throw error for wrong password', () => {
+  test('should throw error for wrong password', async () => {
     const body = 'test:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z';
 
     try {
-      changePasswordToHTPasswd(
+      await changePasswordToHTPasswd(
         body,
         'test',
         'somerandompassword',
@@ -252,15 +253,35 @@ describe('changePasswordToHTPasswd', () => {
         defaultHashConfig
       );
     } catch (error: any) {
-      expect(error.message).toEqual('Invalid old Password');
+      expect(error.message).toEqual(
+        `Unable to change password for user 'test': invalid old password`
+      );
     }
   });
 
-  test('should change the password', () => {
+  test('should throw error when user does not exist', async () => {
+    const body = 'test:$6b9MlB3WUELU:autocreated 2017-11-06T18:17:21.957Z';
+
+    try {
+      await changePasswordToHTPasswd(
+        body,
+        'test2',
+        'somerandompassword',
+        'newPassword',
+        defaultHashConfig
+      );
+    } catch (error: any) {
+      expect(error.message).toEqual(
+        `Unable to change password for user 'test2': user does not currently exist`
+      );
+    }
+  });
+
+  test('should change the password', async () => {
     const body = 'root:$6qLTHoPfGLy2:autocreated 2018-08-20T13:38:12.164Z';
 
     expect(
-      changePasswordToHTPasswd(body, 'root', 'demo123', 'newPassword', defaultHashConfig)
+      await changePasswordToHTPasswd(body, 'root', 'demo123', 'newPassword', defaultHashConfig)
     ).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Related to #3010

## Changes
* fix: refactor htpasswd plugin to use the bcryptjs `compare` api call instead of `compareSync`
* feat: add a new configuration value named `slow_verify_ms` to the htpasswd plugin that when exceeded during password verification will log a warning message
* chore: update README.md for htpasswd plugin to add additional information about the 'rounds' configuration value and also include the new `slow_verify_ms` configuration value