### PR TITLE
fix: avoid warning "time for version x already exists"

### DIFF
--- a/.changeset/quick-buses-scream.md
+++ b/.changeset/quick-buses-scream.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/store': patch
+---
+
+fix: avoid warning "time for version x already exists"

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -1063,7 +1063,7 @@ class Storage {
 
       const hasPackageInStorage = await this.hasPackage(name);
       if (!hasPackageInStorage) {
-        await this.createNewLocalCachePackage(name, versionToPublish);
+        await this.createNewLocalCachePackage(name);
         successResponseMessage = API_MESSAGE.PKG_CREATED;
       } else {
         successResponseMessage = API_MESSAGE.PKG_CHANGED;
@@ -1363,7 +1363,7 @@ class Storage {
    * @param name name of the package
    * @returns
    */
-  private async createNewLocalCachePackage(name: string, latestVersion: string): Promise<void> {
+  private async createNewLocalCachePackage(name: string): Promise<void> {
     const storage: pluginUtils.StorageHandler = this.getPrivatePackageStorage(name);
 
     if (!storage) {
@@ -1377,7 +1377,6 @@ class Storage {
       time: {
         created: currentTime,
         modified: currentTime,
-        [latestVersion]: currentTime,
       },
     };
 


### PR DESCRIPTION
The fix avoids setting a timestamp for a version when creating the initial local package. The timestamp is set properly when publishing the version.

Before:

![image](https://github.com/verdaccio/verdaccio/assets/59966492/16587821-10ba-41ec-9042-a4b86415e535)

After:

![image](https://github.com/verdaccio/verdaccio/assets/59966492/64df700d-7dfe-4301-8589-03e6d9f8516c)
