### PR TITLE
fix: version output with breakline

### DIFF
--- a/.changeset/moody-clocks-roll.md
+++ b/.changeset/moody-clocks-roll.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/cli': patch
+---
+
+fix: version with breakline

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -6,7 +6,7 @@ export class VersionCommand extends Command {
 
   async execute() {
     const version = require('../../package.json').version;
-    this.context.stdout.write(`v${version}`);
+    this.context.stdout.write(`v${version}\n`);
     process.exit(0);
   }
 }


### PR DESCRIPTION
small issue on `Verdaccio --version` display a `%` at the end.