### PR TITLE
enable node 18 on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         ## Node 16 breaks UI test, jest issue
-        node_version: [16, 17]
+        node_version: [16, 17, 18]
     name: ${{ matrix.os }} / Node ${{ matrix.node_version }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Ìt seems a library is not compatible, needs further investigation, worth look into it.
```
packages/plugins/memory test: FAIL test/memory.spec.ts (9.385 s)
packages/plugins/memory test:   ● writing files › should abort while write a tarball
packages/plugins/memory test:     TypeError: Cannot set property closed of [object Object] which has only a getter
packages/plugins/memory test:       at class_2.Object.<anonymous>.FsReadStream.close (../../../node_modules/.pnpm/memfs@3.4.1/node_modules/memfs/lib/volume.js:2047:17)
packages/plugins/memory test:       at class_2.closeOnOpen (../../../node_modules/.pnpm/memfs@3.4.1/node_modules/memfs/lib/volume.js:2059:10)
packages/plugins/memory test:       at class_2.<anonymous> (../../../node_modules/.pnpm/memfs@3.4.1/node_modules/memfs/lib/volume.js:2107:14)
packages/plugins/memory test:       at Immediate.<anonymous> 
``