### PR TITLE
Docker local storage volume demo not working properly

### DIFF
--- a/docker-examples/v6/docker-local-storage-volume/conf/config.yaml
+++ b/docker-examples/v6/docker-local-storage-volume/conf/config.yaml
@@ -15,7 +15,7 @@ storage: /verdaccio/storage
 
 auth:
   htpasswd:
-    file: /verdaccio/conf/htpasswd
+    file: htpasswd
     # Maximum amount of users allowed to register, defaults to "+inf".
     # You can set this to -1 to disable registration.
     #max_users: 1000

--- a/docker-examples/v6/docker-local-storage-volume/docker-compose.yaml
+++ b/docker-examples/v6/docker-local-storage-volume/docker-compose.yaml
@@ -1,3 +1,4 @@
+version: '3'
 services:
   verdaccio:
     image: verdaccio/verdaccio:nightly-master


### PR DESCRIPTION
Unable to login with jpicado account. 

1. Fixed reading proper htpasswd file in config.yaml.
2. Added **version: '3'** in docker-compose.yaml file.