### PR TITLE
fix(loaders): always create plugin instance with new

### DIFF
--- a/.changeset/lovely-drinks-argue.md
+++ b/.changeset/lovely-drinks-argue.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/loaders': patch
+---
+
+always create plugin instance with new

--- a/packages/loaders/src/plugin-loader.ts
+++ b/packages/loaders/src/plugin-loader.ts
@@ -121,7 +121,7 @@ export function loadPlugin<T extends IPlugin<T>>(
     try {
       plugin = isES6(plugin)
         ? new plugin.default(mergeConfig(config, pluginConfigs[pluginId]), params)
-        : plugin(pluginConfigs[pluginId], params);
+        : new plugin(pluginConfigs[pluginId], params);
     } catch (error: any) {
       plugin = null;
       logger.error({ error, pluginId }, 'error loading a plugin @{pluginId}: @{error}');


### PR DESCRIPTION
* class plugin transpile with babel contains a function '_classCallCheck',
* will throw an error when a class is invoked without 'new'
* see: https://babeljs.io/docs/en/babel-plugin-transform-classes#examples