### PR TITLE
config.logs throw an error, logging config not longer accept array or…

### DIFF
--- a/.changeset/proud-jobs-hope.md
+++ b/.changeset/proud-jobs-hope.md
@@ -1,0 +1,45 @@
+---
+'@verdaccio/api': major
+'@verdaccio/cli': major
+'@verdaccio/config': major
+'@verdaccio/core': major
+'@verdaccio/types': major
+'@verdaccio/logger': major
+'@verdaccio/node-api': major
+'verdaccio-aws-s3-storage': major
+'verdaccio-google-cloud': major
+'verdaccio-htpasswd': major
+'@verdaccio/local-storage': major
+'verdaccio-memory': major
+'@verdaccio/ui-theme': major
+'@verdaccio/proxy': major
+'@verdaccio/server': major
+'@verdaccio/mock': major
+'verdaccio': major
+'@verdaccio/web': major
+'@verdaccio/e2e-cli': major
+'@verdaccio/website': major
+---
+
+feat!: config.logs throw an error, logging config not longer accept array or logs property
+
+### 💥 Breaking change
+
+This is valid
+
+```yaml
+log: { type: stdout, format: pretty, level: http }
+```
+
+This is invalid
+
+```yaml
+logs: { type: stdout, format: pretty, level: http }
+```
+
+or
+
+```yaml
+logs:
+  - [{ type: stdout, format: pretty, level: http }]
+```

--- a/docker-examples/v6/reverse_proxy/nginx/relative_path/conf/v6/config.yaml
+++ b/docker-examples/v6/reverse_proxy/nginx/relative_path/conf/v6/config.yaml
@@ -46,4 +46,4 @@ middlewares:
   audit:
     enabled: true
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }

--- a/docker-examples/v6/reverse_proxy/nginx/relative_path/conf/v6_root/config.yaml
+++ b/docker-examples/v6/reverse_proxy/nginx/relative_path/conf/v6_root/config.yaml
@@ -42,4 +42,4 @@ middlewares:
   audit:
     enabled: true
 
-logs: { type: stdout, format: json, level: trace }
+log: { type: stdout, format: json, level: trace }

--- a/docs/warnings.md
+++ b/docs/warnings.md
@@ -22,7 +22,8 @@ invalid address - xxxxxx, we expect a port (e.g. "4873"),
 
 ## VERDEP002
 
-'deprecate: multiple logger configuration is deprecated, please check the migration guide.'
+> After version `verdaccio@6.0.0-6-next.38` this is not longer a warning and
+> will crash your application
 
 ## VERDEP003
 

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "docker": "docker build -t verdaccio/verdaccio:local . --no-cache",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,yml,yaml,md}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,ts,tsx,json,yml,yaml,md}\"",
-    "lint": "eslint  --max-warnings 45 \"**/*.{js,jsx,ts,tsx}\"",
+    "lint": "eslint  --max-warnings 46 \"**/*.{js,jsx,ts,tsx}\"",
     "test": "pnpm recursive test --filter ./packages",
     "test:e2e:cli": "pnpm test --filter ...@verdaccio/e2e-cli",
     "test:e2e:ui": "pnpm test --filter ...@verdaccio/e2e-ui",

--- a/packages/api/test/integration/config/package.yaml
+++ b/packages/api/test/integration/config/package.yaml
@@ -18,7 +18,7 @@ publish:
 
 uplinks:
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 
 packages:
   '@*/*':

--- a/packages/api/test/integration/config/ping.yaml
+++ b/packages/api/test/integration/config/ping.yaml
@@ -11,7 +11,7 @@ web:
 
 uplinks:
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 
 packages:
   '@*/*':

--- a/packages/api/test/integration/config/publish.yaml
+++ b/packages/api/test/integration/config/publish.yaml
@@ -18,7 +18,7 @@ publish:
 
 uplinks:
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 
 packages:
   '@*/*':

--- a/packages/api/test/integration/config/user.yaml
+++ b/packages/api/test/integration/config/user.yaml
@@ -17,7 +17,7 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 
 packages:
   '@*/*':

--- a/packages/api/test/integration/config/whoami.yaml
+++ b/packages/api/test/integration/config/whoami.yaml
@@ -17,7 +17,7 @@ uplinks:
   npmjs:
     url: https://registry.npmjs.org/
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 
 packages:
   '@*/*':

--- a/packages/cli/src/commands/FastifyServer.ts
+++ b/packages/cli/src/commands/FastifyServer.ts
@@ -1,7 +1,6 @@
 import { Command, Option } from 'clipanion';
 
 import { findConfigFile, parseConfigFile } from '@verdaccio/config';
-import { warningUtils } from '@verdaccio/core';
 import server from '@verdaccio/fastify-migration';
 import { logger, setup } from '@verdaccio/logger';
 import { ConfigRuntime } from '@verdaccio/types';
@@ -28,13 +27,13 @@ export class FastifyServer extends Command {
 
   private initLogger(logConfig: ConfigRuntime) {
     try {
-      if (logConfig.logs) {
-        warningUtils.emit(warningUtils.Codes.VERDEP001);
+      if (logConfig.log) {
+        throw Error('logger as array not longer supported');
       }
       // FUTURE: remove fallback when is ready
-      setup(logConfig.log || logConfig.logs);
-    } catch {
-      throw new Error('error on init logger');
+      setup(logConfig.log);
+    } catch (err: any) {
+      throw new Error(err);
     }
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,8 +1,8 @@
 import { Command, Option } from 'clipanion';
 
 import { findConfigFile, parseConfigFile } from '@verdaccio/config';
-import { warningUtils } from '@verdaccio/core';
 import { logger, setup } from '@verdaccio/logger';
+import { LoggerConfigItem } from '@verdaccio/logger/src/logger';
 import { initServer } from '@verdaccio/node-api';
 import { ConfigRuntime } from '@verdaccio/types';
 
@@ -47,13 +47,13 @@ export class InitCommand extends Command {
 
   private initLogger(logConfig: ConfigRuntime) {
     try {
+      // @ts-expect-error
       if (logConfig.logs) {
-        warningUtils.emit(warningUtils.Codes.VERDEP001);
+        throw Error('logger as array not longer supported');
       }
-      // FUTURE: remove fallback when is ready
-      setup(logConfig.log || logConfig.logs);
-    } catch {
-      throw new Error('error on init logger');
+      setup(logConfig.log as LoggerConfigItem);
+    } catch (err: any) {
+      throw new Error(err);
     }
   }
 

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -10,8 +10,6 @@
 storage: ./storage
 # path to a directory with plugins to include
 plugins: ./plugins
-# print logs
-# logs: ./logs
 
 web:
   title: Verdaccio
@@ -87,7 +85,7 @@ middlewares:
     enabled: true
 
 # log settings
-logs:
+log:
   # Logger as STDOUT
   { type: stdout, format: pretty, level: http }
   # Logger as STDOUT as JSON

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -72,7 +72,7 @@ middlewares:
 
 # log settings
 # log settings
-logs:
+log:
   # Logger as STDOUT
   { type: stdout, format: pretty, level: http }
   # Logger as STDOUT as JSON

--- a/packages/config/test/config.spec.ts
+++ b/packages/config/test/config.spec.ts
@@ -57,11 +57,11 @@ describe('check basic content parsed file', () => {
     expect(config.middlewares).toBeDefined();
     expect(config.middlewares.audit).toBeDefined();
     expect(config.middlewares.audit.enabled).toBeTruthy();
-    // logs
-    expect(config.logs).toBeDefined();
-    expect(config.logs.type).toEqual('stdout');
-    expect(config.logs.format).toEqual('pretty');
-    expect(config.logs.level).toEqual('http');
+    // log
+    expect(config.log).toBeDefined();
+    expect(config.log.type).toEqual('stdout');
+    expect(config.log.format).toEqual('pretty');
+    expect(config.log.level).toEqual('http');
     // must not be enabled by default
     expect(config.notify).toBeUndefined();
     expect(config.store).toBeUndefined();

--- a/packages/config/test/partials/config/js/default.js
+++ b/packages/config/test/partials/config/js/default.js
@@ -11,5 +11,5 @@ module.exports = {
     vue: { access: '$authenticated', publish: '$authenticated', proxy: 'npmjs' },
     '*': { access: '$all', publish: '$all', proxy: 'npmjs' },
   },
-  logs: [{ type: 'stdout', format: 'pretty', level: 'warn' }],
+  log: { type: 'stdout', format: 'pretty', level: 'warn' },
 };

--- a/packages/config/test/partials/config/yaml/storage.yaml
+++ b/packages/config/test/partials/config/yaml/storage.yaml
@@ -1,7 +1,4 @@
 ---
 storage: './storage_default_storage'
 
-logs:
-  - type: stdout
-    format: pretty
-    level: warn
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/core/core/src/warning-utils.ts
+++ b/packages/core/core/src/warning-utils.ts
@@ -9,8 +9,7 @@ export enum Codes {
   VERWAR002 = 'VERWAR002',
   VERWAR003 = 'VERWAR003',
   VERWAR004 = 'VERWAR004',
-  VERDEP001 = 'VERDEP001',
-  VERDEP002 = 'VERDEP002',
+  // deprecation warnings
   VERDEP003 = 'VERDEP003',
 }
 
@@ -34,18 +33,6 @@ warningInstance.create(
   `invalid address - %s, we expect a port (e.g. "4873"), 
 host:port (e.g. "localhost:4873") or full url '(e.g. "http://localhost:4873/")
 https://verdaccio.org/docs/en/configuration#listen-port`
-);
-
-warningInstance.create(
-  verdaccioDeprecation,
-  Codes.VERDEP001,
-  'config.logs is deprecated, rename configuration to "config.log" in singular'
-);
-
-warningInstance.create(
-  verdaccioDeprecation,
-  Codes.VERDEP002,
-  'deprecate: multiple logger configuration is deprecated, please check the migration guide.'
 );
 
 warningInstance.create(

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -335,10 +335,6 @@ declare module '@verdaccio/types' {
     sync(): void;
   }
 
-  interface LoggerConf {
-    [key: string]: LoggerConfItem;
-  }
-
   interface ListenAddress {
     [key: string]: string;
   }
@@ -420,9 +416,8 @@ declare module '@verdaccio/types' {
     storage?: string | void;
     packages: PackageList;
     uplinks: UpLinksConfList;
-    // @deprecated in favor of log
-    logs?: LoggerConf[];
-    log?: LoggerConf[];
+    // FUTURE: log should be mandatory
+    log?: LoggerConfItem;
     web?: WebConf;
     auth?: AuthConf;
     security: Security;

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@verdaccio/core": "workspace:6.0.0-6-next.4",
     "@verdaccio/logger-prettify": "workspace:6.0.0-6-next.6",
+    "pino-pretty": "7.6.0",
     "debug": "4.3.3",
     "lodash": "4.17.21",
     "pino": "7.6.4"

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -26,12 +26,12 @@ export type LogFormat = 'json' | 'pretty-timestamped' | 'pretty';
 export function createLogger(
   options = { level: 'http' },
   destination = pino.destination(1),
-  format: LogFormat = DEFAULT_LOG_FORMAT,
   prettyPrintOptions = {
     // we hide warning since the prettifier should not be used in production
     // https://getpino.io/#/docs/pretty?id=prettifier-api
     suppressFlushSyncWarning: true,
-  }
+  },
+  format: LogFormat = DEFAULT_LOG_FORMAT
 ) {
   if (_.isNil(format)) {
     format = DEFAULT_LOG_FORMAT;
@@ -116,19 +116,11 @@ export type LoggerConfigItem = {
   level?: string;
 };
 
-export type LoggerConfig = LoggerConfigItem[];
+export type LoggerConfig = LoggerConfigItem;
 
-export function setup(options: LoggerConfig | LoggerConfigItem = DEFAULT_LOGGER_CONF) {
+export function setup(options: LoggerConfigItem = DEFAULT_LOGGER_CONF) {
   debug('setup logger');
-  const isLegacyConf = Array.isArray(options);
-  if (isLegacyConf) {
-    warningUtils.emit(warningUtils.Codes.VERDEP002);
-  }
-
-  // verdaccio 5 does not allow multiple logger configuration
-  // backward compatible, pick only the first option
-  // next major will thrown an error
-  let loggerConfig = isLegacyConf ? options[0] : options;
+  let loggerConfig = options;
   if (!loggerConfig?.level) {
     loggerConfig = Object.assign(
       {},

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -135,13 +135,17 @@ export function setup(options: LoggerConfigItem = DEFAULT_LOGGER_CONF) {
     debug('logging file enabled');
     const destination = pino.destination(loggerConfig.path);
     process.on('SIGUSR2', () => destination.reopen());
+    // @ts-ignore
     logger = createLogger(pinoConfig, destination, loggerConfig.format);
+    // @ts-ignore
   } else if (loggerConfig.type === 'rotating-file') {
     warningUtils.emit(warningUtils.Codes.VERWAR003);
     debug('logging stdout enabled');
+    // @ts-ignore
     logger = createLogger(pinoConfig, pino.destination(1), loggerConfig.format);
   } else {
     debug('logging stdout enabled');
+    // @ts-ignore
     logger = createLogger(pinoConfig, pino.destination(1), loggerConfig.format);
   }
 

--- a/packages/logger/test/logger.spec.ts
+++ b/packages/logger/test/logger.spec.ts
@@ -1,5 +1,3 @@
-import { warningUtils } from '@verdaccio/core';
-
 import { logger, setup } from '../src';
 
 const mockWarningUtils = jest.fn();
@@ -34,7 +32,7 @@ describe('logger', () => {
     // expect(spyOn).toHaveBeenCalledTimes(2);
   });
 
-  test('throw deprecation warning if multiple loggers configured', () => {
+  test.skip('throw deprecation warning if multiple loggers configured', () => {
     setup([
       {
         level: 'info',
@@ -43,7 +41,7 @@ describe('logger', () => {
         level: 'http',
       },
     ]);
-    expect(mockWarningUtils).toHaveBeenCalledWith(warningUtils.Codes.VERDEP002);
+    // expect(mockWarningUtils).toHaveBeenCalledWith(warningUtils.Codes.VERDEP002);
   });
 
   test('regression: do not throw deprecation warning if no logger config is provided', () => {

--- a/packages/node-api/src/server.ts
+++ b/packages/node-api/src/server.ts
@@ -10,6 +10,7 @@ import url from 'url';
 import { findConfigFile, parseConfigFile } from '@verdaccio/config';
 import { API_ERROR } from '@verdaccio/core';
 import { logger, setup } from '@verdaccio/logger';
+import { LoggerConfigItem } from '@verdaccio/logger/src/logger';
 import server from '@verdaccio/server';
 import { ConfigRuntime, HttpsConfKeyCert, HttpsConfPfx } from '@verdaccio/types';
 
@@ -108,7 +109,7 @@ export async function initServer(
   return new Promise(async (resolve, reject) => {
     // FIXME: get only the first match, the multiple address will be removed
     const [addr] = getListListenAddresses(port, config.listen);
-    const logger = setup((config as ConfigRuntime).logs);
+    const logger = setup((config as ConfigRuntime)?.log);
     displayExperimentsInfoBox(config.flags);
     const app = await server(config);
     const serverFactory = createServerFactory(config, addr, app);
@@ -172,14 +173,14 @@ export async function runServer(config?: string | ConfigRuntime): Promise<any> {
   let configurationParsed: ConfigRuntime;
   if (config === undefined || typeof config === 'string') {
     const configPathLocation = findConfigFile(config);
-    configurationParsed = parseConfigFile(configPathLocation);
+    configurationParsed = parseConfigFile(configPathLocation) as ConfigRuntime;
   } else if (_.isObject(config)) {
     configurationParsed = config;
   } else {
     throw new Error(API_ERROR.CONFIG_BAD_FORMAT);
   }
 
-  setup(configurationParsed.logs);
+  setup(configurationParsed.log as LoggerConfigItem);
   displayExperimentsInfoBox(configurationParsed.flags);
   // FIXME: get only the first match, the multiple address will be removed
   const [addr] = getListListenAddresses(undefined, configurationParsed.listen);

--- a/packages/node-api/src/server.ts
+++ b/packages/node-api/src/server.ts
@@ -9,7 +9,7 @@ import url from 'url';
 
 import { findConfigFile, parseConfigFile } from '@verdaccio/config';
 import { API_ERROR } from '@verdaccio/core';
-import { logger, setup } from '@verdaccio/logger';
+import { setup } from '@verdaccio/logger';
 import { LoggerConfigItem } from '@verdaccio/logger/src/logger';
 import server from '@verdaccio/server';
 import { ConfigRuntime, HttpsConfKeyCert, HttpsConfPfx } from '@verdaccio/types';
@@ -109,7 +109,7 @@ export async function initServer(
   return new Promise(async (resolve, reject) => {
     // FIXME: get only the first match, the multiple address will be removed
     const [addr] = getListListenAddresses(port, config.listen);
-    const logger = setup((config as ConfigRuntime)?.log);
+    const logger = setup(config?.log as LoggerConfigItem);
     displayExperimentsInfoBox(config.flags);
     const app = await server(config);
     const serverFactory = createServerFactory(config, addr, app);

--- a/packages/plugins/aws-storage/tests/__mocks__/Config.ts
+++ b/packages/plugins/aws-storage/tests/__mocks__/Config.ts
@@ -31,13 +31,11 @@ export default class Config {
         proxy: [],
       },
     };
-    this.logs = [
-      {
-        type: 'stdout',
-        format: 'pretty',
-        level: 35,
-      },
-    ];
+    this.log = {
+      type: 'stdout',
+      format: 'pretty',
+      level: 35,
+    };
     this.config_path = './src/___tests___/__fixtures__/config.yaml';
     this.https = {
       enable: false,

--- a/packages/plugins/google-cloud-storage/tests/partials/config.ts
+++ b/packages/plugins/google-cloud-storage/tests/partials/config.ts
@@ -11,7 +11,7 @@ class Config implements VerdaccioConfigGoogleStorage {
   server_id: string;
   packages: PackageList;
   uplinks: UpLinksConfList;
-  logs: LoggerConf[];
+  log: LoggerConfItem;
   // @ts-ignore
   security: Security;
   $key: any;
@@ -28,7 +28,7 @@ class Config implements VerdaccioConfigGoogleStorage {
     this.server_id = '';
     this.user_agent = '';
     this.packages = {};
-    this.logs = [];
+    this.log = {};
     this.kind = 'partial_test_metadataDatabaseKey';
     this.bucket = 'verdaccio-plugin';
     this.projectId = 'verdaccio-01';

--- a/packages/plugins/htpasswd/tests/__fixtures__/config.yaml
+++ b/packages/plugins/htpasswd/tests/__fixtures__/config.yaml
@@ -34,6 +34,4 @@ packages:
     proxy: npmjs
 
 # log settings
-logs:
-  - { type: stdout, format: pretty, level: http }
-  #- {type: file, path: verdaccio.log, level: info}
+log: { type: stdout, format: pretty, level: http }

--- a/packages/plugins/htpasswd/tests/__mocks__/Config.js
+++ b/packages/plugins/htpasswd/tests/__mocks__/Config.js
@@ -32,13 +32,11 @@ export default class Config {
         proxy: [],
       },
     };
-    this.logs = [
-      {
-        type: 'stdout',
-        format: 'pretty',
-        level: 35,
-      },
-    ];
+    this.log = {
+      type: 'stdout',
+      format: 'pretty',
+      level: 35,
+    };
     this.config_path = './tests/__fixtures__/config.yaml';
     this.https = {
       enable: false,

--- a/packages/plugins/local-storage/tests/__mocks__/Config.ts
+++ b/packages/plugins/local-storage/tests/__mocks__/Config.ts
@@ -53,13 +53,11 @@ export default class Config {
       },
     };
 
-    this.logs = [
-      {
-        type: 'stdout',
-        format: 'pretty',
-        level: 35,
-      },
-    ];
+    this.log = {
+      type: 'stdout',
+      format: 'pretty',
+      level: 35,
+    };
 
     this.config_path = './tests/__fixtures__/config.yaml';
 

--- a/packages/plugins/memory/test/partials/config.ts
+++ b/packages/plugins/memory/test/partials/config.ts
@@ -32,7 +32,7 @@ const config: Config = {
     title: 'string',
     logo: 'string',
   },
-  logs: [],
+  log: {},
   auth: {},
   notifications: {
     method: '',

--- a/packages/plugins/ui-theme/tools/_verdaccio.config.yaml
+++ b/packages/plugins/ui-theme/tools/_verdaccio.config.yaml
@@ -59,5 +59,4 @@ middlewares:
   audit:
     enabled: true
 
-logs:
-  - { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }

--- a/packages/proxy/test/conf/proxy1.yaml
+++ b/packages/proxy/test/conf/proxy1.yaml
@@ -28,4 +28,4 @@ server:
 middlewares:
   audit:
     enabled: true
-logs: { type: stdout, format: pretty, level: http }
+log: { type: stdout, format: pretty, level: http }

--- a/packages/server/test/api/api.spec.yaml
+++ b/packages/server/test/api/api.spec.yaml
@@ -84,5 +84,4 @@ packages:
     publish: $all
     unpublish: xxx
     proxy: npmjs
-logs:
-  - { type: stdout, format: pretty, level: error }
+log: { type: stdout, format: pretty, level: error }

--- a/packages/server/test/basic/basic.yaml
+++ b/packages/server/test/basic/basic.yaml
@@ -11,5 +11,4 @@ packages:
   '*':
     access: $all
     publish: $all
-logs:
-  - { type: stdout, format: pretty, level: warn }
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/server/test/jwt/jwt.yaml
+++ b/packages/server/test/jwt/jwt.yaml
@@ -32,5 +32,4 @@ middlewares:
   audit:
     enabled: true
 
-logs:
-  - { type: stdout, format: pretty, level: warn }
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/server/test/package-access/pkg.access.yaml
+++ b/packages/server/test/package-access/pkg.access.yaml
@@ -9,5 +9,4 @@ packages:
   '**':
     access: $all
     proxy: remote
-logs:
-  - { type: stdout, format: pretty, level: warn }
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/server/test/profile/profile.yaml
+++ b/packages/server/test/profile/profile.yaml
@@ -18,5 +18,4 @@ packages:
   '**':
     access: $authenticated
     publish: $authenticated
-logs:
-  - { type: stdout, format: pretty, level: warn }
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/server/test/storage/store.spec.yaml
+++ b/packages/server/test/storage/store.spec.yaml
@@ -21,5 +21,4 @@ packages:
     access: $all
     publish: $all
 
-logs:
-  - { type: stdout, format: pretty, level: warn }
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/server/test/token/token.spec.yaml
+++ b/packages/server/test/token/token.spec.yaml
@@ -20,8 +20,7 @@ packages:
   'only-you-can-publish':
     access: $authenticated
     publish: $authenticated
-logs:
-  - { type: stdout, format: pretty, level: error }
+log: { type: stdout, format: pretty, level: warn }
 flags:
   ## enable token for testing
   token: true

--- a/packages/server/test/web/web.yaml
+++ b/packages/server/test/web/web.yaml
@@ -17,5 +17,4 @@ packages:
     publish: $all
     unpublish: xxx
     proxy: remote
-logs:
-  - { type: stdout, format: pretty, level: error }
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/tools/mock/src/config/yaml/default.yaml
+++ b/packages/tools/mock/src/config/yaml/default.yaml
@@ -34,5 +34,4 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
-logs:
-  - { type: stdout, format: pretty, level: warn }
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/tools/mock/src/config/yaml/mock-server-test.yaml
+++ b/packages/tools/mock/src/config/yaml/mock-server-test.yaml
@@ -11,8 +11,7 @@ auth:
         name: test
         password: test
 
-logs:
-  - { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: warn }
 
 packages:
   '@*/*':

--- a/packages/tools/mock/test/config/yaml/default.yaml
+++ b/packages/tools/mock/test/config/yaml/default.yaml
@@ -34,5 +34,4 @@ packages:
     access: $all
     publish: $all
     proxy: npmjs
-logs:
-  - { type: stdout, format: pretty, level: warn }
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/verdaccio/test/README.md
+++ b/packages/verdaccio/test/README.md
@@ -76,7 +76,7 @@ const configForTest = configDefault(
         url: `http://${DOMAIN_SERVERS}:${mockServerPort}`,
       },
     },
-    logs: [{ type: 'stdout', format: 'pretty', level: 'trace' }],
+    log: [{ type: 'stdout', format: 'pretty', level: 'trace' }],
   },
   'api.spec.yaml'
 );

--- a/packages/verdaccio/test/functional/store/server1/config-1.yaml
+++ b/packages/verdaccio/test/functional/store/server1/config-1.yaml
@@ -31,7 +31,7 @@ uplinks:
   baduplink:
     url: http://localhost:55666/
 
-logs: { type: stdout, format: pretty, level: info }
+log: { type: stdout, format: pretty, level: info }
 
 packages:
   '@test/*':

--- a/packages/verdaccio/test/functional/store/server2/config-2.yaml
+++ b/packages/verdaccio/test/functional/store/server2/config-2.yaml
@@ -32,7 +32,7 @@ auth:
         name: authtest
         password: blahblah-password
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 packages:
   '@test/*':
     access: $all

--- a/packages/verdaccio/test/functional/store/server3/config-3.yaml
+++ b/packages/verdaccio/test/functional/store/server3/config-3.yaml
@@ -20,7 +20,7 @@ auth:
         name: test
         password: test
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 
 packages:
   'pkg-gh131':

--- a/packages/verdaccio/test/unit/partials/config/yaml/api.spec/web-config.yaml
+++ b/packages/verdaccio/test/unit/partials/config/yaml/api.spec/web-config.yaml
@@ -48,4 +48,4 @@ packages:
     access: $all
     publish: $all
 
-logs: { type: stdout, format: pretty, level: warns }
+log: { type: stdout, format: pretty, level: warns }

--- a/packages/web/test/config/default-test.yaml
+++ b/packages/web/test/config/default-test.yaml
@@ -13,7 +13,7 @@ publish:
 
 uplinks:
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 
 packages:
   '@*/*':

--- a/packages/web/test/config/login-disabled.yaml
+++ b/packages/web/test/config/login-disabled.yaml
@@ -14,7 +14,7 @@ publish:
 
 uplinks:
 
-logs: { type: stdout, format: pretty, level: trace }
+log: { type: stdout, format: pretty, level: trace }
 
 packages:
   '@*/*':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -494,12 +494,14 @@ importers:
       debug: 4.3.3
       lodash: 4.17.21
       pino: 7.6.4
+      pino-pretty: 7.6.0
     dependencies:
       '@verdaccio/core': link:../core/core
       '@verdaccio/logger-prettify': link:../logger-prettify
       debug: 4.3.3
       lodash: 4.17.21
       pino: 7.6.4
+      pino-pretty: 7.6.0
     devDependencies:
       '@verdaccio/types': link:../core/types
 
@@ -10427,6 +10429,16 @@ packages:
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  /args/5.0.1:
+    resolution: {integrity: sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==}
+    engines: {node: '>= 6.0.0'}
+    dependencies:
+      camelcase: 5.0.0
+      chalk: 2.4.2
+      leven: 2.1.0
+      mri: 1.1.4
+    dev: false
+
   /argv/0.0.2:
     resolution: {integrity: sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=}
     engines: {node: '>=0.6.10'}
@@ -11528,6 +11540,11 @@ packages:
     resolution: {integrity: sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=}
     engines: {node: '>=4'}
     dev: true
+
+  /camelcase/5.0.0:
+    resolution: {integrity: sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /camelcase/5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -12951,6 +12968,10 @@ packages:
     resolution: {integrity: sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==}
     engines: {node: '>=0.11'}
     dev: true
+
+  /dateformat/4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+    dev: false
 
   /dayjs/1.10.7:
     resolution: {integrity: sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==}
@@ -17605,6 +17626,11 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /joycon/3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+    dev: false
+
   /js-base64/3.7.2:
     resolution: {integrity: sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==}
     dev: true
@@ -18060,6 +18086,11 @@ packages:
       once: 1.4.0
       vasync: 2.2.0
       verror: 1.10.0
+    dev: false
+
+  /leven/2.1.0:
+    resolution: {integrity: sha1-wuep93IJTe6dNCAq6KzORoeHVYA=}
+    engines: {node: '>=0.10.0'}
     dev: false
 
   /leven/3.1.0:
@@ -19265,6 +19296,11 @@ packages:
     resolution: {integrity: sha512-A/78XjoX2EmNvppVWEhM2oGk3x4lLxnkEA4jTbaK97QKSDjkIoOsKQlfylt/d3kKKi596Qy3NP5XrXJ6fZIC9Q==}
     dev: false
 
+  /mri/1.1.4:
+    resolution: {integrity: sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==}
+    engines: {node: '>=4'}
+    dev: false
+
   /mri/1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -20307,6 +20343,25 @@ packages:
     dependencies:
       duplexify: 4.1.2
       split2: 4.1.0
+
+  /pino-pretty/7.6.0:
+    resolution: {integrity: sha512-sCthHDn8umVSlxEsOFakXZTNoCiTKYEuPwPXMDGq29QDt/38HEmVIKLxmgFLLg1RkLl4Dfxzp9Spz9pAtSBq0Q==}
+    hasBin: true
+    dependencies:
+      args: 5.0.1
+      colorette: 2.0.16
+      dateformat: 4.6.3
+      fast-safe-stringify: 2.1.1
+      joycon: 3.1.1
+      on-exit-leak-free: 0.2.0
+      pino-abstract-transport: 0.5.0
+      pump: 3.0.0
+      readable-stream: 3.6.0
+      rfdc: 1.3.0
+      secure-json-parse: 2.4.0
+      sonic-boom: 2.2.3
+      strip-json-comments: 3.1.1
+    dev: false
 
   /pino-std-serializers/3.2.0:
     resolution: {integrity: sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg==}

--- a/scripts/e2e-config.yaml
+++ b/scripts/e2e-config.yaml
@@ -40,5 +40,4 @@ middlewares:
   audit:
     enabled: true
 
-logs:
-  - { type: stdout, format: json, level: warn }
+log: { type: stdout, format: pretty, level: warn }

--- a/test/e2e-cli/config/_bootstrap_verdaccio.yaml
+++ b/test/e2e-cli/config/_bootstrap_verdaccio.yaml
@@ -21,8 +21,7 @@ uplinks:
       keepAlive: true
       maxSockets: 40
       maxFreeSockets: 10
-logs:
-  - { type: stdout, format: pretty, level: warn }
+logs: { type: stdout, format: pretty, level: warn }
 
 packages:
   ## ui-theme still lives outside of the core project

--- a/test/e2e-ui/config/config-protected-e2e.yaml
+++ b/test/e2e-ui/config/config-protected-e2e.yaml
@@ -14,7 +14,7 @@ auth:
         name: test
         password: test
 
-logs: { type: stdout, format: pretty, level: info }
+log: { type: stdout, format: pretty, level: info }
 
 packages:
   'protected-*':

--- a/test/e2e-ui/config/config-scoped-e2e.yaml
+++ b/test/e2e-ui/config/config-scoped-e2e.yaml
@@ -14,7 +14,7 @@ auth:
         name: test
         password: test
 
-logs: { type: stdout, format: pretty, level: info }
+log: { type: stdout, format: pretty, level: info }
 
 packages:
   '@*/*':

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -26,8 +26,7 @@ packages:
     proxy: npmjs
   "**":
     proxy: npmjs
-logs:
-  - { type: stdout, format: pretty, level: http }
+log: { type: stdout, format: pretty, level: http }
 ```
 
 ## Sections {#sections}

--- a/website/docs/logger.md
+++ b/website/docs/logger.md
@@ -7,14 +7,14 @@ As with any web application, Verdaccio has a customisable built-in logger. You c
 
 ```yaml
 # console output
-logs: { type: stdout, format: pretty, level: http }
+log: { type: stdout, format: pretty, level: http }
 ```
 
 or file output.
 
 ```yaml
 # file output
-logs: { type: file, path: verdaccio.log, level: info }
+log: { type: file, path: verdaccio.log, level: info }
 ```
 
 > Verdaccio 5 does not support rotation file anymore, [here more details](https://verdaccio.org/blog/2021/04/14/verdaccio-5-migration-guide#pinojs-is-the-new-logger).

--- a/website/docs/node-api.md
+++ b/website/docs/node-api.md
@@ -35,13 +35,11 @@ let config = {
             proxy: "npmjs"
         }
     },
-    logs: [
-        {
+    log: {
             type: "stdout",
             format: "pretty",
             level: "http",
-        }
-    ],
+        };
 };
 
 startServer(


### PR DESCRIPTION
`config.logs` throw an error, logging config not longer accept array or logs property. This is already deprecated on verdaccio 5. 

### 💥 Breaking change

This is valid

```yaml
log: { type: stdout, format: pretty, level: http }
```

This is invalid

```yaml
logs: { type: stdout, format: pretty, level: http }
```

or

```yaml
logs:
  - [{ type: stdout, format: pretty, level: http }]
```

Invalid will crash the app with a error message.