### PR TITLE
fix: display labels for engine versions

### DIFF
--- a/.changeset/eight-squids-judge.md
+++ b/.changeset/eight-squids-judge.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/ui-theme': patch
+'@verdaccio/ui-components': patch
+---
+
+fix: display labels for engine versions

--- a/packages/plugins/ui-theme/src/i18n/crowdin/ui.json
+++ b/packages/plugins/ui-theme/src/i18n/crowdin/ui.json
@@ -128,8 +128,10 @@
       "title": "Contributors"
     },
     "engines": {
-      "npm-version": "NPM Version",
-      "node-js": "NODE JS"
+      "npm-version": "Npm Version",
+      "pnpm-version": "Pnpm Version",
+      "yarn-version": "Yarn Version",
+      "node-js": "Node.js"
     }
   },
   "footer": {

--- a/packages/ui-components/src/components/Engines/Engines.tsx
+++ b/packages/ui-components/src/components/Engines/Engines.tsx
@@ -68,7 +68,7 @@ const Engine: React.FC<Props> = ({ packageMeta }) => {
       {engines.npm ? (
         <EngineItem
           element={<Npm />}
-          engineText={engines.node}
+          engineText={engines.npm}
           title={t('sidebar.engines.npm-version')}
         />
       ) : null}
@@ -77,7 +77,7 @@ const Engine: React.FC<Props> = ({ packageMeta }) => {
         <EngineItem
           element={<Yarn />}
           engineText={engines.yarn}
-          title={t('sidebar.engines.npm-version')}
+          title={t('sidebar.engines.yarn-version')}
         />
       ) : null}
 
@@ -85,7 +85,7 @@ const Engine: React.FC<Props> = ({ packageMeta }) => {
         <EngineItem
           element={<Pnpm />}
           engineText={engines.pnpm}
-          title={t('sidebar.engines.npm-version')}
+          title={t('sidebar.engines.pnpm-version')}
         />
       ) : null}
     </Grid>


### PR DESCRIPTION
Fixes the following issues with the engine component (in the sidebar):

- Spelling of "NODE JS"
- Display of "node version" under "NPM Version"
- Incorrect title for "Yarn Version" and "Pnpm Version" 

![image](https://github.com/verdaccio/verdaccio/assets/59966492/9732d3df-efba-4072-bd4a-9c9e7fa9dd11)

Corrections:

- Changed "NODE JS" to the official "[Node.js](https://nodejs.org/en/about)" spelling 
- Display the correct npm version for the "Npm Version" box
- Added proper titles for "Yarn Version" and "Pnpm Version" 

![image](https://github.com/verdaccio/verdaccio/assets/59966492/7ab37372-3b4f-492c-9ff1-9248338d9e1b)

PS: It shows as "Node.Js" instead of "Node.js" because of `text-transform: capitalize;` CSS. Not sure if you want to correct this. 