### PR TITLE
feat(experiment): accept async tarball_url_redirect function

### DIFF
--- a/src/api/endpoint/api/package.ts
+++ b/src/api/endpoint/api/package.ts
@@ -64,7 +64,6 @@ const redirectOrDownloadStream = async (
     }
 
     res.redirect(tarballUrl);
-
   } catch (err) {
     res.locals.report_error(err);
   }

--- a/src/api/endpoint/api/package.ts
+++ b/src/api/endpoint/api/package.ts
@@ -45,12 +45,12 @@ const redirectOrDownloadStream = (
   const tarballUrlRedirect = _.get(config, 'experiments.tarball_url_redirect');
   storage
     .hasLocalTarball(packageName, filename)
-    .then((hasLocalTarball) => {
+    .then(async (hasLocalTarball) => {
       if (hasLocalTarball) {
         const context = { packageName, filename };
         const tarballUrl =
           typeof tarballUrlRedirect === 'function'
-            ? tarballUrlRedirect(context)
+            ? (tarballUrlRedirect.constructor.name === 'AsyncFunction' ? await tarballUrlRedirect(context) : tarballUrlRedirect(context))
             : _.template(tarballUrlRedirect)(context);
         res.redirect(tarballUrl);
       } else {

--- a/src/api/endpoint/api/package.ts
+++ b/src/api/endpoint/api/package.ts
@@ -50,7 +50,9 @@ const redirectOrDownloadStream = (
         const context = { packageName, filename };
         const tarballUrl =
           typeof tarballUrlRedirect === 'function'
-            ? (tarballUrlRedirect.constructor.name === 'AsyncFunction' ? await tarballUrlRedirect(context) : tarballUrlRedirect(context))
+            ? tarballUrlRedirect.constructor.name === 'AsyncFunction'
+              ? await tarballUrlRedirect(context)
+              : tarballUrlRedirect(context)
             : _.template(tarballUrlRedirect)(context);
         res.redirect(tarballUrl);
       } else {

--- a/src/api/endpoint/api/package.ts
+++ b/src/api/endpoint/api/package.ts
@@ -34,34 +34,40 @@ const downloadStream = (
   stream.pipe(res);
 };
 
-const redirectOrDownloadStream = (
+const redirectOrDownloadStream = async (
   packageName: string,
   filename: string,
   storage: any,
   req: $RequestExtend,
   res: $ResponseExtend,
   config: Config
-): void => {
-  const tarballUrlRedirect = _.get(config, 'experiments.tarball_url_redirect');
-  storage
-    .hasLocalTarball(packageName, filename)
-    .then(async (hasLocalTarball) => {
-      if (hasLocalTarball) {
-        const context = { packageName, filename };
-        const tarballUrl =
-          typeof tarballUrlRedirect === 'function'
-            ? tarballUrlRedirect.constructor.name === 'AsyncFunction'
-              ? await tarballUrlRedirect(context)
-              : tarballUrlRedirect(context)
-            : _.template(tarballUrlRedirect)(context);
-        res.redirect(tarballUrl);
+): Promise<void> => {
+  try {
+    const hasLocalTarball = await storage.hasLocalTarball(packageName, filename);
+
+    if (!hasLocalTarball) {
+      return downloadStream(packageName, filename, storage, req, res);
+    }
+
+    const tarballUrlRedirect = _.get(config, 'experiments.tarball_url_redirect');
+    const context = { packageName, filename };
+    let tarballUrl;
+
+    if (typeof tarballUrlRedirect === 'function') {
+      if (tarballUrlRedirect.constructor.name === 'AsyncFunction') {
+        tarballUrl = await tarballUrlRedirect(context);
       } else {
-        downloadStream(packageName, filename, storage, req, res);
+        tarballUrl = tarballUrlRedirect(context);
       }
-    })
-    .catch((err) => {
-      res.locals.report_error(err);
-    });
+    } else {
+      tarballUrl = _.template(tarballUrlRedirect)(context);
+    }
+
+    res.redirect(tarballUrl);
+
+  } catch (err) {
+    res.locals.report_error(err);
+  }
 };
 
 export default function (route: Router, auth: Auth, storage: Storage, config: Config): void {

--- a/test/helpers/initializeServer.ts
+++ b/test/helpers/initializeServer.ts
@@ -5,8 +5,8 @@ import path from 'path';
 
 import { errorUtils } from '@verdaccio/core';
 import { final } from '@verdaccio/middleware';
-import { generateRandomHexString } from '@verdaccio/utils';
 import { ConfigYaml } from '@verdaccio/types';
+import { generateRandomHexString } from '@verdaccio/utils';
 
 import { errorReportingMiddleware, handleError } from '../../src/api/middleware';
 import Auth from '../../src/lib/auth';

--- a/test/helpers/initializeServer.ts
+++ b/test/helpers/initializeServer.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import { errorUtils } from '@verdaccio/core';
 import { final } from '@verdaccio/middleware';
 import { generateRandomHexString } from '@verdaccio/utils';
+import { ConfigYaml } from '@verdaccio/types';
 
 import { errorReportingMiddleware, handleError } from '../../src/api/middleware';
 import Auth from '../../src/lib/auth';
@@ -14,12 +15,12 @@ import Config from '../../src/lib/config';
 const debug = buildDebug('verdaccio:tools:helpers:server');
 
 export async function initializeServer(
-  configName,
+  configuration: ConfigYaml,
   routesMiddleware: any[] = [],
   Storage
 ): Promise<Application> {
   const app = express();
-  const config = new Config(configName);
+  const config = new Config(configuration);
   config.storage = path.join(os.tmpdir(), '/storage', generateRandomHexString());
   // httpass would get path.basename() for configPath thus we need to create a dummy folder
   // to avoid conflics

--- a/test/unit/modules/api/_helper.ts
+++ b/test/unit/modules/api/_helper.ts
@@ -5,7 +5,7 @@ import supertest from 'supertest';
 
 import { parseConfigFile } from '@verdaccio/config';
 import { HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
-import { GenericBody, PackageUsers } from '@verdaccio/types';
+import { GenericBody, PackageUsers, ConfigYaml } from '@verdaccio/types';
 import { buildToken, generateRandomHexString } from '@verdaccio/utils';
 
 import apiMiddleware from '../../../../src/api/endpoint';
@@ -24,8 +24,12 @@ export const getConf = (conf) => {
   return config;
 };
 
-export async function initializeServer(configName): Promise<Application> {
+export async function initializeServer(configName: string): Promise<Application> {
   const config = getConf(configName);
+  return initializeServerHelper(config, [apiMiddleware], Storage);
+}
+
+export async function initializeServerWithConfig(config: ConfigYaml): Promise<Application> {  
   return initializeServerHelper(config, [apiMiddleware], Storage);
 }
 

--- a/test/unit/modules/api/_helper.ts
+++ b/test/unit/modules/api/_helper.ts
@@ -5,7 +5,7 @@ import supertest from 'supertest';
 
 import { parseConfigFile } from '@verdaccio/config';
 import { HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
-import { GenericBody, PackageUsers, ConfigYaml } from '@verdaccio/types';
+import { ConfigYaml, GenericBody, PackageUsers } from '@verdaccio/types';
 import { buildToken, generateRandomHexString } from '@verdaccio/utils';
 
 import apiMiddleware from '../../../../src/api/endpoint';
@@ -29,7 +29,7 @@ export async function initializeServer(configName: string): Promise<Application>
   return initializeServerHelper(config, [apiMiddleware], Storage);
 }
 
-export async function initializeServerWithConfig(config: ConfigYaml): Promise<Application> {  
+export async function initializeServerWithConfig(config: ConfigYaml): Promise<Application> {
   return initializeServerHelper(config, [apiMiddleware], Storage);
 }
 

--- a/test/unit/modules/api/config/experiments.yaml
+++ b/test/unit/modules/api/config/experiments.yaml
@@ -1,0 +1,25 @@
+storage: ./storage_experiments
+
+auth:
+  htpasswd:
+    file: ./htpasswd-package
+
+web:
+  enable: true
+  title: verdaccio
+
+publish:
+  allow_offline: false
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@*/*':
+    access: $anonymous
+    publish: $anonymous
+  '**':
+    access: $anonymous
+    publish: $anonymous
+_debug: true

--- a/test/unit/modules/api/experiments.spec.ts
+++ b/test/unit/modules/api/experiments.spec.ts
@@ -1,0 +1,156 @@
+import supertest from 'supertest';
+
+import { DIST_TAGS, HEADERS, HEADER_TYPE, HTTP_STATUS } from '@verdaccio/core';
+
+import { initializeServer, initializeServerWithConfig, getConf, publishVersion } from './_helper';
+
+describe('experiments', () => {
+
+  describe('for a function value of tarball_url_redirect', () => {
+    let app;
+    beforeEach(async () => {
+      const baseTestConfig = getConf('experiments.yaml');
+      app = await initializeServerWithConfig({
+        ...baseTestConfig,
+        experiments: {
+          // @ts-ignore
+          tarball_url_redirect(context) {
+            return `https://myapp.sfo1.mycdn.com/verdaccio/${context.packageName}/${context.filename}`;
+          },
+        },
+      });
+      await publishVersion(app, '@tarball_tester/testTarballPackage', '1.0.0');
+      await publishVersion(app, 'testTarballPackage', '1.0.0');
+    });
+
+    test('should redirect for package tarball as function', (done) => {
+      supertest(app)
+        .get('/testTarballPackage/-/testTarballPackage-1.0.0.tgz')
+        .expect(302)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.headers.location).toEqual(
+            'https://myapp.sfo1.mycdn.com/verdaccio/testTarballPackage/testTarballPackage-1.0.0.tgz'
+          );
+          done();
+        });
+
+        
+    });
+
+    test('should redirect for scoped package tarball', (done) => {
+      supertest(app)
+        .get('/@tarball_tester/testTarballPackage/-/testTarballPackage-1.0.0.tgz')
+        .expect(302)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.headers.location).toEqual(
+            'https://myapp.sfo1.mycdn.com/verdaccio/@tarball_tester/testTarballPackage/testTarballPackage-1.0.0.tgz'
+          );
+          done();
+        });
+    });
+   
+  });
+  describe('for a async function value of tarball_url_redirect', () => {
+    let app;
+    beforeEach(async () => {
+      const baseTestConfig = getConf('experiments.yaml');
+      app = await initializeServerWithConfig({
+        ...baseTestConfig,
+        experiments: {
+          // @ts-ignore
+          async tarball_url_redirect(context) {
+            await new Promise((resolve) => {
+              setTimeout(resolve, 1000);
+            });
+            return `https://myapp.sfo1.mycdn.com/verdaccio/${context.packageName}/${context.filename}`;
+          },
+        },
+      });
+      await publishVersion(app, '@tarball_tester/testTarballPackage', '1.0.0');
+      await publishVersion(app, 'testTarballPackage', '1.0.0');
+    });
+
+    test('should redirect for package tarball', (done) => {
+      supertest(app)
+        .get('/testTarballPackage/-/testTarballPackage-1.0.0.tgz')
+        .expect(302)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.headers.location).toEqual(
+            'https://myapp.sfo1.mycdn.com/verdaccio/testTarballPackage/testTarballPackage-1.0.0.tgz'
+          );
+          done();
+        });     
+    });
+
+    test('should redirect for scoped package tarball', (done) => {
+      supertest(app)
+        .get('/@tarball_tester/testTarballPackage/-/testTarballPackage-1.0.0.tgz')
+        .expect(302)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.headers.location).toEqual(
+            'https://myapp.sfo1.mycdn.com/verdaccio/@tarball_tester/testTarballPackage/testTarballPackage-1.0.0.tgz'
+          );
+          done();
+        });
+    });
+   
+  });
+  describe('for a string value of tarball_url_redirect', () => {
+    let app;
+    beforeEach(async () => {
+      const baseTestConfig = getConf('experiments.yaml');
+      app = await initializeServerWithConfig({
+        ...baseTestConfig,
+        experiments: {
+          // @ts-ignore
+          tarball_url_redirect: 'https://myapp.sfo1.mycdn.com/verdaccio/${packageName}/${filename}',
+        },
+      });
+      await publishVersion(app, '@tarball_tester/testTarballPackage', '1.0.0');
+      await publishVersion(app, 'testTarballPackage', '1.0.0');
+    });
+
+    test('should redirect for scoped package tarball', (done) => {
+      supertest(app)
+        .get('/@tarball_tester/testTarballPackage/-/testTarballPackage-1.0.0.tgz')
+        .expect(302)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.headers.location).toEqual(
+            'https://myapp.sfo1.mycdn.com/verdaccio/@tarball_tester/testTarballPackage/testTarballPackage-1.0.0.tgz'
+          );
+          done();
+        });
+    });
+
+    test('should redirect for package tarball', (done) => {
+      supertest(app)
+        .get('/testTarballPackage/-/testTarballPackage-1.0.0.tgz')
+        .expect(302)
+        .end(function (err, res) {
+          if (err) {
+            return done(err);
+          }
+          expect(res.headers.location).toEqual(
+            'https://myapp.sfo1.mycdn.com/verdaccio/testTarballPackage/testTarballPackage-1.0.0.tgz'
+          );
+          done();
+        });
+    });
+
+  })
+});

--- a/test/unit/modules/api/experiments.spec.ts
+++ b/test/unit/modules/api/experiments.spec.ts
@@ -2,10 +2,9 @@ import supertest from 'supertest';
 
 import { DIST_TAGS, HEADERS, HEADER_TYPE, HTTP_STATUS } from '@verdaccio/core';
 
-import { initializeServer, initializeServerWithConfig, getConf, publishVersion } from './_helper';
+import { getConf, initializeServer, initializeServerWithConfig, publishVersion } from './_helper';
 
 describe('experiments', () => {
-
   describe('for a function value of tarball_url_redirect', () => {
     let app;
     beforeEach(async () => {
@@ -36,8 +35,6 @@ describe('experiments', () => {
           );
           done();
         });
-
-        
     });
 
     test('should redirect for scoped package tarball', (done) => {
@@ -54,7 +51,6 @@ describe('experiments', () => {
           done();
         });
     });
-   
   });
   describe('for a async function value of tarball_url_redirect', () => {
     let app;
@@ -88,7 +84,7 @@ describe('experiments', () => {
             'https://myapp.sfo1.mycdn.com/verdaccio/testTarballPackage/testTarballPackage-1.0.0.tgz'
           );
           done();
-        });     
+        });
     });
 
     test('should redirect for scoped package tarball', (done) => {
@@ -105,7 +101,6 @@ describe('experiments', () => {
           done();
         });
     });
-   
   });
   describe('for a string value of tarball_url_redirect', () => {
     let app;
@@ -151,6 +146,5 @@ describe('experiments', () => {
           done();
         });
     });
-
-  })
+  });
 });


### PR DESCRIPTION
PR to able to generate a tarball redirect url asynchronously. ref https://github.com/verdaccio/verdaccio/pull/1688

usage example:
```javascript
  experiments: {
    tarball_url_redirect: async (packageName, filename) => {
      return aws.createPresignedUrl({
        Key: `verdaccio/${packageName}/${filename}`,
      });
    },
  }
``` 
`config.js`