### PR TITLE
Fixes Heroku typo in README

### DIFF
--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -115,6 +115,6 @@ docker run -it --rm --name verdaccio -p 4873:4873 verdaccio/verdaccio
 
 ## Heroku with Docker
 
-For easy deployment you could use [Heroku](https://www.heroku.com/home), the _free_ dino tier allows you to test their platform using a Docker container, check this example.
+For easy deployment you could use [Heroku](https://www.heroku.com/home), the _free_ dyno tier allows you to test their platform using a Docker container, check this example.
 
 [https://github.com/juanpicado/verdaccio-heroku-example](https://github.com/juanpicado/verdaccio-heroku-example)


### PR DESCRIPTION
This fixes a **very** minor typo: Heroku spells them as *dyno* instead of *dino*.