### PR TITLE
fix: typo in config.yaml file

### DIFF
--- a/packages/verdaccio/test/config.yaml
+++ b/packages/verdaccio/test/config.yaml
@@ -82,7 +82,7 @@ packages:
     # and three keywords: "$all", "$anonymous", "$authenticated"
     access: $all
 
-    # allow all known users to publish/publish packages
+    # allow all known users to publish/unpublish packages
     # (anyone can register by default, remember?)
     publish: $authenticated
     unpublish: $authenticated


### PR DESCRIPTION
I found a typo where instead of `publish/unpublish` it says `publish/publish`