### PR TITLE
Fix typo in docker examples README.md

### DIFF
--- a/docker-examples/README.md
+++ b/docker-examples/README.md
@@ -10,7 +10,7 @@ The following examples aim to be demonstrative and can be either improved or upd
 - [v5 examples](v5/README.md)
 - [v6 examples](v6/README.md)
 
-## Aditional data
+## Additional data
 
 This folder aims to create a collection of Docker and Kubernetes examples.
 


### PR DESCRIPTION
To get started with verdaccio, I found a typo while reading the docker example document and created this PR :)

`adtional` -> `additional`

Please take a look.