### PR TITLE
fix: permission denied, mkdir

### DIFF
--- a/website/docs/docker.md
+++ b/website/docs/docker.md
@@ -175,9 +175,9 @@ services:
     ports:
       - '4873:4873'
     volumes:
-      - './storage:/verdaccio/storage'
-      - './config:/verdaccio/conf'
-      - './plugins:/verdaccio/plugins'
+      - './storage:/storage'
+      - './config:/conf'
+      - './plugins:/plugins'
 networks:
   node-network:
     driver: bridge


### PR DESCRIPTION
to give a clean test environment,  I use PVE to creat a VM, install  Ubuntu 22.04
docker info 
```shell
Client:
 Context:    default
 Debug Mode: false
 Plugins:
  buildx: Docker Buildx (Docker Inc.)
    Version:  v0.10.2
    Path:     /usr/libexec/docker/cli-plugins/docker-buildx
  compose: Docker Compose (Docker Inc.)
    Version:  v2.16.0
    Path:     /usr/libexec/docker/cli-plugins/docker-compose
  scan: Docker Scan (Docker Inc.)
    Version:  v0.23.0
    Path:     /usr/libexec/docker/cli-plugins/docker-scan

Server:
 Containers: 1
  Running: 0
  Paused: 0
  Stopped: 1
 Images: 1
 Server Version: 23.0.1
 Storage Driver: overlay2
  Backing Filesystem: extfs
  Supports d_type: true
  Using metacopy: false
  Native Overlay Diff: true
  userxattr: false
 Logging Driver: json-file
 Cgroup Driver: systemd
 Cgroup Version: 2
 Plugins:
  Volume: local
  Network: bridge host ipvlan macvlan null overlay
  Log: awslogs fluentd gcplogs gelf journald json-file local logentries splunk syslog
 Swarm: inactive
 Runtimes: io.containerd.runc.v2 runc
 Default Runtime: runc
 Init Binary: docker-init
 containerd version: 2456e983eb9e37e47538f59ea18f2043c9a73640
 runc version: v1.1.4-0-g5fd4c4d
 init version: de40ad0
 Security Options:
  apparmor
  seccomp
   Profile: builtin
  cgroupns
 Kernel Version: 5.15.0-67-generic
 Operating System: Ubuntu 22.04.2 LTS
 OSType: linux
 Architecture: x86_64
 CPUs: 4
 Total Memory: 3.832GiB
 Name: argo
 ID: 7606f7f4-796b-41b7-a206-311bd1af3dfd
 Docker Root Dir: /var/lib/docker
 Debug Mode: false
 Registry: https://index.docker.io/v1/
 Experimental: false
 Insecure Registries:
  127.0.0.0/8
 Registry Mirrors:
  https://registry.docker-cn.com/
  http://hub-mirror.c.163.com/
  https://docker.mirrors.ustc.edu.cn/
  https://zrb2xl6u.mirror.aliyuncs.com/
 Live Restore Enabled: false
 Default Address Pools:
   Base: 172.20.0.0/16, Size: 24
   Base: 172.30.0.0/16, Size: 24
   Base: 172.40.0.0/16, Size: 24
```
I found that not need  user setting, only need change volumes setting
```yaml
volumes:
      - './storage:/storage'
      - './config:/conf'
      - './plugins:/plugins'
```
Closes #3665 




