### PR TITLE
fix: package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git://github.com/verdaccio/verdaccio"
   },
   "homepage": "https://verdaccio.org",
-  "main": "buid/index.js",
+  "main": "build/index.js",
   "types": "build/index.d.ts",
   "bin": "./bin/verdaccio",
   "funding": {


### PR DESCRIPTION
https://github.com/verdaccio/verdaccio/pull/3689 introduced what seems to be typo and not intented change.

Result of it is that `require('verdaccio')` now imports https://unpkg.com/browse/verdaccio@5.23.0/index.js instead of CJS file and it started to cause failures for us:

```
/usr/local/share/.config/yarn/global/node_modules/verdaccio/index.js:1
export { default as startVerdaccio } from './build/index';
^^^^^^

SyntaxError: Unexpected token 'export'
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1049:15)
    at Module._compile (node:internal/modules/cjs/loader:1084:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1174:10)
    at Module.load (node:internal/modules/cjs/loader:998:32)
    at Module._load (node:internal/modules/cjs/loader:839:12)
    at Module.require (node:internal/modules/cjs/loader:1022:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/usr/local/share/.config/yarn/global/node_modules/gatsby-dev-cli/dist/local-npm-registry/index.js:3:24)
    at Module._compile (node:internal/modules/cjs/loader:1120:14)

Node.js v18.6.0
```