### PR TITLE
docs: fix typos in different areas

### DIFF
--- a/docker-examples/v5/plugins/docker-build-install-plugin/docker.yaml
+++ b/docker-examples/v5/plugins/docker-build-install-plugin/docker.yaml
@@ -88,7 +88,7 @@ packages:
     # and three keywords: "$all", "$anonymous", "$authenticated"
     access: $all
 
-    # allow all known users to publish/publish packages
+    # allow all known users to publish/unpublish packages
     # (anyone can register by default, remember?)
     publish: $authenticated
     unpublish: $authenticated

--- a/docker-examples/v5/plugins/docker-local-plugin/docker.yaml
+++ b/docker-examples/v5/plugins/docker-local-plugin/docker.yaml
@@ -90,7 +90,7 @@ packages:
     # and three keywords: "$all", "$anonymous", "$authenticated"
     access: $all
 
-    # allow all known users to publish/publish packages
+    # allow all known users to publish/unpublish packages
     # (anyone can register by default, remember?)
     publish: $authenticated
     unpublish: $authenticated

--- a/docker-examples/v6/plugins/docker-build-install-plugin/docker.yaml
+++ b/docker-examples/v6/plugins/docker-build-install-plugin/docker.yaml
@@ -88,7 +88,7 @@ packages:
     # and three keywords: "$all", "$anonymous", "$authenticated"
     access: $all
 
-    # allow all known users to publish/publish packages
+    # allow all known users to publish/unpublish packages
     # (anyone can register by default, remember?)
     publish: $authenticated
     unpublish: $authenticated

--- a/docker-examples/v6/plugins/docker-local-plugin/docker.yaml
+++ b/docker-examples/v6/plugins/docker-local-plugin/docker.yaml
@@ -90,7 +90,7 @@ packages:
     # and three keywords: "$all", "$anonymous", "$authenticated"
     access: $all
 
-    # allow all known users to publish/publish packages
+    # allow all known users to publish/unpublish packages
     # (anyone can register by default, remember?)
     publish: $authenticated
     unpublish: $authenticated

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -82,7 +82,7 @@ packages:
     # and three keywords: "$all", "$anonymous", "$authenticated"
     access: $all
 
-    # allow all known users to publish/publish packages
+    # allow all known users to publish/unpublish packages
     # (anyone can register by default, remember?)
     publish: $authenticated
     unpublish: $authenticated

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -86,7 +86,7 @@ packages:
     # and three keywords: "$all", "$anonymous", "$authenticated"
     access: $all
 
-    # Allow all known users to publish/publish packages
+    # Allow all known users to publish/unpublish packages
     # (anyone can register by default, remember?)
     publish: $authenticated
     unpublish: $authenticated

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -252,7 +252,7 @@ user_agent: 'custom user agent'
 
 <small>Since: [verdaccio@5.4.0](https://github.com/verdaccio/verdaccio/releases/tag/v5.4.0)</small>
 
-Add default rate limit to user endpoints, `npm token`, `npm profile`, `npm loding/adduser` and login website to 100 request peer 15 min, customizable via:
+Add default rate limit to user endpoints, `npm token`, `npm profile`, `npm login/adduser` and login website to 100 request peer 15 min, customizable via:
 
 ```
 userRateLimit:

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -25,7 +25,7 @@ module.exports = {
         'third-party',
         {
           type: 'category',
-          label: 'Uses Cases',
+          label: 'Use Cases',
           items: ['caching', 'linking-remote-registry'],
         },
         'articles',

--- a/website/versioned_docs/version-5.x/config.md
+++ b/website/versioned_docs/version-5.x/config.md
@@ -209,7 +209,7 @@ user_agent: 'custom user agent'
 
 <small>Since: [verdaccio@5.4.0](https://github.com/verdaccio/verdaccio/releases/tag/v5.4.0)</small>
 
-Add default rate limit to user endpoints, `npm token`, `npm profile`, `npm loding/adduser` and login website to 100 request peer 15 min, customizable via:
+Add default rate limit to user endpoints, `npm token`, `npm profile`, `npm login/adduser` and login website to 100 request peer 15 min, customizable via:
 
 ```
 userRateLimit:

--- a/website/versioned_docs/version-6.x/config.md
+++ b/website/versioned_docs/version-6.x/config.md
@@ -252,7 +252,7 @@ user_agent: 'custom user agent'
 
 <small>Since: [verdaccio@5.4.0](https://github.com/verdaccio/verdaccio/releases/tag/v5.4.0)</small>
 
-Add default rate limit to user endpoints, `npm token`, `npm profile`, `npm loding/adduser` and login website to 100 request peer 15 min, customizable via:
+Add default rate limit to user endpoints, `npm token`, `npm profile`, `npm login/adduser` and login website to 100 request peer 15 min, customizable via:
 
 ```
 userRateLimit:

--- a/website/versioned_sidebars/version-5.x-sidebars.json
+++ b/website/versioned_sidebars/version-5.x-sidebars.json
@@ -24,7 +24,7 @@
         "logo",
         {
           "type": "category",
-          "label": "Uses Cases",
+          "label": "Use Cases",
           "items": ["caching", "github-actions", "linking-remote-registry"]
         },
         "articles"

--- a/website/versioned_sidebars/version-6.x-sidebars.json
+++ b/website/versioned_sidebars/version-6.x-sidebars.json
@@ -23,7 +23,7 @@
         "third-party",
         {
           "type": "category",
-          "label": "Uses Cases",
+          "label": "Use Cases",
           "items": ["caching", "linking-remote-registry"]
         },
         "articles"


### PR DESCRIPTION
Fixed some typos in config examples, config docs and the website sidebar.

- "Uses cases" → "Use cases"
- "publish/publish" → "publish/unpublish"
- "loding" → "login"