### PR TITLE
feat: refactor upstream proxy and hooks with got v12

### DIFF
--- a/.changeset/silver-needles-drum.md
+++ b/.changeset/silver-needles-drum.md
@@ -1,0 +1,9 @@
+---
+'@verdaccio/core': patch
+'@verdaccio/hooks': patch
+'@verdaccio/proxy': patch
+'@verdaccio/store': patch
+'@verdaccio/web': patch
+---
+
+refactor: got instead undici

--- a/.changeset/silver-spoons-nail.md
+++ b/.changeset/silver-spoons-nail.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/proxy': minor
+'@verdaccio/store': minor
+---
+
+feat: refactor proxy with got v12

--- a/packages/core/core/src/error-utils.ts
+++ b/packages/core/core/src/error-utils.ts
@@ -29,6 +29,7 @@ export const API_ERROR = {
   REGISTRATION_DISABLED: 'user registration disabled',
   UNAUTHORIZED_ACCESS: 'unauthorized access',
   BAD_STATUS_CODE: 'bad status code',
+  SERVER_TIME_OUT: 'looks like the server is taking to long to respond',
   PACKAGE_EXIST: 'this package is already present',
   BAD_AUTH_HEADER: 'bad authorization header',
   WEB_DISABLED: 'Web interface is disabled in the config file',

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -26,7 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=12"
   },
   "dependencies": {
     "@verdaccio/core": "workspace:6.0.0-6-next.74",
@@ -34,12 +34,13 @@
     "core-js": "3.30.2",
     "debug": "4.3.4",
     "handlebars": "4.7.7",
-    "undici": "4.16.0"
+    "got-cjs": "12.5.4"
   },
   "devDependencies": {
     "@verdaccio/auth": "workspace:6.0.0-6-next.53",
     "@verdaccio/config": "workspace:6.0.0-6-next.74",
-    "@verdaccio/types": "workspace:11.0.0-6-next.25"
+    "@verdaccio/types": "workspace:11.0.0-6-next.25",
+    "nock": "13.2.9"
   },
   "scripts": {
     "clean": "rimraf ./build",

--- a/packages/hooks/src/notify-request.ts
+++ b/packages/hooks/src/notify-request.ts
@@ -1,5 +1,5 @@
 import buildDebug from 'debug';
-import { fetch } from 'undici';
+import got from 'got-cjs';
 
 import { HTTP_STATUS } from '@verdaccio/core';
 import { logger } from '@verdaccio/logger';
@@ -16,7 +16,7 @@ export async function notifyRequest(url: string, options: FetchOptions): Promise
   let response;
   try {
     debug('uri %o', url);
-    response = await fetch(url, {
+    response = got.post(url, {
       body: JSON.stringify(options.body),
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -26,8 +26,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=16",
-    "npm": ">=6"
+    "node": ">=12"
   },
   "scripts": {
     "clean": "rimraf ./build",
@@ -41,22 +40,20 @@
   "dependencies": {
     "@verdaccio/config": "workspace:6.0.0-6-next.74",
     "@verdaccio/core": "workspace:6.0.0-6-next.74",
-    "@verdaccio/local-storage": "workspace:11.0.0-6-next.44",
-    "@verdaccio/logger": "workspace:6.0.0-6-next.42",
     "@verdaccio/utils": "workspace:6.0.0-6-next.42",
     "JSONStream": "1.3.5",
     "debug": "4.3.4",
-    "lodash": "4.17.21",
-    "got": "11.8.6",
+    "got-cjs": "12.5.4",
     "hpagent": "1.2.0",
-    "undici": "4.16.0"
+    "lodash": "4.17.21"
   },
   "devDependencies": {
-    "p-cancelable": "2.1.1",
     "@verdaccio/types": "workspace:11.0.0-6-next.25",
+    "@verdaccio/logger": "workspace:6.0.0-6-next.42",
     "get-stream": "^6.0.1",
     "nock": "13.2.9",
     "node-mocks-http": "1.12.1",
+    "p-cancelable": "2.1.1",
     "semver": "7.5.4"
   },
   "funding": {

--- a/packages/proxy/src/agent.ts
+++ b/packages/proxy/src/agent.ts
@@ -1,4 +1,4 @@
-import { Agents } from 'got';
+import { Agents } from 'got-cjs';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import { Agent as HttpAgent, AgentOptions as HttpAgentOptions } from 'http';
 import { Agent as HttpsAgent, AgentOptions as HttpsAgentOptions } from 'https';

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -1,10 +1,15 @@
 import JSONStream from 'JSONStream';
 import buildDebug from 'debug';
-import got, { RequiredRetryOptions, Headers as gotHeaders } from 'got';
-import type { Agents, Options } from 'got';
+import got, {
+  Agents,
+  Delays,
+  Options,
+  RequestError,
+  RetryOptions,
+  Headers as gotHeaders,
+} from 'got-cjs';
 import _ from 'lodash';
 import Stream, { PassThrough, Readable } from 'stream';
-import { Headers, fetch as undiciFetch } from 'undici';
 import { URL } from 'url';
 
 import {
@@ -23,8 +28,6 @@ import { buildToken } from '@verdaccio/utils';
 
 import CustomAgents, { AgentOptionsConf } from './agent';
 import { parseInterval } from './proxy-utils';
-
-const LoggerApi = require('@verdaccio/logger');
 
 const debug = buildDebug('verdaccio:proxy');
 
@@ -51,10 +54,11 @@ export interface ProxyList {
 }
 
 export type ProxySearchParams = {
-  headers?: Headers;
   url: string;
-  query?: searchUtils.SearchQuery;
   abort: AbortController;
+  query?: searchUtils.SearchQuery;
+  headers?: Headers;
+  retry?: Partial<RetryOptions>;
 };
 export interface IProxy {
   config: UpLinkConfLocal;
@@ -65,15 +69,18 @@ export interface IProxy {
   server_id: string;
   url: URL;
   maxage: number;
-  timeout: number;
+  timeout: Delays;
   max_fails: number;
   fail_timeout: number;
   upname: string;
   search(options: ProxySearchParams): Promise<Stream.Readable>;
-  getRemoteMetadata(name: string, options: ISyncUplinksOptions): Promise<[Manifest, string]>;
+  getRemoteMetadata(
+    name: string,
+    options: Partial<ISyncUplinksOptions>
+  ): Promise<[Manifest, string]>;
   fetchTarball(
     url: string,
-    options: Pick<ISyncUplinksOptions, 'remoteAddress' | 'etag' | 'retry'>
+    options: Partial<Pick<ISyncUplinksOptions, 'remoteAddress' | 'etag' | 'retry'>>
   ): PassThrough;
 }
 
@@ -99,7 +106,7 @@ class ProxyStorage implements IProxy {
   public server_id: string;
   public url: URL;
   public maxage: number;
-  public timeout: number;
+  public timeout: Delays;
   public max_fails: number;
   public fail_timeout: number;
   public agent_options: AgentOptionsConf;
@@ -111,14 +118,14 @@ class ProxyStorage implements IProxy {
   // @ts-ignore
   public last_request_time: number | null;
   public strict_ssl: boolean;
-  private retry: Partial<RequiredRetryOptions> | number;
+  private retry: Partial<RetryOptions>;
 
-  public constructor(config: UpLinkConfLocal, mainConfig: Config, agent?: Agents) {
+  public constructor(config: UpLinkConfLocal, mainConfig: Config, logger: Logger, agent?: Agents) {
     this.config = config;
     this.failed_requests = 0;
     this.userAgent = mainConfig.user_agent ?? 'hidden';
     this.ca = config.ca;
-    this.logger = LoggerApi.logger.child({ sub: 'out' });
+    this.logger = logger;
     this.server_id = mainConfig.server_id;
     this.agent_options = setConfig(this.config, 'agent_options', {
       keepAlive: true,
@@ -145,7 +152,9 @@ class ProxyStorage implements IProxy {
     // a bunch of different configurable timers
     this.maxage = parseInterval(setConfig(this.config, 'maxage', '2m'));
     // https://github.com/sindresorhus/got/blob/main/documentation/6-timeout.md
-    this.timeout = parseInterval(setConfig(this.config, 'timeout', '30s'));
+    this.timeout = {
+      request: parseInterval(setConfig(this.config, 'timeout', '30s')),
+    };
     this.max_fails = Number(setConfig(this.config, 'max_fails', this.config.max_fails ?? 2));
     this.fail_timeout = parseInterval(setConfig(this.config, 'fail_timeout', '5m'));
     this.strict_ssl = Boolean(setConfig(this.config, 'strict_ssl', true));
@@ -296,7 +305,7 @@ class ProxyStorage implements IProxy {
 
   public async getRemoteMetadata(
     name: string,
-    options: ISyncUplinksOptions
+    options: Partial<ISyncUplinksOptions>
   ): Promise<[Manifest, string]> {
     if (this._ifRequestFailure()) {
       throw errorUtils.getInternalError(API_ERROR.UPLINK_OFFLINE);
@@ -326,8 +335,7 @@ class ProxyStorage implements IProxy {
         method,
         agent: this.agent,
         retry,
-        // @ts-ignore
-        timeout: { request: options?.timeout ?? this.timeout },
+        timeout: this.timeout,
         hooks: {
           afterResponse: [
             (afterResponse) => {
@@ -349,8 +357,7 @@ class ProxyStorage implements IProxy {
             },
           ],
           beforeRetry: [
-            // FUTURE: got 12.0.0, the option arg should be removed
-            (_options, error: any, count) => {
+            (error: RequestError, count: number) => {
               this.failed_requests = count ?? 0;
               this.logger.info(
                 {
@@ -378,7 +385,7 @@ class ProxyStorage implements IProxy {
         .on('request', () => {
           this.last_request_time = Date.now();
         })
-        .on('response', (eventResponse) => {
+        .on<any>('response', (eventResponse) => {
           const message = "@{!status}, req: '@{request.method} @{request.url}' (streaming)";
           this.logger.http(
             {
@@ -482,37 +489,32 @@ class ProxyStorage implements IProxy {
    * @param {*} options request options
    * @return {Stream}
    */
-  public async search({ url, abort }: ProxySearchParams): Promise<Stream.Readable> {
+  public async search({ url, abort, retry }: ProxySearchParams): Promise<Stream.Readable> {
     debug('search url %o', url);
 
-    let response;
     try {
       const fullURL = new URL(`${this.url}${url}`);
       // FIXME: a better way to remove duplicate slashes?
       const uri = fullURL.href.replace(/([^:]\/)\/+/g, '$1');
       this.logger.http({ uri, uplink: this.upname }, 'search request to uplink @{uplink} - @{uri}');
-      response = await undiciFetch(uri, {
-        method: 'GET',
-        // FUTURE: whitelist domains what we are sending not need it headers, security check
-        // headers: new Headers({
-        //   ...headers,
-        //   connection: 'keep-alive',
-        // }),
-        signal: abort?.signal,
+      const response = got(uri, {
+        signal: abort.signal,
+        agent: this.agent,
+        timeout: this.timeout,
+        retry: retry ?? this.retry,
       });
-      debug('response.status  %o', response.status);
+      // debug('response.status  %o', response.status);
 
-      if (response.status >= HTTP_STATUS.BAD_REQUEST) {
-        throw errorUtils.getInternalError(`bad status code ${response.status} from uplink`);
-      }
-
-      const streamSearch = new PassThrough({ objectMode: true });
       const res = await response.text();
+      const streamSearch = new PassThrough({ objectMode: true });
       const streamResponse = Readable.from(res);
       // objects is one of the properties on the body, it ignores date and total
       streamResponse.pipe(JSONStream.parse('objects')).pipe(streamSearch, { end: true });
       return streamSearch;
     } catch (err: any) {
+      if (err.response.statusCode === 409) {
+        throw errorUtils.getInternalError(`bad status code ${err.response.statusCode} from uplink`);
+      }
       this.logger.error(
         { errorMessage: err?.message, name: this.upname },
         'proxy uplink @{name} search error: @{errorMessage}'

--- a/packages/proxy/test/headers.auth.spec.ts
+++ b/packages/proxy/test/headers.auth.spec.ts
@@ -1,11 +1,23 @@
 import { DEFAULT_REGISTRY } from '@verdaccio/config';
 import { HEADERS, TOKEN_BASIC, TOKEN_BEARER, constants } from '@verdaccio/core';
-import { setup } from '@verdaccio/logger';
+import { Logger } from '@verdaccio/types';
 import { buildToken } from '@verdaccio/utils';
 
 import { ProxyStorage } from '../src';
 
-setup();
+const mockDebug = jest.fn();
+const mockInfo = jest.fn();
+const mockHttp = jest.fn();
+const mockError = jest.fn();
+const mockWarn = jest.fn();
+
+const logger = {
+  debug: mockDebug,
+  info: mockInfo,
+  http: mockHttp,
+  error: mockError,
+  warn: mockWarn,
+} as unknown as Logger;
 
 function createUplink(config) {
   const defaultConfig = {
@@ -13,7 +25,7 @@ function createUplink(config) {
   };
   const mergeConfig = Object.assign({}, defaultConfig, config);
   // @ts-ignore
-  return new ProxyStorage(mergeConfig, {});
+  return new ProxyStorage(mergeConfig, {}, logger);
 }
 
 function setHeadersNext(config: unknown = {}, headers: any = {}) {

--- a/packages/proxy/test/headers.auth.spec.ts
+++ b/packages/proxy/test/headers.auth.spec.ts
@@ -30,7 +30,7 @@ function createUplink(config) {
 
 function setHeadersNext(config: unknown = {}, headers: any = {}) {
   const uplink = createUplink(config);
-  return uplink.getHeadersNext({ ...headers });
+  return uplink.getHeaders({ ...headers });
 }
 
 describe('setHeadersNext', () => {

--- a/packages/proxy/test/noProxy.spec.ts
+++ b/packages/proxy/test/noProxy.spec.ts
@@ -1,11 +1,13 @@
+import { logger, setup } from '@verdaccio/logger';
+
 import { ProxyStorage } from '../src';
 
-require('@verdaccio/logger').setup([]);
+setup({});
 
 function getProxyInstance(host, uplinkConf, appConfig) {
   uplinkConf.url = host;
 
-  return new ProxyStorage(uplinkConf, appConfig);
+  return new ProxyStorage(uplinkConf, appConfig, logger);
 }
 
 describe('Use proxy', () => {

--- a/packages/proxy/test/proxy.tarball.spec.ts
+++ b/packages/proxy/test/proxy.tarball.spec.ts
@@ -2,7 +2,7 @@ import nock from 'nock';
 import path from 'path';
 
 import { Config, parseConfigFile } from '@verdaccio/config';
-import { setup } from '@verdaccio/logger';
+import { logger, setup } from '@verdaccio/logger';
 
 import { ProxyStorage } from '../src';
 
@@ -44,7 +44,7 @@ describe('tarball proxy', () => {
       nock('https://registry.verdaccio.org')
         .get('/jquery/-/jquery-0.0.1.tgz')
         .replyWithFile(201, path.join(__dirname, 'partials/jquery-0.0.1.tgz'));
-      const prox1 = new ProxyStorage(defaultRequestOptions, conf);
+      const prox1 = new ProxyStorage(defaultRequestOptions, conf, logger);
       const stream = prox1.fetchTarball(
         'https://registry.verdaccio.org/jquery/-/jquery-0.0.1.tgz',
         {}

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -58,7 +58,6 @@
   "devDependencies": {
     "@verdaccio/types": "workspace:11.0.0-6-next.25",
     "@verdaccio/test-helper": "workspace:2.0.0-6-next.8",
-    "undici": "4.16.0",
     "nock": "13.2.9",
     "node-mocks-http": "1.12.1",
     "mockdate": "3.0.5"

--- a/packages/store/src/lib/uplink-util.ts
+++ b/packages/store/src/lib/uplink-util.ts
@@ -1,3 +1,4 @@
+import { logger } from '@verdaccio/logger';
 import { IProxy, ProxyStorage } from '@verdaccio/proxy';
 import { Config, Manifest } from '@verdaccio/types';
 
@@ -14,7 +15,7 @@ export function setupUpLinks(config: Config): ProxyInstanceList {
   for (const uplinkName in config.uplinks) {
     if (Object.prototype.hasOwnProperty.call(config.uplinks, uplinkName)) {
       // instance for each up-link definition
-      const proxy: IProxy = new ProxyStorage(config.uplinks[uplinkName], config);
+      const proxy: IProxy = new ProxyStorage(config.uplinks[uplinkName], config, logger);
       // TODO: review this can be inside ProxyStorage
       proxy.upname = uplinkName;
 

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -237,11 +237,11 @@ class Storage {
     });
 
     try {
-      debug('search uplinks');
-      // we only process those streams end successfully, if all fails
-      // we just include local storage
+      debug('searching on %s uplinks...', searchUplinksStreams?.length);
+      // only process those streams end successfully, if all request fails
+      // just include local storage results (if local fails then return 500)
       await Promise.allSettled([...searchUplinksStreams]);
-      debug('search uplinks done');
+      debug('searching all uplinks done');
     } catch (err: any) {
       this.logger.error({ err: err?.message }, ' error on uplinks search @{err}');
       streamPassThrough.emit('error', err);
@@ -912,7 +912,8 @@ class Storage {
           url: distFile.url,
           cache: true,
         },
-        this.config
+        this.config,
+        logger
       );
     }
     return uplink;
@@ -1619,7 +1620,7 @@ class Storage {
   public async syncUplinksMetadataNext(
     name: string,
     localManifest: Manifest | null,
-    options: ISyncUplinksOptions = {}
+    options: Partial<ISyncUplinksOptions> = {}
   ): Promise<[Manifest | null, any]> {
     let found = localManifest !== null;
     let syncManifest: Manifest | null = null;
@@ -1712,7 +1713,7 @@ class Storage {
   private async mergeCacheRemoteMetadata(
     uplink: IProxy,
     cachedManifest: Manifest,
-    options: ISyncUplinksOptions
+    options: Partial<ISyncUplinksOptions>
   ): Promise<Manifest> {
     // we store which uplink is updating the manifest
     const upLinkMeta = cachedManifest._uplinks[uplink.upname];

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -226,11 +226,11 @@ class Storage {
     const transformResults = new TransFormResults({ objectMode: true });
     const streamPassThrough = new PassThrough({ objectMode: true });
     const upLinkList = this.getProxyList();
-
+    debug('uplinks found %s', upLinkList.length);
     const searchUplinksStreams = upLinkList.map((uplinkId: string) => {
       const uplink = this.uplinks[uplinkId];
       if (!uplink) {
-        // this should never tecnically happens
+        // this line should never happens
         this.logger.error({ uplinkId }, 'uplink @upLinkId not found');
       }
       return this.consumeSearchStream(uplinkId, uplink, options, streamPassThrough);
@@ -1642,7 +1642,7 @@ class Storage {
     }
 
     const uplinksErrors: any[] = [];
-    // we resolve uplinks async in serie, first come first serve
+    // we resolve uplinks async in series, first come first serve
     for (const uplink of upLinks) {
       try {
         const tempManifest = _.isNil(localManifest)

--- a/packages/store/test/fixtures/config/syncDoubleUplinksMetadata.yaml
+++ b/packages/store/test/fixtures/config/syncDoubleUplinksMetadata.yaml
@@ -1,6 +1,7 @@
 uplinks:
   timeout:
     url: https://registry.domain.com/
+    timeout: 2s
   some:
     url: https://registry.domain.com/
   ver:

--- a/packages/store/test/search.spec.ts
+++ b/packages/store/test/search.spec.ts
@@ -6,7 +6,7 @@ import { setup } from '@verdaccio/logger';
 
 import { Storage, removeDuplicates } from '../src';
 
-setup([]);
+setup({});
 
 describe('search', () => {
   describe('search manager utils', () => {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -47,7 +47,6 @@
     "supertest": "6.3.3",
     "nock": "13.2.9",
     "jsdom": "20.0.3",
-    "undici": "4.16.0",
     "verdaccio-auth-memory": "workspace:11.0.0-6-next.39",
     "verdaccio-memory": "workspace:11.0.0-6-next.41"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1389,12 +1389,6 @@ importers:
       '@verdaccio/core':
         specifier: workspace:6.0.0-6-next.74
         version: link:../core/core
-      '@verdaccio/local-storage':
-        specifier: workspace:11.0.0-6-next.44
-        version: link:../plugins/local-storage
-      '@verdaccio/logger':
-        specifier: workspace:6.0.0-6-next.42
-        version: link:../logger/logger
       '@verdaccio/utils':
         specifier: workspace:6.0.0-6-next.42
         version: link:../utils
@@ -1404,19 +1398,19 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@6.1.0)
-      got:
-        specifier: 11.8.5
-        version: 11.8.5
+      got-cjs:
+        specifier: 12.5.4
+        version: 12.5.4
       hpagent:
         specifier: 1.2.0
         version: 1.2.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
-      undici:
-        specifier: 4.16.0
-        version: 4.16.0
     devDependencies:
+      '@verdaccio/logger':
+        specifier: workspace:6.0.0-6-next.42
+        version: link:../logger/logger
       '@verdaccio/types':
         specifier: workspace:11.0.0-6-next.25
         version: link:../core/types
@@ -13513,6 +13507,11 @@ packages:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
     engines: {node: '>=10.6.0'}
 
+  /cacheable-lookup@6.1.0:
+    resolution: {integrity: sha512-KJ/Dmo1lDDhmW2XDPMo+9oiy/CeqosPguPCrgcVzKyZrL6pM1gU2GmPY/xo6OQPTUaA/c0kwHuywB4E6nmT9ww==}
+    engines: {node: '>=10.6.0'}
+    dev: false
+
   /cacheable-request@7.0.2:
     resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
     engines: {node: '>=8'}
@@ -17546,6 +17545,10 @@ packages:
       typescript: 4.9.4
       webpack: 5.82.1(webpack-cli@4.10.0)
 
+  /form-data-encoder@1.7.2:
+    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
+    dev: false
+
   /form-data@2.3.3:
     resolution: {integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==}
     engines: {node: '>= 0.12'}
@@ -17973,6 +17976,24 @@ packages:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
       get-intrinsic: 1.2.0
+
+  /got-cjs@12.5.4:
+    resolution: {integrity: sha512-Uas6lAsP8bRCt5WXGMhjFf/qEHTrm4v4qxGR02rLG2kdG9qedctvlkdwXVcDJ7Cs84X+r4dPU7vdwGjCaspXug==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/responselike': 1.0.0
+      cacheable-lookup: 6.1.0
+      cacheable-request: 7.0.2
+      decompress-response: 6.0.0
+      form-data-encoder: 1.7.2
+      get-stream: 6.0.1
+      http2-wrapper: 2.2.0
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+    dev: false
 
   /got@11.8.5:
     resolution: {integrity: sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==}
@@ -18485,6 +18506,14 @@ packages:
     dependencies:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
+
+  /http2-wrapper@2.2.0:
+    resolution: {integrity: sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==}
+    engines: {node: '>=10.19.0'}
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+    dev: false
 
   /https-browserify@1.0.0:
     resolution: {integrity: sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1658,9 +1658,6 @@ importers:
       node-mocks-http:
         specifier: 1.12.1
         version: 1.12.1
-      undici:
-        specifier: 4.16.0
-        version: 4.16.0
 
   packages/tools/docusaurus-plugin-contributors:
     dependencies:
@@ -2109,9 +2106,6 @@ importers:
       supertest:
         specifier: 6.3.3
         version: 6.3.3
-      undici:
-        specifier: 4.16.0
-        version: 4.16.0
       verdaccio-auth-memory:
         specifier: workspace:11.0.0-6-next.39
         version: link:../plugins/auth-memory
@@ -27254,6 +27248,7 @@ packages:
   /undici@4.16.0:
     resolution: {integrity: sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==}
     engines: {node: '>=12.18'}
+    dev: false
 
   /unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,12 +773,12 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4(supports-color@6.1.0)
+      got-cjs:
+        specifier: 12.5.4
+        version: 12.5.4
       handlebars:
         specifier: 4.7.7
         version: 4.7.7
-      undici:
-        specifier: 4.16.0
-        version: 4.16.0
     devDependencies:
       '@verdaccio/auth':
         specifier: workspace:6.0.0-6-next.53
@@ -789,6 +789,9 @@ importers:
       '@verdaccio/types':
         specifier: workspace:11.0.0-6-next.25
         version: link:../core/types
+      nock:
+        specifier: 13.2.9
+        version: 13.2.9
 
   packages/loaders:
     dependencies:
@@ -27244,11 +27247,6 @@ packages:
   /undefsafe@2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
-
-  /undici@4.16.0:
-    resolution: {integrity: sha512-tkZSECUYi+/T1i4u+4+lwZmQgLXd4BLGlrc7KZPcLIW7Jpq99+Xpc30ONv7nS6F5UNOxp/HBZSSL9MafUrvJbw==}
-    engines: {node: '>=12.18'}
-    dev: false
 
   /unfetch@4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}


### PR DESCRIPTION
One more step to move the refactored code from 6.x to 5.x and slow under-hood migration, the packages proxy and hooks are the prev steps before moving the `storage` (which causes some known issues/bugs), this will help with double maintenance in a big chunk of code. It removes `undici` because cannot be used in Node.js 12 in favour of got wrapped for common-js.

This PR aims to
-  prepare the `@verdaccio/proxy` module to be used at `5.x` and at the same time get rid of the `request` #1807 library
- prepare the `@verdaccio/hooks` module to be used at `5.x` and at the same time get rid of the `request` #1807 library