### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -12,6 +12,9 @@ env:
   CI: true
   PNPM_CACHE_FOLDER: .pnpm-store
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   # Update package versions from changesets.
   version:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,10 @@ on:
       - 'master'
     tags:
       - 'v*'
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-data.yml
+++ b/.github/workflows/static-data.yml
@@ -10,6 +10,10 @@ on:
   # push:
   #   branches:
   #     - master
+
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   prepare:
     name: Run script

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,8 +9,16 @@ on:
   schedule:
     - cron: '0 0 * * *' 
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
+    permissions:
+      contents: read  #  to fetch code (actions/checkout)
+      deployments: write
+      pull-requests: write  #  to comment on pull-requests
+
     runs-on: ubuntu-latest
     env:
       NODE_OPTIONS: --max_old_space_size=4096


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.