### PR TITLE
feat(web): add a config item to web，let the developer can select whether enable the html cache

### DIFF
--- a/.changeset/slow-carrots-relate.md
+++ b/.changeset/slow-carrots-relate.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/config': minor
+'@verdaccio/web': minor
+---
+
+feat(web): add a config item to web，let the developer can select whet……her enable the html cache

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -19,6 +19,7 @@ web:
   # sort_packages: asc
   # convert your UI to the dark side
   # darkMode: true
+  # html_cache: true
   #  HTML tags injected after manifest <scripts/>
   # scriptsBodyAfter:
   #    - '<script type="text/javascript" src="https://my.company.com/customJS.min.js"></script>'

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -23,7 +23,22 @@ web:
   # gravatar: false
   # by default packages are ordercer ascendant (asc|desc)
   # sort_packages: asc
+  # convert your UI to the dark side
   # darkMode: true
+  # html_cache: true
+  #  HTML tags injected after manifest <scripts/>
+  # scriptsBodyAfter:
+  #    - '<script type="text/javascript" src="https://my.company.com/customJS.min.js"></script>'
+  #  HTML tags injected before ends </head>
+  #  metaScripts:
+  #    - '<script type="text/javascript" src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>'
+  #    - '<script type="text/javascript" src="https://browser.sentry-cdn.com/5.15.5/bundle.min.js"></script>'
+  #    - '<meta name="robots" content="noindex" />'
+  #  HTML tags injected first child at <body/>
+  #  bodyBefore:
+  #    - '<div id="myId">html before webpack scripts</div>'
+  #  Public path for template manifest scripts (only manifest)
+  #  publicPath: http://somedomain.org/
 
 # translate your registry, api i18n not available yet
 # i18n:

--- a/packages/web/src/renderHTML.ts
+++ b/packages/web/src/renderHTML.ts
@@ -1,4 +1,5 @@
 import buildDebug from 'debug';
+import _ from 'lodash';
 import LRU from 'lru-cache';
 import { URL } from 'url';
 
@@ -66,8 +67,9 @@ export default function renderHTML(config, manifest, manifestFiles, req, res) {
 
   try {
     webPage = cache.get('template');
+    const needHtmlCache = _.get(config, 'web.cache', undefined) || _.get(config, 'web.cache', true);
 
-    if (!webPage) {
+    if (!webPage || needHtmlCache) {
       debug('web options %o', options);
       debug('web manifestFiles %o', manifestFiles);
       webPage = renderTemplate(

--- a/website/docs/web.md
+++ b/website/docs/web.md
@@ -33,7 +33,8 @@ web:
     - '<script type="text/javascript" src="https://browser.sentry-cdn.com/5.15.5/bundle.min.js"></script>'
     - '<meta name="robots" content="noindex" />'
   scriptsbodyBefore:
-    - '<div id="myId">html before webpack scripts</div>'        
+    - '<div id="myId">html before webpack scripts</div>'
+  html_cache: true
 ```
 
 All access restrictions defined to [protect your packages](protect-your-dependencies.md) will also apply to the Web Interface.
@@ -73,7 +74,7 @@ i18n:
 | scriptsBodyAfter | string[] | No | any list of strings | `>=5.0.0` | inject scripts after the <body/> tag |
 | metaScripts | string[] | No | any list of strings | `>=5.0.0` | inject scripts inside <head/> |
 | scriptsbodyBefore | string[] | No | any list of strings | `>=5.0.0` |  inject scripts before the <body/>|
-
+| html_cache    | boolean    | No       | false                                                         | `>=v5.9.0`  | whether the html cache is enabled, default true                                                                          |
 
 > The recommended logo size is `40x40` pixels.
 

--- a/website/docs/web.md
+++ b/website/docs/web.md
@@ -74,7 +74,7 @@ i18n:
 | scriptsBodyAfter | string[] | No | any list of strings | `>=5.0.0` | inject scripts after the <body/> tag |
 | metaScripts | string[] | No | any list of strings | `>=5.0.0` | inject scripts inside <head/> |
 | scriptsbodyBefore | string[] | No | any list of strings | `>=5.0.0` |  inject scripts before the <body/>|
-| html_cache    | boolean    | No       | false                                                         | `>=v5.9.0`  | whether the html cache is enabled, default true                                                                          |
+| html_cache    | boolean    | No       | true                                                         | `>=v5.9.0`  | whether the html cache is enabled, default true                                                                          |
 
 > The recommended logo size is `40x40` pixels.
 


### PR DESCRIPTION
Now html cache is always enable, I can't set it disabled, so this character will bring some problems.
For example:
My website supports HTTP & HTTPS at the same time. a developer visit website by use [http://npm.XX.com，so](http://npm.xx.com%2Cso/) the verdaccio's will save http://npm.xx.com/ to the html cache. And then the developer to visit this website by [https://npm.XX.com，the](https://npm.xx.com%2Cthe/) page will report an error of cross-origin;
In fact, the situation I'm facing is more complicated.
So I need to let the user of verdaccio can select whether enable the html cache by himself.