### PR TITLE
 Node JS API Documentation : Working Implementation Code

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Audit preview URL with Lighthouse
         id: lighthouse_audit
-        uses: treosh/lighthouse-ci-action@v9.3.0
+        uses: treosh/lighthouse-ci-action@9.3.0
         with:
           urls: |
             ${{ steps.netlify_preview.outputs.preview-url }}

--- a/website/docs/node-api.md
+++ b/website/docs/node-api.md
@@ -45,9 +45,9 @@ let config = {
 };
 
 startServer(
-    config, // Replace by undefined if you use a config file
+    config,
     6000,
-    undefined, // Config file path 
+    undefined,
     "1.0.0",
     "verdaccio",
     (webServer, addrs) => {

--- a/website/docs/node-api.md
+++ b/website/docs/node-api.md
@@ -10,14 +10,56 @@ Verdaccio can be invoked programmatically. The Node API was introduced after ver
 #### Programmatically {#programmatically}
 
 ```js
- import startServer from 'verdaccio';
+const startServer = require("verdaccio").default;
 
- startServer(configJsonFormat, 6000, store, '1.0.0', 'verdaccio',
-    (webServer, addrs, pkgName, pkgVersion) => {
-		webServer.listen(addr.port || addr.path, addr.host, () => {
-			console.log('verdaccio running');
-		});
-  });
+let config = {
+    storage: "./storage",
+    auth: {
+        htpasswd: {
+            file: "./htpasswd"
+        }
+    },
+    uplinks: {
+        npmjs: {
+            url: "https://registry.npmjs.org/",
+        }
+    },
+    self_path: "./",
+    packages: {
+        "@*/*": {
+            access: "$all",
+            publish: "$authenticated",
+            proxy: "npmjs",
+        },
+        "**": {
+            proxy: "npmjs"
+        }
+    },
+    logs: [
+        {
+            type: "stdout",
+            format: "pretty",
+            level: "http",
+        }
+    ],
+};
+
+startServer(
+    config, // Replace by undefined if you use a config file
+    6000,
+    undefined, // Config file path 
+    "1.0.0",
+    "verdaccio",
+    (webServer, addrs) => {
+        webServer.listen(
+            addrs.port || addrs.path,
+            addrs.host,
+            () => {
+                console.log(`verdaccio running on : ${addrs.host}:${addrs.port}`);
+            }
+        );
+    }
+);
 ```
 
 ## Other implementations {#other-implementations}


### PR DESCRIPTION
Improving Node API documentation

Maybe add where do the `addrs` comes from / how we can define it from config file ?
Added host and port display cause otherwise user doesn't know which default address and port are.