### PR TITLE
patch(core/url): Throw if VERDACCIO_FORWARDED_PROTO resolves to an array

### DIFF
--- a/.changeset/stupid-dancers-relate.md
+++ b/.changeset/stupid-dancers-relate.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/url': patch
+---
+
+patch(core/url): Throw if VERDACCIO_FORWARDED_PROTO resolves to an array (#4613 by @Tobbe)

--- a/packages/core/url/src/index.ts
+++ b/packages/core/url/src/index.ts
@@ -121,10 +121,17 @@ export function getPublicUrl(url_prefix: string = '', requestOptions: RequestOpt
       throw new Error('invalid host');
     }
 
+    // 'X-Forwarded-Proto' is the default header
     const protoHeader: string =
       process.env.VERDACCIO_FORWARDED_PROTO?.toLocaleLowerCase() ??
       HEADERS.FORWARDED_PROTO.toLowerCase();
-    const forwardedProtocolHeaderValue = requestOptions.headers[protoHeader] as string | undefined;
+    const forwardedProtocolHeaderValue = requestOptions.headers[protoHeader];
+
+    if (Array.isArray(forwardedProtocolHeaderValue)) {
+      // This really should never happen - only set-cookie is allowed to have
+      // multiple values.
+      throw new Error('invalid forwarded protocol header value. Reading header ' + protoHeader);
+    }
 
     const protocol = getWebProtocol(forwardedProtocolHeaderValue, requestOptions.protocol);
     const combinedUrl = combineBaseUrl(protocol, host, url_prefix);

--- a/packages/core/url/tests/getPublicUrl.spec.ts
+++ b/packages/core/url/tests/getPublicUrl.spec.ts
@@ -316,6 +316,31 @@ describe('env variable', () => {
     delete process.env.VERDACCIO_FORWARDED_PROTO;
   });
 
+  test('with the VERDACCIO_FORWARDED_PROTO environment variable set to "set-cookie"', () => {
+    process.env.VERDACCIO_FORWARDED_PROTO = 'set-cookie';
+    const req = httpMocks.createRequest({
+      method: 'GET',
+      headers: {
+        host: 'some.com',
+        cookie: 'name=value; name2=value2;',
+        'set-cookie': [
+          'cookieName1=value; expires=Tue, 19 Jan 2038 03:14:07 GMT;',
+          'cookieName2=value; expires=Tue, 19 Jan 2038 03:14:07 GMT;',
+        ],
+      },
+      url: '/',
+    });
+
+    expect(() =>
+      getPublicUrl('/test/', {
+        host: req.hostname,
+        headers: req.headers as any,
+        protocol: req.protocol,
+      })
+    ).toThrow('invalid forwarded protocol header value. Reading header set-cookie');
+    delete process.env.VERDACCIO_FORWARDED_PROTO;
+  });
+
   test('with a invalid X-Forwarded-Proto https and host injection with invalid host', () => {
     process.env.VERDACCIO_PUBLIC_URL = 'http://injection.test.com"><svg onload="alert(1)">';
     const req = httpMocks.createRequest({


### PR DESCRIPTION
`requestOptions.headers` are of type `IncomingHttpHeaders`. This is a dictionary whose values can be `string | string[] | undefined`. Looking at all the keys we can see that only `"set-cookie?"` allows a value of type `string[]`. 

`requestOptions.headers` is used like this: `requestOptions.headers[protoHeader]`. So only if `protoHeader` has the value `"set-cookie"` can the returned value ever be an array. For all other values it's either going to be `undefined` or a string. So only for `"set-cookie`"  will this code ever potentially throw this new error that is added in this PR.

So. If for some very very weird reason 🙃 some user of Verdaccio has configured `VERDACCIO_FORWARDED_PROTO` to have the value "set-cookie" this is before and after this PR:

Before:
`forwardedProtocolHeaderValue` is an array of strings. This is passed to `getWebProtocol`. That function will in this case return `requestOptions.protocol`, which is the same behavior as if `forwardedProtocolHeaderValue` was undefined or an empty string. (So another option would be to just allow string arrays to be passed to `getWebProtocol`. Would you prefer that?) 

After:
A (hopefully) helpful error is thrown, letting the user know they have most likely misconfigured their setup