### PR TITLE
Update config to use log property

### DIFF
--- a/docker-examples/v6/docker-local-storage-volume/conf/config.yaml
+++ b/docker-examples/v6/docker-local-storage-volume/conf/config.yaml
@@ -66,6 +66,6 @@ middlewares:
     enabled: true
 
 # log settings
-logs:
+log:
   - { type: stdout, format: pretty, level: trace }
   #- {type: file, path: verdaccio.log, level: info}


### PR DESCRIPTION
Update config.yaml to use log property instead of the depreciated logs

When using logs the following error occurs

```
Error: Error: the property config "logs" property is longer supported, rename to "log" and use object instead
```