### PR TITLE
fix: adduser error message grammar

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -239,7 +239,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
           password,
           function (err: VerdaccioError | null, ok?: boolean | string): void {
             if (err) {
-              debug('the user %o could not being added. Error: %o', user, err?.message);
+              debug('the user %o could not be added. Error: %o', user, err?.message);
               return cb(err);
             }
             if (ok) {


### PR DESCRIPTION
Just fixing a tiny grammatical error in an error message 🙂 

Thanks a lot for all the work you put into Verdaccio 🙏 