### PR TITLE
chore: fix missing dep on master

### DIFF
--- a/packages/api/src/dist-tags.ts
+++ b/packages/api/src/dist-tags.ts
@@ -36,7 +36,7 @@ export default function (route: Router, auth: IAuth, storage: Storage): void {
   // tagging a package.
   route.put(
     '/:package/:tag',
-    can('publishf'),
+    can('publish'),
     media(mime.getType('json')),
     addTagPackageVersionMiddleware
   );

--- a/packages/api/src/dist-tags.ts
+++ b/packages/api/src/dist-tags.ts
@@ -36,7 +36,7 @@ export default function (route: Router, auth: IAuth, storage: Storage): void {
   // tagging a package.
   route.put(
     '/:package/:tag',
-    can('publish'),
+    can('publishf'),
     media(mime.getType('json')),
     addTagPackageVersionMiddleware
   );

--- a/packages/logger-prettify/src/levels.ts
+++ b/packages/logger-prettify/src/levels.ts
@@ -1,4 +1,4 @@
-import { black, blue, cyan, green, magenta, red, white, yellow } from 'kleur';
+import { black, blue, cyan, green, magenta, red, white, yellow } from 'colorette';
 
 export type LogLevel = 'trace' | 'debug' | 'info' | 'http' | 'warn' | 'error' | 'fatal';
 


### PR DESCRIPTION
```
Status: Downloaded newer image for verdaccio/verdaccio:nightly-master
node:internal/modules/cjs/loader:959
  throw err;
  ^

Error: Cannot find module 'kleur'
Require stack:
```

regresion at https://github.com/verdaccio/verdaccio/pull/3308 