### PR TITLE
docs: change link to docker examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ To run the docker container:
 docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio
 ```
 
-Docker examples are available [in this repository](https://github.com/verdaccio/docker-examples).
+Docker examples are available [in this repository](https://github.com/verdaccio/verdaccio/tree/master/docker-examples).
 
 ## Compatibility
 


### PR DESCRIPTION
Change the link to docker examples to a non-deprecated one.

The current link points to: https://github.com/verdaccio/docker-examples

Changed it to: https://github.com/verdaccio/verdaccio/tree/master/docker-examples