### PR TITLE
fix: fixed an issue where logger.info in allow_action always output undefined

### DIFF
--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -45,7 +45,7 @@ export function allow_action(action: string): Function {
     debug('[auth/allow_action]: hasPermission? %o} for user: %o', hasPermission, user?.name);
 
     if (hasPermission) {
-      logger.info({ remote: user.name }, `auth/allow_action: access granted to: @{user}`);
+      logger.info({ user: user.name }, `auth/allow_action: access granted to: @{user}`);
       return callback(null, true);
     }
 


### PR DESCRIPTION
When I debug registry, I found that the log always outputs "auth/allow_action: access granted to: undefined", which is strange, and then I found this problem in the code, which will always output undefined

```javascript
logger.info({ remote: user.name }, `auth/allow_action: access granted to: @{user}`);
```
