### PR TITLE
fix package parameter

### DIFF
--- a/packages/api/src/package.ts
+++ b/packages/api/src/package.ts
@@ -58,13 +58,13 @@ export default function (route: Router, auth: Auth, storage: Storage): void {
   );
 
   route.get(
-    '/:pkg/-/:filename',
+    '/:package/-/:filename',
     can('access'),
     async function (req: $RequestExtend, res: $ResponseExtend, next): Promise<void> {
-      const { pkg, filename } = req.params;
+      const { package, filename } = req.params;
       const abort = new AbortController();
       try {
-        const stream = (await storage.getTarballNext(pkg, filename, {
+        const stream = (await storage.getTarballNext(package, filename, {
           signal: abort.signal,
           // TODO: review why this param
           // enableRemote: true,

--- a/packages/api/src/package.ts
+++ b/packages/api/src/package.ts
@@ -61,10 +61,10 @@ export default function (route: Router, auth: Auth, storage: Storage): void {
     '/:package/-/:filename',
     can('access'),
     async function (req: $RequestExtend, res: $ResponseExtend, next): Promise<void> {
-      const { package, filename } = req.params;
+      const { package: pkgName, filename } = req.params;
       const abort = new AbortController();
       try {
-        const stream = (await storage.getTarballNext(package, filename, {
+        const stream = (await storage.getTarballNext(pkgName, filename, {
           signal: abort.signal,
           // TODO: review why this param
           // enableRemote: true,


### PR DESCRIPTION
`pkg` parameter brokes `can('access')` middleware, which wants `package`