### PR TITLE
feat: add forceEnhancedLegacySignature

### DIFF
--- a/.changeset/rare-planets-travel.md
+++ b/.changeset/rare-planets-travel.md
@@ -1,0 +1,9 @@
+---
+'@verdaccio/config': minor
+'@verdaccio/core': minor
+'@verdaccio/types': minor
+'@verdaccio/signature': minor
+'@verdaccio/test-helper': minor
+---
+
+feat: add forceEnhancedLegacySignature

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -28,7 +28,6 @@ const debug = buildDebug('verdaccio:config');
  * @return {String} the config file path
  */
 function findConfigFile(configPath?: string): string {
-  // console.log(process.env);
   if (typeof configPath !== 'undefined') {
     return path.resolve(configPath);
   }

--- a/packages/config/src/token.ts
+++ b/packages/config/src/token.ts
@@ -4,7 +4,6 @@ export const TOKEN_VALID_LENGTH = 32;
 
 /**
  * Secret key must have 32 characters.
- * @deprecated
  */
 export function generateRandomSecretKey(): string {
   return randomBytes(TOKEN_VALID_LENGTH).toString('base64').substring(0, TOKEN_VALID_LENGTH);

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -9,6 +9,9 @@
   "references": [
     {
       "path": "../utils"
+    },
+    {
+      "path": "../core/core"
     }
   ]
 }

--- a/packages/core/core/src/warning-utils.ts
+++ b/packages/core/core/src/warning-utils.ts
@@ -9,6 +9,7 @@ export enum Codes {
   VERWAR002 = 'VERWAR002',
   VERWAR003 = 'VERWAR003',
   VERWAR004 = 'VERWAR004',
+  VERWAR005 = 'VERWAR005',
   // deprecation warnings
   VERDEP003 = 'VERDEP003',
 }
@@ -37,6 +38,12 @@ warningInstance.create(
   `invalid address - %s, we expect a port (e.g. "4873"), 
 host:port (e.g. "localhost:4873") or full url '(e.g. "http://localhost:4873/")
 https://verdaccio.org/docs/en/configuration#listen-port`
+);
+
+warningInstance.create(
+  verdaccioWarning,
+  Codes.VERWAR005,
+  'disable enhanced legacy signature is considered a security risk, please reconsider enable it'
 );
 
 warningInstance.create(

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -185,6 +185,7 @@ export interface APITokenOptions {
 }
 
 export interface Security {
+  enhancedLegacySignature?: boolean;
   web: JWTOptions;
   api: APITokenOptions;
 }
@@ -266,8 +267,6 @@ export interface ConfigYaml {
   flags?: FlagsConfig;
   userRateLimit?: RateLimit;
   // internal objects, added by internal yaml to JS config parser
-  // @deprecated use configPath instead
-  config_path?: string;
   // save the configuration file path
   configPath?: string;
 }
@@ -282,6 +281,8 @@ export interface Config extends Omit<ConfigYaml, 'packages' | 'security' | 'conf
   secret: string;
   // save the configuration file path, it's fails without thi configPath
   configPath: string;
+  // @deprecated use configPath
+  self_path?: string;
   // packages from yaml file looks different from packages inside the config file
   packages: PackageList;
   // security object defaults is added by the config file but optional in the yaml file

--- a/packages/node-api/test/run-server.spec.ts
+++ b/packages/node-api/test/run-server.spec.ts
@@ -11,7 +11,7 @@ describe('startServer via API', () => {
 
   test('should fail on start with empty configuration', async () => {
     // @ts-expect-error
-    await expect(runServer({})).rejects.toThrow('config_path is required');
+    await expect(runServer({})).rejects.toThrow('configPath is required');
   });
 
   test('should fail on start with null as entry', async () => {

--- a/packages/node-api/test/run-server.spec.ts
+++ b/packages/node-api/test/run-server.spec.ts
@@ -11,7 +11,7 @@ describe('startServer via API', () => {
 
   test('should fail on start with empty configuration', async () => {
     // @ts-expect-error
-    await expect(runServer({})).rejects.toThrow('configPath is required');
+    await expect(runServer({})).rejects.toThrow('configPath property is required');
   });
 
   test('should fail on start with null as entry', async () => {

--- a/packages/signature/src/legacy-signature/index.ts
+++ b/packages/signature/src/legacy-signature/index.ts
@@ -43,8 +43,7 @@ export function aesDecryptDeprecated(buf: Buffer, secret: string): Buffer {
 export const TOKEN_VALID_LENGTH_DEPRECATED = 64;
 
 /**
- * Genrate a secret key of 64 characters.
- * @deprecated keys should be length max of 64
+ * Generate a secret key of 64 characters.
  */
 export function generateRandomSecretKeyDeprecated(): string {
   return generateRandomHexString(6);

--- a/packages/signature/src/signature.ts
+++ b/packages/signature/src/signature.ts
@@ -20,7 +20,7 @@ const VERDACCIO_LEGACY_ENCRYPTION_KEY = process.env.VERDACCIO_LEGACY_ENCRYPTION_
 
 export function aesEncrypt(value: string, key: string): string | void {
   // https://nodejs.org/api/crypto.html#crypto_crypto_createcipher_algorithm_password_options
-  // https://www.grainger.xyz/changing-from-cipher-to-cipheriv/
+  // https://www.grainger.xyz/posts/changing-from-cipher-to-cipheriv
   debug('encrypt %o', value);
   debug('algorithm %o', defaultAlgorithm);
   // IV must be a buffer of length 16

--- a/packages/tools/helpers/src/initializeServer.ts
+++ b/packages/tools/helpers/src/initializeServer.ts
@@ -19,7 +19,7 @@ export async function initializeServer(
   Storage
 ): Promise<Application> {
   const app = express();
-  const config = new Config(configName);
+  const config = new Config(configName, { forceEnhancedLegacySignature: true });
   config.storage = path.join(os.tmpdir(), '/storage', generateRandomHexString());
   // httpass would get path.basename() for configPath thus we need to create a dummy folder
   // to avoid conflics


### PR DESCRIPTION
Improve `@verdaccio/config`  adding `forceEnhancedLegacySignature` property. This property allows legacy secret key generation for v5 compatibility but at the same time also allows verdaccio 5 uses improved token generation with IV support by default