### PR TITLE
fix: Avoid 404 error when getting favicon on root

### DIFF
--- a/.changeset/weak-fans-explain.md
+++ b/.changeset/weak-fans-explain.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/server': patch
+---
+
+fix: Avoid 404 error when getting favicon from root

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -48,7 +48,7 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<an
   app.get(
     '/favicon.ico',
     function (req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer): void {
-      req.url = '/-/static/favicon.png';
+      req.url = '/-/static/favicon.ico';
       next();
     }
   );


### PR DESCRIPTION
Request for `favicon.ico` on root for server failed with 404.

![image](https://github.com/verdaccio/verdaccio/assets/59966492/32b7e69c-2e12-450e-bdbf-8b5977f22bef)


![image](https://github.com/verdaccio/verdaccio/assets/59966492/d980f712-a545-4778-9e0d-21ba296a0839)

Looks like cause was redirect to a `png` which does not exist