### PR TITLE
chore: limit workflows to verdaccio repo

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -29,10 +29,6 @@ jobs:
       run: |
         mkdir ~/.pnpm-store
         pnpm config set store-dir ~/.pnpm-store
-    - name: set store
-      run: |
-        mkdir ~/.pnpm-store
-        pnpm config set store-dir ~/.pnpm-store            
     - name: Install
       run: pnpm install --registry http://localhost:4873
     - name: Cache .pnpm-store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     name: synchronize translations
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'verdaccio/verdaccio') || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v3
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v3

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,6 +22,7 @@ permissions:
 jobs:
   docker:
     runs-on: ubuntu-latest
+    if: github.repository == 'verdaccio/verdaccio'
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v3
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # tag=v1

--- a/.github/workflows/static-data.yml
+++ b/.github/workflows/static-data.yml
@@ -18,6 +18,7 @@ jobs:
   prepare:
     name: Run script
     runs-on: ubuntu-latest
+    if: github.repository == 'verdaccio/verdaccio'
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v3
         with:

--- a/.github/workflows/ui-components.yml
+++ b/.github/workflows/ui-components.yml
@@ -19,6 +19,7 @@ jobs:
       pull-requests: write  #  to comment on pull-requests
 
     runs-on: ubuntu-latest
+    if: github.repository == 'verdaccio/verdaccio'
     env:
       NODE_OPTIONS: --max_old_space_size=4096
     steps:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -16,6 +16,7 @@ jobs:
       pull-requests: write  #  to comment on pull-requests
 
     runs-on: ubuntu-latest
+    if: github.repository == 'verdaccio/verdaccio'
     name: setup verdaccio
     services:
       verdaccio:


### PR DESCRIPTION
This avoids failing workflows in forks (like [here](https://github.com/mbtools/verdaccio/actions)). 

These workflows are relevant to main verdaccio repo only (and typically require secrets available in main repo). 

Also contain a fix for CI-windows (side effect of https://github.com/verdaccio/verdaccio/pull/3726).

