### PR TITLE
fix: hide search icon on medium or larger devices

### DIFF
--- a/.changeset/modern-maps-lie.md
+++ b/.changeset/modern-maps-lie.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-theme': patch
+---
+
+Hide search icon on medium or larger devices

--- a/packages/plugins/ui-theme/src/App/Header/styles.ts
+++ b/packages/plugins/ui-theme/src/App/Header/styles.ts
@@ -74,6 +74,9 @@ export const NavBar = styled(AppBar)<{ theme?: Theme }>(({ theme }) => ({
     ${SearchWrapper} {
       display: flex;
     }
+    ${IconSearchButton} {
+      display: none;
+    }
     ${MobileNavBar} {
       display: none;
     }


### PR DESCRIPTION
Avoids showing two search options 

Regression of https://github.com/verdaccio/verdaccio/commit/d43894e8f692ff59a11b7c376f41d939b06a5b0c

Closes #3396