### PR TITLE
fix: remove version from website title

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -249,7 +249,7 @@ module.exports = {
       },
     },
     navbar: {
-      title: `Verdaccio - v5.x`,
+      title: `Verdaccio`,
       logo: {
         alt: 'Verdaccio Logo',
         src: 'img/logo/uk/verdaccio-tiny-uk-no-bg.svg',


### PR DESCRIPTION
Version is switched via drop-down so it should not appear hardcoded in the website title anymore.

Before:

![image](https://github.com/verdaccio/verdaccio/assets/59966492/cc7e45d8-5374-421d-a2b5-f575a32ab416)

![image](https://github.com/verdaccio/verdaccio/assets/59966492/e7c06816-df3b-4243-a65a-61288e2467a3)

After:

![image](https://github.com/verdaccio/verdaccio/assets/59966492/f2ee840c-d70a-45ab-a90d-cbd635dc34c3)

![image](https://github.com/verdaccio/verdaccio/assets/59966492/b851c16d-c726-4f78-9ffc-1e5534481099)
