### PR TITLE
fix: Fix storing same named files from different pkgs in memory plugin

### DIFF
--- a/.changeset/chilled-ways-fetch.md
+++ b/.changeset/chilled-ways-fetch.md
@@ -1,0 +1,5 @@
+---
+'verdaccio-memory': patch
+---
+
+Fix storing tarballs with identical names from different packages in memory plugin


### PR DESCRIPTION
The memory plugin was not correctly writing tarballs that have the same name but are from different packages and have different content.

I noticed this when using the memory plugin and installing `json-buffer` and `@types/json-buffer`.
This resulted in two things:

First verdaccio memory-plugin was logging a warning:

```
this package is already present
```

and secondly, yarn was throwing an error on subsequent installs:

```
error http://localhost:7460/json-buffer/-/json-buffer-3.0.0.tgz: Integrity check failed for "json-buffer" (computed integrity doesn't match our records, got "sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ== sha1-hcH/DwlI/BWYENS1vjW/jCCHX2Q=")
```

The underlying issue is that both of these packages have the tarball named `json-buffer-3.0.0.tgz`, but obviously with different content. So yarn received the wrong tarball, because only one was stored for both of these packages.

For the review, it is the easiest to hide whitespace changes.

If this is okay, I would also like to backport this to 5.x. Is this okay with you?