### PR TITLE
Allow express 'trust proxy' to be set

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -85,7 +85,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@verdaccio/local-storage", "npm:10.3.1"],
             ["@verdaccio/readme", "npm:10.4.1"],
             ["@verdaccio/streams", "npm:10.2.0"],
-            ["@verdaccio/types", "npm:10.5.1"],
+            ["@verdaccio/types", "npm:10.5.2"],
             ["@verdaccio/ui-theme", "npm:6.0.0-6-next.25"],
             ["JSONStream", "npm:1.3.5"],
             ["all-contributors-cli", "npm:6.20.0"],
@@ -5817,10 +5817,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
         }]
       ]],
       ["@verdaccio/types", [
-        ["npm:10.5.1", {
-          "packageLocation": "./.yarn/cache/@verdaccio-types-npm-10.5.1-44031defeb-15a5a65148.zip/node_modules/@verdaccio/types/",
+        ["npm:10.5.2", {
+          "packageLocation": "./.yarn/cache/@verdaccio-types-npm-10.5.2-df408a0b4b-60f8a1068b.zip/node_modules/@verdaccio/types/",
           "packageDependencies": [
-            ["@verdaccio/types", "npm:10.5.1"]
+            ["@verdaccio/types", "npm:10.5.2"]
           ],
           "linkType": "HARD",
         }]
@@ -18059,7 +18059,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@verdaccio/local-storage", "npm:10.3.1"],
             ["@verdaccio/readme", "npm:10.4.1"],
             ["@verdaccio/streams", "npm:10.2.0"],
-            ["@verdaccio/types", "npm:10.5.1"],
+            ["@verdaccio/types", "npm:10.5.2"],
             ["@verdaccio/ui-theme", "npm:6.0.0-6-next.25"],
             ["JSONStream", "npm:1.3.5"],
             ["all-contributors-cli", "npm:6.20.0"],

--- a/conf/default.yaml
+++ b/conf/default.yaml
@@ -103,6 +103,9 @@ packages:
 # WORKAROUND: Through given configuration you can workaround following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enough.
 server:
   keepAliveTimeout: 60
+  # Allow `req.ip` to resolve properly when Verdaccio is behind a proxy or load-balancer
+  # See: https://expressjs.com/en/guide/behind-proxies.html
+  # trustProxy: '127.0.0.1'
 
 # https://verdaccio.org/docs/configuration#offline-publish
 # publish:

--- a/conf/docker.yaml
+++ b/conf/docker.yaml
@@ -107,6 +107,9 @@ packages:
 # WORKAROUND: Through given configuration you can workaround following issue https://github.com/verdaccio/verdaccio/issues/301. Set to 0 in case 60 is not enough.
 server:
   keepAliveTimeout: 60
+  # Allow `req.ip` to resolve properly when Verdaccio is behind a proxy or load-balancer
+  # See: https://expressjs.com/en/guide/behind-proxies.html
+  # trustProxy: '127.0.0.1'
 
 # https://verdaccio.org/docs/configuration#offline-publish
 # publish:

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@typescript-eslint/parser": "5.22.0",
     "@verdaccio-scope/verdaccio-auth-foo": "0.0.2",
     "@verdaccio/eslint-config": "^10.0.0",
-    "@verdaccio/types": "10.5.1",
+    "@verdaccio/types": "10.5.2",
     "all-contributors-cli": "6.20.0",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.6.3",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -27,6 +27,13 @@ const defineAPI = function (config: IConfig, storage: IStorageHandler): any {
   // run in production mode by default, just in case
   // it shouldn't make any difference anyway
   app.set('env', process.env.NODE_ENV || 'production');
+
+  // Allow `req.ip` to resolve properly when Verdaccio is behind a proxy or load-balancer
+  // See: https://expressjs.com/en/guide/behind-proxies.html
+  if (config.server?.trustProxy) {
+    app.set('trust proxy', config.server.trustProxy);
+  }
+
   app.use(cors());
 
   // Router setup

--- a/yarn.lock
+++ b/yarn.lock
@@ -3945,10 +3945,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@verdaccio/types@npm:10.5.1":
-  version: 10.5.1
-  resolution: "@verdaccio/types@npm:10.5.1"
-  checksum: 15a5a65148554c92bd34222be7c03ca24d59be34ce324f74e660c49a40ce7b67b9a7f8b83ff9b0bc0e5a873ca8d50f3cebfcc1e7c1e17358c99354848c780bb8
+"@verdaccio/types@npm:10.5.2":
+  version: 10.5.2
+  resolution: "@verdaccio/types@npm:10.5.2"
+  checksum: 60f8a1068be4872d4c971e40862df641fab65a554c3783106b776c26aac01328a33af3d566a083711f86cac72d89d9d83fb0d63c0b0485b6a76ef1eb579033b9
   languageName: node
   linkType: hard
 
@@ -14967,7 +14967,7 @@ typescript@4.1.3:
     "@verdaccio/local-storage": 10.3.1
     "@verdaccio/readme": 10.4.1
     "@verdaccio/streams": 10.2.0
-    "@verdaccio/types": 10.5.1
+    "@verdaccio/types": 10.5.2
     "@verdaccio/ui-theme": 6.0.0-6-next.25
     JSONStream: 1.3.5
     all-contributors-cli: 6.20.0


### PR DESCRIPTION
Related to [Rate limiting when behind a proxy or load balancer](https://github.com/verdaccio/verdaccio/discussions/3269) discussion.

I was able to test this change and verify manually while running Verdaccio locally.

I did attempt to add some unit tests for this to [test/unit/modules/api/api.spec.ts](https://github.com/verdaccio/verdaccio/blob/5.x/test/unit/modules/api/api.spec.ts) as well. I ran into issues in that regard as it doesn't appear the `app.set('trust proxy', config.server.trustProxy);` has any effect when [supertest](https://www.npmjs.com/package/supertest) is being leveraged. I'm not sure why this is the case. I've provided an example unit test below. No matter what I tried, the following issues were encountered:
1. When providing an `X-Forwarded-For` header, the `req.ip` field would still resolve to `127.0.0.1` from the express handler. I verified this  when a break point was placed at [src/api/endpoint/api/ping.ts:7](https://github.com/verdaccio/verdaccio/blob/5.x/src/api/endpoint/api/ping.ts#L7). This is not the expected behavior or the behavior exhibited when actually running Verdaccio.
2. The `res.req.ip` property being checked in the test would always resolve to `undefined`. It seems that value is unavailable in the unit test as it gets cleared out after the response is sent. Even if it was available, based on bullet point <span>#</span>1, it would not be the expected value.

## Attempted unit tests that wouldn't work:
 [test/unit/modules/api/api.spec.ts](https://github.com/verdaccio/verdaccio/blob/5.x/test/unit/modules/api/api.spec.ts)
```diff
@@ -39,6 +39,7 @@ const putVersion = (app, name, publishMetadata) => {
 describe('endpoint unit test', () => {
   let app;
   const mockServerPort = 55549;
+  const trustProxy = '127.0.0.1';
   let mockRegistry;

   beforeAll(function (done) {
@@ -71,6 +72,7 @@ describe('endpoint unit test', () => {
             },
           },
           logs: [{ type: 'stdout', format: 'pretty', level: 'warn' }],
+          server: { trustProxy }
         },
         'api.spec.yaml'
       );
@@ -90,7 +92,41 @@ describe('endpoint unit test', () => {
     nock.cleanAll();
   });

-  describe('Registry API Endpoints', () => {
+  describe.only('Registry API Endpoints', () => {
+
+    test('should derive the client IP from req.ipwhen the X-Forwarded-For header is not present', (done) => {
+      request(app)
+        .get('/-/ping')
+        .connect("127.0.0.1")
+        .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+        .expect(HTTP_STATUS.OK)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.req.ip).toEqual('127.0.0.1') // this fails as `res.req.ip` is undefined
+          done();
+        });
+    });
+
+    test('should derive the client IP from the X-Forwarded-For header when present', (done) => {
+      const clientIP = '9.8.7.6';
+      request(app)
+        .get('/-/ping')
+        .connect("127.0.0.1")
+        .set('X-Forwarded-For', `${clientIP}, ${trustProxy}`)
+        .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+        .expect(HTTP_STATUS.OK)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.req.ip).toEqual(clientIP) // this fails as `res.req.ip` is undefined
+          done();
+        });
+    });
+
+
```