### PR TITLE
fix: error when writing tarball (missing folder)

### DIFF
--- a/.changeset/unlucky-cycles-sparkle.md
+++ b/.changeset/unlucky-cycles-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/local-storage': patch
+---
+
+fix: error when writing tarball (missing folder)

--- a/packages/plugins/local-storage/tests/local-fs.test.ts
+++ b/packages/plugins/local-storage/tests/local-fs.test.ts
@@ -93,6 +93,21 @@ describe('Local FS test', () => {
     });
   });
 
+  describe('writeTarballNextNoFolder', () => {
+    test('should write a tarball even if folder does not exist', (done) => {
+      const abort = new AbortController();
+      const tmp = path.join(localTempStorage, 'local-fs-write-tarball-new-folder');
+      const localFs = new LocalDriver(tmp, logger);
+      const readableStream = Readable.from('foooo');
+      localFs.writeTarball('juan-1.0.0.tgz', { signal: abort.signal }).then((stream) => {
+        stream.on('finish', () => {
+          done();
+        });
+        readableStream.pipe(stream);
+      });
+    });
+  });
+
   describe('readTarballNext', () => {
     test('should read a tarball', (done) => {
       const abort = new AbortController();


### PR DESCRIPTION
This addresses issue https://github.com/openupm/verdaccio-storage-proxy/issues/30 (also a TODO here) which happens if `writeTarball` or `writeTempFileAndRename` are called before the folder is created. 