### PR TITLE
fix typo in e2e.md

### DIFF
--- a/website/docs/e2e.md
+++ b/website/docs/e2e.md
@@ -69,7 +69,7 @@ sh -c "npm --registry $local_registry publish"
 
 - [Hyperledger](https://github.com/hyperledger/fabric-chaincode-node)
 
-### Programtically Examples
+### Programmatically Examples
 
 - [Storybook](https://github.com/storybooks/storybook) _(+44k ⭐️)_
 - [Gatsby](https://github.com/gatsbyjs/gatsby) \*(+40k ⭐️)


### PR DESCRIPTION
Change this:

> **Programtically** Examples

To this:

> **Programmatically** Examples