### PR TITLE
Remove link to Red Cross donation

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -59,7 +59,7 @@ module.exports = {
     announcementBar: {
       id: 'announcementBar',
       content:
-        '<a target="_blank" rel="noopener noreferrer" href="https://donate.redcrossredcrescent.org/ua/donate/~my-donation?_cv=1">Help provide humanitarian support to Ukraine refugees</a>!',
+        '<a target="_blank" rel="noopener noreferrer" href="https://savelife.in.ua/en/donate/">Support Ukraine</a>!',
         isCloseable: false,
         backgroundColor: '#1595de',
         textColor: '#ffffff',


### PR DESCRIPTION
Removed Red Cross donation link, as they spending money in a terrible way.
Sources:
https://mobile.twitter.com/your_psychoo/status/1507110118906863617?s=21&t=8Wz67Xfp19a3lT6r0VaIwg
https://life.pravda.com.ua/society/2022/03/26/247987/
https://telegraf.com.ua/ukr/ukraina/2022-03-25/5700516-na-krasnom-kreste-mozhno-stavit-krest-ukraintsev-vozmutili-strannye-dogovorennosti-s-lavrovym
https://nv.ua/ukr/ukraine/events/chervoniy-hrest-skandal-z-ofisom-u-rostovi-nacionalniy-komitet-poyasniv-situaciyu-novini-ukrajini-50228742.html