### PR TITLE
Missing "onClick" prop in @verdaccio/ui-components Link component preventing handleDownload call in Package.tsx #3988

### DIFF
--- a/.changeset/chilled-carrots-guess.md
+++ b/.changeset/chilled-carrots-guess.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+- added `onClick` prop to `Link` component in @verdaccio/ui-components. (@moglerdev in #3989)
+- resolved issue in the `Package` component where the download button was incorrectly opening a new tab to the homepage. (@moglerdev in #3989)

--- a/packages/ui-components/src/components/Link/Link.tsx
+++ b/packages/ui-components/src/components/Link/Link.tsx
@@ -15,15 +15,22 @@ export const CustomRouterLink = styled(RouterLink)`
 
 // TODO: improve any with custom types for a and RouterLink
 const Link = React.forwardRef<LinkRef, any>(function LinkFunction(
-  { external, to, children, variant, className },
+  { external, to, children, variant, className, onClick },
   ref
 ) {
   return external ? (
-    <a className={className} href={to} ref={ref} rel="noopener noreferrer" target="_blank">
+    <a
+      className={className}
+      href={to}
+      onClick={onClick}
+      ref={ref}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
       <Typography variant={variant ?? 'caption'}>{children}</Typography>
     </a>
   ) : (
-    <CustomRouterLink className={className} innerRef={ref} to={to}>
+    <CustomRouterLink className={className} innerRef={ref} onClick={onClick} to={to}>
       <Typography variant={variant}>{children}</Typography>
     </CustomRouterLink>
   );

--- a/packages/ui-components/src/components/Package/Package.tsx
+++ b/packages/ui-components/src/components/Package/Package.tsx
@@ -163,7 +163,6 @@ const Package: React.FC<PackageInterface> = ({
     dist?.tarball &&
     url.isURL(dist.tarball) && (
       <Link
-        external={true}
         onClick={() => {
           handleDownload(dist.tarball);
         }}


### PR DESCRIPTION
At present, attempting to download the "tar" file from the Package List on the homepage does not work as expected. Clicking on the link only opens a new tab, but no download action occurs.

The root cause of this problem lies in the `Link` Component within @verdaccio/ui-components. It lacks a necessary `onClick` prop, preventing the execution of the `handleDownload` function in `Package.tsx`.