### PR TITLE
chore: reduce log to info if database is not found

### DIFF
--- a/.changeset/pink-balloons-leave.md
+++ b/.changeset/pink-balloons-leave.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/local-storage': patch
+---
+
+chore: reduce log to info if database is not found

--- a/packages/plugins/local-storage/src/local-database.ts
+++ b/packages/plugins/local-storage/src/local-database.ts
@@ -287,7 +287,7 @@ class LocalDatabase extends pluginUtils.Plugin<{}> implements Storage {
     } catch (err: any) {
       // readFileSync is platform specific, macOS, Linux and Windows thrown an error
       // Only recreate if file not found to prevent data loss
-      this.logger.warn(
+      this.logger.info(
         { path: this.path },
         'no private database found, recreating new one on @{path}'
       );


### PR DESCRIPTION
Test runs create a lot of warnings which makes it harder to find real issues:

![image](https://github.com/verdaccio/verdaccio/assets/59966492/57dc3106-86b6-4bcd-8413-b7a216c25f41)

Creating a new db is expected, so reducing to "info". 