### PR TITLE
Avoid displaying "prettify pipeline error" if there is no error

### DIFF
--- a/.changeset/slow-wasps-glow.md
+++ b/.changeset/slow-wasps-glow.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/logger-prettify': patch
+---
+
+Avoid displaying "prettify pipeline error" if there is no error

--- a/packages/logger/logger-prettify/src/prettify.ts
+++ b/packages/logger/logger-prettify/src/prettify.ts
@@ -110,8 +110,10 @@ export default function (opts) {
     });
 
     pipeline(source, stream, destination, (err) => {
-      // eslint-disable-next-line no-console
-      console.error('prettify pipeline error ', err);
+      if (err) {
+        // eslint-disable-next-line no-console
+        console.error('prettify pipeline error ', err);
+      }
     });
     return stream;
   });


### PR DESCRIPTION
 I noticed this strange "prettify pipeline error undefined" line while using verdaccio in our project (cf [our logs](https://github.com/AmadeusITGroup/AgnosUI/actions/runs/8359565541/job/22883350927#step:21:1007) and [our usage of verdaccio](https://github.com/AmadeusITGroup/AgnosUI/blob/938b178fd2d8063f1e9f0024f10adf733444ad3f/verdaccio/publish.js)). It does not cause any specific error, but, when looking at the logs, I was wondering if there was an error. Note that, as documented [here](https://nodejs.org/docs/latest/api/stream.html#streampipelinesource-transforms-destination-callback) the callback is `called when the pipeline is fully done.` (whether there is an error or not), but I think it is confusing to display `error` when there is no error.
<img width="446" alt="Screenshot 2024-03-22 at 09 37 16" src="https://github.com/verdaccio/verdaccio/assets/558752/f38f3522-6b05-49af-8ae0-04713cb9a5c1">
