### PR TITLE
chore (docs): Update Uplinks/K8s doc to reference `secretEnvVars`

### DIFF
--- a/website/docs/kubernetes.md
+++ b/website/docs/kubernetes.md
@@ -102,6 +102,19 @@ use:
 helm install npm --set existingConfigMap=verdaccio-config verdaccio/verdaccio
 ```
 
+### Authenticate with private upstreams using Helm
+
+As of version `4.8.0` of the helm chart, a new `secretEnvVars` field was added.  
+This allows you to inject sensitive values to the container via a [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
+
+1. Update your Verdaccio config according to the [Uplinks](./uplinks.md#auth-property) documentation
+2. Pass the secret environment variable to your values file or via `--set secretEnvVars.FOO_TOKEN=superSecretBarToken`
+```yaml
+# values.yaml
+secretEnvVars:
+  FOO_TOKEN: superSecretBarToken
+```
+
 #### NGINX proxy body-size limit {#nginx-proxy-body-size-limit}
 
 The standard k8s NGINX ingress proxy allows for 1MB for body-size which can be increased

--- a/website/docs/kubernetes.md
+++ b/website/docs/kubernetes.md
@@ -104,7 +104,7 @@ helm install npm --set existingConfigMap=verdaccio-config verdaccio/verdaccio
 
 ### Authenticate with private upstreams using Helm
 
-As of version `4.8.0` of the helm chart, a new `secretEnvVars` field was added.  
+As of version `4.8.0` of the helm chart, a new `secretEnvVars` field has been added.  
 This allows you to inject sensitive values to the container via a [Kubernetes Secret](https://kubernetes.io/docs/concepts/configuration/secret/).
 
 1. Update your Verdaccio config according to the [Uplinks](./uplinks.md#auth-property) documentation

--- a/website/docs/uplinks.md
+++ b/website/docs/uplinks.md
@@ -84,3 +84,4 @@ uplinks:
 * Setting `cache` to false will help to save space in your hard drive. This will avoid store `tarballs` but [it will keep metadata in folders](https://github.com/verdaccio/verdaccio/issues/391).
 * Exceed with multiple uplinks might slow down the lookup of your packages due for each request a npm client does, verdaccio does 1 call for each uplink.
 * The (timeout, maxage and fail_timeout) format follow the [NGINX measurement units](http://nginx.org/en/docs/syntax.html)
+* When using the [Helm Chart](https://github.com/verdaccio/charts), you can use `secretEnvVars` to inject sensitive environment variables, which can be used to configure private uplink auth.


### PR DESCRIPTION
* Update Uplinks Documentation to refer to the Helm Chart's new
  `secretEnvVars` value
* Update Kubernetes Documentation with the new `secretEnvVars` helm
  value

https://github.com/verdaccio/charts/pull/95