### PR TITLE
feat: update docker base node to 14.x in 4.x branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.17.0-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.18.3-alpine as builder
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.verdaccio.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14.18.3-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:14-alpine as builder
 
 ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.verdaccio.org
@@ -23,7 +23,7 @@ RUN yarn config set npmRegistryServer $VERDACCIO_BUILD_REGISTRY && \
 
 
 
-FROM node:14.17.0-alpine
+FROM node:14-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV NODE_ENV=production \
     VERDACCIO_BUILD_REGISTRY=https://registry.verdaccio.org
 
 RUN apk --no-cache add openssl ca-certificates wget && \
-    apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python && \
+    apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python2 && \
     wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
     wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
     apk add glibc-2.25-r0.apk


### PR DESCRIPTION
`v14.18.3` of node fixes a bunch of security vulnerabilities. Originally, I upgraded node to the earliest version possible to avoid any unnecessary breaking changes. In the review, I was recommended to just switch to `node:14-alpine` (latest `v14` version of node) so I did.

Specifically:

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22921
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22930
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22918
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22940
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22960
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22959
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44532
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44533
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44531
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22931
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3672