### PR TITLE
feat: Improve "Current Tags" version list

### DIFF
--- a/.changeset/sour-maps-live.md
+++ b/.changeset/sour-maps-live.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-theme': patch
+---
+
+Add links to "Current Tags" and sort them in descending order

--- a/packages/plugins/ui-theme/src/i18n/crowdin/ui.json
+++ b/packages/plugins/ui-theme/src/i18n/crowdin/ui.json
@@ -52,7 +52,7 @@
   },
   "versions": {
     "current-tags": "Current Tags",
-    "version-history": "Version history",
+    "version-history": "Version History",
     "not-available": "Not available"
   },
   "package": {

--- a/packages/plugins/ui-theme/src/pages/Version/DetailContainer/Versions/Versions.tsx
+++ b/packages/plugins/ui-theme/src/pages/Version/DetailContainer/Versions/Versions.tsx
@@ -21,10 +21,10 @@ const Versions: React.FC = () => {
 
   return (
     <>
-      {distTags && Object.keys(distTags).length > 0 && (
+      {distTags && Object.keys(distTags).length > 0 && packageName && (
         <>
           <StyledText variant="subtitle1">{t('versions.current-tags')}</StyledText>
-          <VersionsTagList tags={distTags} />
+          <VersionsTagList packageName={packageName} tags={distTags} time={time} />
         </>
       )}
       {versions && Object.keys(versions).length > 0 && packageName && (

--- a/packages/plugins/ui-theme/src/pages/Version/DetailContainer/Versions/VersionsTagList.tsx
+++ b/packages/plugins/ui-theme/src/pages/Version/DetailContainer/Versions/VersionsTagList.tsx
@@ -3,19 +3,26 @@ import ListItem from '@mui/material/ListItem';
 import React from 'react';
 
 import { DistTags } from '../../../../../types/packageMeta';
-import { ListItemText, Spacer } from './styles';
+import { Time } from '../../../../../types/packageMeta';
+import { ListItemText, Spacer, StyledLink } from './styles';
 
 interface Props {
   tags: DistTags;
+  packageName: string;
+  time: Time;
 }
 
-const VersionsTagList: React.FC<Props> = ({ tags }) => (
+const VersionsTagList: React.FC<Props> = ({ tags, packageName, time }) => (
   <List dense={true}>
     {Object.keys(tags)
-      .reverse()
+      .sort((a, b) => {
+        return time[tags[a]] < time[tags[b]] ? 1 : time[tags[a]] > time[tags[b]] ? -1 : 0;
+      })
       .map((tag) => (
         <ListItem className="version-item" key={tag}>
-          <ListItemText>{tag}</ListItemText>
+          <StyledLink to={`/-/web/detail/${packageName}/v/${tags[tag]}`}>
+            <ListItemText>{tag}</ListItemText>
+          </StyledLink>
           <Spacer />
           <ListItemText>{tags[tag]}</ListItemText>
         </ListItem>


### PR DESCRIPTION
- Adds links to tags under "Current Tags" jumping to the corresponding version 
- Sorts the tags in descending order, which will always bring "latest" to the top and result in the same order as the "Version History"

Example for "tap" package:

Before:

![image](https://user-images.githubusercontent.com/59966492/192681470-3f8da37c-0e57-4e3a-9fbe-c049912a663a.png)

After: 

![image](https://user-images.githubusercontent.com/59966492/192680605-ec2c0fbe-4678-4ccc-81f7-6ff02fd0cde4.png)
