### PR TITLE
chore: remove deprecated corepack command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack install
+          corepack prepare --activate pnpm@8.9.0
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: ~/.pnpm-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,30 +25,30 @@ jobs:
         ports:
           - 4873:4873
         env:
-          NODE_ENV: production          
+          NODE_ENV: production
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-    - name: Node
-      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # tag=v3
-      with:
-        node-version-file: '.nvmrc'
-    - name: Install pnpm
-      run: |
-        corepack enable
-        corepack prepare --activate pnpm@8.9.0
-    - name: set store
-      run: |
-        mkdir ~/.pnpm-store
-        pnpm config set store-dir ~/.pnpm-store
-    - name: Install
-      run: pnpm install  --registry http://localhost:4873
-    - name: Cache .pnpm-store
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
-      with:
-        path: ~/.pnpm-store
-        key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-        restore-keys: |
-          pnpm-
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - name: Node
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # tag=v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install pnpm
+        run: |
+          corepack enable
+          corepack install
+      - name: set store
+        run: |
+          mkdir ~/.pnpm-store
+          pnpm config set store-dir ~/.pnpm-store
+      - name: Install
+        run: pnpm install  --registry http://localhost:4873
+      - name: Cache .pnpm-store
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-
   lint:
     runs-on: ubuntu-latest
     name: Lint
@@ -62,14 +62,14 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare --activate pnpm@8.9.0
+          corepack install
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: set store
         run: |
-          pnpm config set store-dir ~/.pnpm-store              
+          pnpm config set store-dir ~/.pnpm-store
       - name: Install
         run: pnpm install --ignore-scripts
       - name: Lint
@@ -87,14 +87,14 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare --activate pnpm@8.9.0
+          corepack install
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: set store
         run: |
-          pnpm config set store-dir ~/.pnpm-store              
+          pnpm config set store-dir ~/.pnpm-store
       - name: Install
         run: pnpm install --ignore-scripts
       - name: Lint
@@ -117,14 +117,14 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare --activate pnpm@8.9.0
+          corepack install
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: set store
         run: |
-          pnpm config set store-dir ~/.pnpm-store              
+          pnpm config set store-dir ~/.pnpm-store
       - name: Install
         run: pnpm install --ignore-scripts --registry http://localhost:4873
       - name: build
@@ -144,14 +144,14 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare --activate pnpm@8.9.0
+          corepack install
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
       - name: set store
         run: |
-          pnpm config set store-dir ~/.pnpm-store              
+          pnpm config set store-dir ~/.pnpm-store
       - name: Install
         ## we need scripts, pupetter downloads aditional content
         run: pnpm install --registry http://localhost:4873

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -15,26 +15,28 @@ jobs:
         env:
           NODE_ENV: production
     steps:
-    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-    - name: Use Node
-      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # tag=v3
-      with:
-        node-version-file: '.nvmrc'
-    - name: Install pnpm
-      run: npm i pnpm@latest-8 -g
-    - name: set store
-      run: |
-        mkdir ~/.pnpm-store
-        pnpm config set store-dir ~/.pnpm-store
-    - name: Install
-      run: pnpm install --reporter=silence --ignore-scripts --registry http://localhost:4873
-    - name: Cache .pnpm-store
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
-      with:
-        path: ~/.pnpm-store
-        key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}-${{ github.sha }}
-        restore-keys: |
-          pnpm-
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - name: Use Node
+        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # tag=v3
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install pnpm
+        run: |
+          corepack enable
+          corepack prepare --activate pnpm@8.9.0
+      - name: set store
+        run: |
+          mkdir ~/.pnpm-store
+          pnpm config set store-dir ~/.pnpm-store
+      - name: Install
+        run: pnpm install --reporter=silence --ignore-scripts --registry http://localhost:4873
+      - name: Cache .pnpm-store
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}-${{ github.sha }}
+          restore-keys: |
+            pnpm-
   build:
     needs: [prepare]
     runs-on: ubuntu-latest
@@ -45,14 +47,16 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: Install pnpm
-        run: npm i pnpm@latest-8 -g
+        run: |
+          corepack enable
+          corepack prepare --activate pnpm@8.9.0
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}-${{ github.sha }}
       - name: set store
         run: |
-          pnpm config set store-dir ~/.pnpm-store              
+          pnpm config set store-dir ~/.pnpm-store
       - name: Install
         run: pnpm recursive install --reporter=silence --registry http://localhost:4873
       - name: build
@@ -78,7 +82,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pkg: [npm6, npm7, npm8, npm9, npm10, pnpm6, pnpm7, pnpm8, yarn1, yarn2, yarn3, yarn4]
+        pkg:
+          [
+            npm6,
+            npm7,
+            npm8,
+            npm9,
+            npm10,
+            pnpm6,
+            pnpm7,
+            pnpm8,
+            yarn1,
+            yarn2,
+            yarn3,
+            yarn4,
+          ]
         node: [16, 18, 19]
     name: ${{ matrix.pkg }}/ ubuntu-latest / ${{ matrix.node }}
     runs-on: ubuntu-latest
@@ -88,14 +106,16 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Install pnpm
-        run: npm i pnpm@latest-8 -g
+        run: |
+          corepack enable
+          corepack prepare --activate pnpm@8.9.0
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
           path: ~/.pnpm-store
           key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}-${{ github.sha }}
       - name: set store
         run: |
-          pnpm config set store-dir ~/.pnpm-store              
+          pnpm config set store-dir ~/.pnpm-store
       - name: Install
         run: pnpm install --offline --reporter=silence --ignore-scripts --registry http://localhost:4873
       - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
@@ -107,6 +127,6 @@ jobs:
       #     path: ./e2e/
       #     key: test-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.run_id }}-${{ github.sha }}
       - name: build e2e
-        run:  pnpm --filter @verdaccio/test-cli-commons build
+        run: pnpm --filter @verdaccio/test-cli-commons build
       - name: Test CLI
         run: NODE_ENV=production pnpm test --filter ...@verdaccio/e2e-cli-${{matrix.pkg}}

--- a/.github/workflows/e2e-ui.yml
+++ b/.github/workflows/e2e-ui.yml
@@ -22,8 +22,8 @@ jobs:
           node-version-file: '.nvmrc'
       - name: Install pnpm
         run: |
-         corepack enable
-         corepack prepare --activate pnpm@8.9.0
+          corepack enable
+          corepack install
       - name: Install
         run: pnpm install --reporter=silence --registry http://localhost:4873
       - name: build

--- a/.github/workflows/ui-components.yml
+++ b/.github/workflows/ui-components.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-            corepack install
+          corepack install
       - name: Install
         run: pnpm install
       - name: Build storybook
@@ -56,7 +56,7 @@ jobs:
         # the msw.js worker is need it at the storybook-static folder in production
         run: cp -R packages/ui-components/public/* packages/ui-components/storybook-static
       - name: 🔥 Deploy Production UI Netlify
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
         uses: verdaccio/action-netlify-deploy@1c086d59169edeec9254672c7de17d2ceac3928f # v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-components.yml
+++ b/.github/workflows/ui-components.yml
@@ -1,17 +1,17 @@
 name: UI Components
 
-on: 
+on:
   workflow_dispatch:
   pull_request:
     paths:
-    - .github/workflows/ui-components.yml
-    - 'packages/ui-components/**'
-    - 'package.json'
-    - 'pnpm-workspace.yaml'
-    - 'pnpm-lock.yaml'
+      - .github/workflows/ui-components.yml
+      - 'packages/ui-components/**'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - 'pnpm-lock.yaml'
 
 permissions:
-  contents: read  #  to fetch code (actions/checkout)
+  contents: read #  to fetch code (actions/checkout)
 
 env:
   DEBUG: verdaccio*
@@ -19,9 +19,9 @@ env:
 jobs:
   deploy:
     permissions:
-      contents: read  #  to fetch code (actions/checkout)
+      contents: read #  to fetch code (actions/checkout)
       deployments: write
-      pull-requests: write  #  to comment on pull-requests
+      pull-requests: write #  to comment on pull-requests
 
     runs-on: ubuntu-latest
     env:
@@ -47,9 +47,9 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-            corepack prepare --activate pnpm@8.9.0
+            corepack install
       - name: Install
-        run: pnpm install  
+        run: pnpm install
       - name: Build storybook
         run: pnpm ui:storybook:build
       - name: Copy public content
@@ -62,7 +62,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           netlify-auth-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           netlify-site-id: ${{ secrets.NETLIFY_UI_SITE_ID }}
-          build-dir: './packages/ui-components/storybook-static'          
+          build-dir: './packages/ui-components/storybook-static'
       - name: 🤖 Deploy Preview UI Components Netlify
         if: github.repository == 'verdaccio/verdaccio'
         uses: semoal/action-netlify-deploy@1a53f098745bf78555d11b436f5ee3af87e6b566

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,12 +41,12 @@ package-lock=false
 
 This setting would cause the `pnpm install` command to install incorrect versions of package dependencies and the subsequent `pnpm build` step would likely fail.
 
-To begin your development setup, please install the latest version of pnpm globally:
+We use [corepack](https://github.com/nodejs/corepack) to install and use a specific (latest) version of pnpm. Please run the following commands which is use a specific version on Node.js and configure it to use a specific version of pnpm. The version of pnpm is specified in the `package.json` file in `packageManager` field.
 
 ```
 nvm install
 corepack enable
-corepack prepare --activate pnpm@8.9.0
+corepack install
 ```
 
 With pnpm installed, the first step is installing all dependencies:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,15 +43,23 @@ This setting would cause the `pnpm install` command to install incorrect version
 
 We use [corepack](https://github.com/nodejs/corepack) to install and use a specific (latest) version of pnpm. Please run the following commands which is use a specific version on Node.js and configure it to use a specific version of pnpm. The version of pnpm is specified in the `package.json` file in `packageManager` field.
 
-```
+```shell
 nvm install
 corepack enable
 corepack install
 ```
 
+`pnpm` version will be updated mainly by the maintainers but if you would like to set it to a specific version, you can do so by running the following command:
+
+```shell
+corepack use pnpm@8.9.1
+```
+
+It will update the `package.json` file with the new version of pnpm in the `packageManager` field.
+
 With pnpm installed, the first step is installing all dependencies:
 
-```
+```shell
 pnpm install
 ```
 
@@ -59,45 +67,45 @@ pnpm install
 
 Each package is independent, dependencies must be build first, run:
 
-```
+```shell
 pnpm build
 ```
 
 ### Running test
 
-```
+```shell
 pnpm test
 ```
 
 Verdaccio is a mono repository. To run the tests for for a specific package:
 
-```
+```shell
 cd packages/store
 pnpm test
 ```
 
 or an specific test in that package:
 
-```
+```shell
 pnpm test test/merge.dist.tags.spec.ts
 ```
 
 or a single test unit:
 
-```
+```shell
 pnpm test test/merge.dist.tags.spec.ts -- -t 'simple'
 ```
 
 Coverage reporting is enabled by default, but you can turn it off to speed up
 test runs:
 
-```
+```shell
 pnpm test test/merge.dist.tags.spec.ts -- -t 'simple' --coverage=false
 ```
 
 You can enable increased [`debug`](https://www.npmjs.com/package/debug) output:
 
-```
+```shell
 DEBUG=verdaccio:* pnpm test
 ```
 
@@ -137,14 +145,14 @@ Currently you can only run pre-compiled packages in debug mode. To enable debug
 while running add the `verdaccio` namespace using the `DEBUG` environment
 variable, like this:
 
-```
+```shell
 DEBUG=verdaccio:* node packages/verdaccio/debug/bootstrap.js
 ```
 
 You can filter this output to just the packages you're interested in using
 namespaces:
 
-```
+```shell
 DEBUG=verdaccio:plugin:* node packages/verdaccio/debug/bootstrap.js
 ```
 
@@ -160,14 +168,14 @@ Once you have perform your changes in the code base, the build and tests passes 
 - Ensure you have build all modules (or the one you have modified)
 - Run `pnpm local:publish:release` to launch a local registry and publish all packages into it. This command will be alive until server is killed (Control Key + C)
 
-```
+```shell
 pnpm build
 pnpm local:publish:release
 ```
 
 The last step consist on install globally the package from the local registry which runs on the default port (4873).
 
-```
+```shell
 npm i -g verdaccio --registry=http://localhost:4873
 verdaccio
 ```
@@ -298,7 +306,7 @@ contribution to get merged (unless it does not affect functionality or
 user-facing content, eg: docs, readme, adding test or typo/lint fixes). To
 create a changeset please run:
 
-```
+```shell
 pnpm changeset
 ```
 

--- a/package.json
+++ b/package.json
@@ -185,5 +185,6 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,yml,yaml,md}": "prettier --write",
     "*.{js,jsx,ts,tsx}": "eslint --cache --fix"
-  }
+  },
+  "packageManager": "pnpm@8.9.0+sha256.8f5264ad1d100da11a6add6bb8a94c6f1e913f9e9261b2a551fabefad2ec0fec"
 }


### PR DESCRIPTION
It appears that `corepack` has deprecated the `prepare` command and recommends the use of `install` command instead. Running `corepack use pnpm@8.9.0` locks the version in the `package.json` file and set the following property:

```json
{
  "packageManager": "pnpm@8.9.0+sha256.8f5264ad1d100da11a6add6bb8a94c6f1e913f9e9261b2a551fabefad2ec0fec"
}
```

Running `corepack install` will then install and configure the correct package manager. I have also updated the documentation to reflect this change.

[Corepack doc](https://nodejs.org/docs/latest-v20.x/api/corepack.html)