### PR TITLE
fix(core): fix bug about isObject function

### DIFF
--- a/.changeset/poor-suns-film.md
+++ b/.changeset/poor-suns-film.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/core': patch
+---
+
+fix(core): fix `isObject` function.`isObject(true)` should return false.

--- a/packages/core/core/src/validation-utils.ts
+++ b/packages/core/core/src/validation-utils.ts
@@ -95,14 +95,15 @@ export function normalizeMetadata(manifest: Manifest, name: string): Manifest {
  * @return {Boolean}
  */
 export function isObject(obj: any): boolean {
-  if (obj === null || typeof obj === 'undefined' || typeof obj === 'string') {
-    return false;
-  }
+  // if (obj === null || typeof obj === 'undefined' || typeof obj === 'string') {
+  //   return false;
+  // }
 
-  return (
-    (typeof obj === 'object' || typeof obj.prototype === 'undefined') &&
-    Array.isArray(obj) === false
-  );
+  // return (
+  //   (typeof obj === 'object' || typeof obj.prototype === 'undefined') &&
+  //   Array.isArray(obj) === false
+  // );
+  return Object.prototype.toString.call(obj) === '[object Object]';
 }
 
 export function validatePassword(

--- a/packages/core/core/test/validation-utilts.spec.ts
+++ b/packages/core/core/test/validation-utilts.spec.ts
@@ -31,6 +31,7 @@ describe('isObject', () => {
     expect(isObject(['foo'])).toBeFalsy();
     expect(isObject(null)).toBeFalsy();
     expect(isObject(undefined)).toBeFalsy();
+    expect(isObject(true)).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
It should return false when input is a boolean

This bug will case
[request](https://github.com/verdaccio/verdaccio/blob/bae430fe24c9bb63dcf7b7b9e5f9f0dbf3f42669/src/lib/up-storage.ts#L157) has a body when options.json is `true`.

fix #3601