### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -3,6 +3,6 @@ import semver from 'semver';
 export const MIN_NODE_VERSION = '14.0.0';
 
 export function isVersionValid(processVersion) {
-  const version = processVersion.substr(1);
+  const version = processVersion.slice(1);
   return semver.satisfies(version, `>=${MIN_NODE_VERSION}`);
 }

--- a/packages/core/url/src/index.ts
+++ b/packages/core/url/src/index.ts
@@ -38,7 +38,7 @@ export function getWebProtocol(headerProtocol: string | void, protocol: string):
   if (typeof headerProtocol === 'string' && headerProtocol !== '') {
     debug('header protocol: %o', protocol);
     const commaIndex = headerProtocol.indexOf(',');
-    returnProtocol = commaIndex > 0 ? headerProtocol.substr(0, commaIndex) : headerProtocol;
+    returnProtocol = commaIndex > 0 ? headerProtocol.slice(0, commaIndex) : headerProtocol;
   } else {
     debug('req protocol: %o', headerProtocol);
     returnProtocol = protocol;

--- a/packages/logger-prettify/src/formatter.ts
+++ b/packages/logger-prettify/src/formatter.ts
@@ -26,7 +26,7 @@ export function fillInMsgTemplate(msg, templateOptions: ObjectTemplate, colors):
     let str = templateOptions;
     let isError;
     if (name[0] === ERROR_FLAG) {
-      name = name.substr(1);
+      name = name.slice(1);
       isError = true;
     }
 

--- a/packages/plugins/htpasswd/src/utils.ts
+++ b/packages/plugins/htpasswd/src/utils.ts
@@ -61,14 +61,14 @@ export async function verifyPassword(passwd: string, hash: string): Promise<bool
       bcrypt.compare(passwd, hash, (error, result) => (error ? reject(error) : resolve(result)))
     );
   } else if (hash.indexOf('{PLAIN}') === 0) {
-    return passwd === hash.substr(7);
+    return passwd === hash.slice(7);
   } else if (hash.indexOf('{SHA}') === 0) {
     return (
       crypto
         .createHash('sha1')
         // https://nodejs.org/api/crypto.html#crypto_hash_update_data_inputencoding
         .update(passwd, 'utf8')
-        .digest('base64') === hash.substr(5)
+        .digest('base64') === hash.slice(5)
     );
   }
   // for backwards compatibility, first check md5 then check crypt3

--- a/packages/plugins/local-storage/src/local-fs.ts
+++ b/packages/plugins/local-storage/src/local-fs.ts
@@ -35,7 +35,7 @@ export const fSError = function (message: string, code = 409): VerdaccioError {
 };
 
 const tempFile = function (str): string {
-  return `${str}.tmp${String(Math.random()).substr(2)}`;
+  return `${str}.tmp${String(Math.random()).slice(2)}`;
 };
 
 const renameTmp = function (src, dst, _cb): void {

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -158,7 +158,7 @@ export function pad(str, max): string {
  * @returns {String}
  */
 export function mask(str: string, charNum = 3): string {
-  return `${str.substr(0, charNum)}...${str.substr(-charNum)}`;
+  return `${str.slice(0, charNum)}...${str.slice(-charNum)}`;
 }
 
 // @deprecated


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.