### PR TITLE
feat: add dist.signatures to core/types

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -78,6 +78,7 @@ declare module '@verdaccio/types' {
 
   interface Dist {
     'npm-signature'?: string;
+    signatures?: Signatures[];
     fileCount?: number;
     integrity?: string;
     shasum: string;


### PR DESCRIPTION
According to [`npm`](https://docs.npmjs.com/about-registry-signatures): _"Signatures are provided in the package's `packument` in each published version within the `dist` object"_

Here's an [example of a package version from the public npm registry with `dist.signatures`](https://registry.npmjs.org/light-cycle/1.4.3).