### PR TITLE
docs: fix formatting in packages/core/types/README

### DIFF
--- a/packages/core/types/README.md
+++ b/packages/core/types/README.md
@@ -9,24 +9,18 @@ For usage with the library, the `tsconfig.json` should looks like this.
 ```json5
 // tsconfig.json
 {
-  "compilerOptions": {
-    "target": "esnext",
-    "module": "commonjs",
-    "declaration": true,
-    "noImplicitAny": false,
-    "strict": true,
-    "outDir": "lib",
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "typeRoots": [
-      "./node_modules/@verdaccio/types/lib/verdaccio",
-      "./node_modules/@types"
-    ]
+  compilerOptions: {
+    target: 'esnext',
+    module: 'commonjs',
+    declaration: true,
+    noImplicitAny: false,
+    strict: true,
+    outDir: 'lib',
+    allowSyntheticDefaultImports: true,
+    esModuleInterop: true,
+    typeRoots: ['./node_modules/@verdaccio/types/lib/verdaccio', './node_modules/@types'],
   },
-  "include": [
-    "src/*.ts",
-    "types/*.d.ts"
-  ]
+  include: ['src/*.ts', 'types/*.d.ts'],
 }
 ```
 

--- a/packages/core/types/README.md
+++ b/packages/core/types/README.md
@@ -1,13 +1,13 @@
-# Typescript types for Verdaccio
+# TypeScript types for Verdaccio
 
-Typescript definitions for verdaccio plugins and internal code
+TypeScript definitions for Verdaccio plugins and internal code.
 
-# Typescript
+# TypeScript
 
 For usage with the library, the `tsconfig.json` should looks like this.
 
-```
-//tsconfig.json
+```json5
+// tsconfig.json
 {
   "compilerOptions": {
     "target": "esnext",
@@ -32,11 +32,10 @@ For usage with the library, the `tsconfig.json` should looks like this.
 
 ### Imports
 
-```
+```ts
 import type {ILocalData, LocalStorage, Logger, Config} from '@verdaccio/types';
 
- class LocalData implements ILocalData {
-
+class LocalData implements ILocalData {
   path: string;
   logger: Logger;
   data: LocalStorage;


### PR DESCRIPTION
The code samples had no syntax highlighting, so I added languages and fixed some minor formatting