### PR TITLE
fix: incorrect src reference from __VERDACCIO_BASENAME_UI_OPTIONS - Logo.tsx

### DIFF
--- a/packages/ui-components/src/components/Logo/Logo.tsx
+++ b/packages/ui-components/src/components/Logo/Logo.tsx
@@ -29,7 +29,7 @@ const Logo: React.FC<Props> = ({ size, onClick, className, isDefault = false }) 
   if (!isDefault && (configOptions?.logo || configOptions?.logoURI)) {
     return (
       <ImageLogo className={className} onClick={onClick}>
-        <img alt="logo" height="40px" src={(configOptions?.logo || configOptions?.logoURI)} />
+        <img alt="logo" height="40px" src={configOptions?.logo || configOptions?.logoURI} />
       </ImageLogo>
     );
   }

--- a/packages/ui-components/src/components/Logo/Logo.tsx
+++ b/packages/ui-components/src/components/Logo/Logo.tsx
@@ -26,10 +26,10 @@ interface Props {
 
 const Logo: React.FC<Props> = ({ size, onClick, className, isDefault = false }) => {
   const { configOptions } = useConfig();
-  if (!isDefault && configOptions?.logo) {
+  if (!isDefault && (configOptions?.logo || configOptions?.logoURI)) {
     return (
       <ImageLogo className={className} onClick={onClick}>
-        <img alt="logo" height="40px" src={configOptions.logo} />
+        <img alt="logo" height="40px" src={(configOptions?.logo || configOptions?.logoURI)} />
       </ImageLogo>
     );
   }


### PR DESCRIPTION
Fixing the logo custom image src.
under window.__VERDACCIO_BASENAME_UI_OPTIONS, we have logoURI not logo, so adding logoURI also along with the logo