### PR TITLE
Changed the deprecated installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,18 @@ Google Cloud Storage** or create your own plugin.
 Install with npm:
 
 ```bash
-npm install --global verdaccio@6-next
+npm install --location=global verdaccio@6-next
+```
+With `yarn`
+
+```bash
+yarn global add verdaccio@6-next
+```
+
+With `pnpm`
+
+```bash
+pnpm i -g verdaccio@6-next
 ```
 
 or
@@ -68,8 +79,8 @@ Furthermore, you can read the [**Debugging Guidelines**](https://github.com/verd
 You can develop your own [plugins](https://verdaccio.org/docs/plugins) with the [verdaccio generator](https://github.com/verdaccio/generator-verdaccio-plugin). Installing [Yeoman](https://yeoman.io/) is required.
 
 ```
-npm install -g yo
-npm install -g generator-verdaccio-plugin
+npm install --location=global yo
+npm install --location=global generator-verdaccio-plugin
 ```
 
 Learn more [here](https://verdaccio.org/docs/dev-plugins) how to develop plugins. Share your plugins with the community.

--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -34,7 +34,7 @@ Learn the basics before getting started, how to install, where is the location o
 Using `npm`
 
 ```bash
-npm install -g verdaccio
+npm install --location=global verdaccio
 ```
 
 or using `yarn`
@@ -56,7 +56,7 @@ pnpm install -g verdaccio
 Next [major release is under development](https://github.com/verdaccio/verdaccio/discussions/2970), byt can try it out already, either for testing purposes or helping to catch any possible bug, if you find something report it under the label [6.x bugs](https://github.com/verdaccio/verdaccio/labels/6.x%20bugs).
 
 ```bash
-npm install --global verdaccio@6-next
+npm install --location=global verdaccio@6-next
 ```
 
 or with the docker image


### PR DESCRIPTION
Changed the global installation flag for `npm` from `-g` and `--global` to `--location=global` i.e. `npm --location=global`