### PR TITLE
chore: add node 19 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: [12, 14, 15, 16, 17, 18]
+        node_version: [12, 14, 15, 16, 17, 18, 19]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Enable Node 19 for CI testing latest releases