### PR TITLE
fix: log spacing depending on the FORMAT and COLORS options

### DIFF
--- a/.changeset/dry-shoes-report.md
+++ b/.changeset/dry-shoes-report.md
@@ -1,4 +1,5 @@
 ---
+'@verdaccio/logger-commons': patch
 '@verdaccio/logger-prettify': patch
 ---
 

--- a/.changeset/dry-shoes-report.md
+++ b/.changeset/dry-shoes-report.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/logger-prettify': patch
+---
+
+fix: log spacing depending on the FORMAT and COLORS options

--- a/packages/logger/logger-commons/test/logger.spec.ts
+++ b/packages/logger/logger-commons/test/logger.spec.ts
@@ -36,7 +36,7 @@ describe('logger test', () => {
       logger.trace(`this should not be logged`);
       logger.error(`this should logged`);
       const content = await readLogFile(file);
-      expect(content).toBe('info --- testing test \nerror--- this should logged \n');
+      expect(content).toBe('info --- testing test\nerror--- this should logged\n');
     });
 
     test('should include all logging level', async () => {
@@ -51,7 +51,7 @@ describe('logger test', () => {
       logger.error(`this should logged`);
       const content = await readLogFile(file);
       expect(content).toBe(
-        'info --- testing test \ndebug--- this should not be logged \ntrace--- this should not be logged \nerror--- this should logged \n'
+        'info --- testing test\ndebug--- this should not be logged\ntrace--- this should not be logged\nerror--- this should logged\n'
       );
     });
   });
@@ -101,7 +101,7 @@ describe('logger test', () => {
         `publishing or updating a new version for @{packageName}`
       );
       const content = await readLogFile(file);
-      expect(content).toEqual('info --- publishing or updating a new version for test \n');
+      expect(content).toEqual('info --- publishing or updating a new version for test\n');
     });
 
     test('should log into a file with pretty-timestamped', async () => {
@@ -122,7 +122,7 @@ describe('logger test', () => {
       );
       const content = await readLogFile(file);
       // TODO: we might want mock time for testing
-      expect(content).toMatch('info --- publishing or updating a new version for test \n');
+      expect(content).toMatch('info --- publishing or updating a new version for test\n');
     });
   });
 });

--- a/packages/logger/logger-prettify/src/formatter.ts
+++ b/packages/logger/logger-prettify/src/formatter.ts
@@ -68,11 +68,11 @@ function getMessage(debugLevel, msg, sub, templateObjects, hasColors: boolean) {
       `${subSystemType} ${finalMessage}`
     )}`;
 
-    return padLeft(logString);
+    return logString;
   }
   const logString = `${padRight(debugLevel, LEVEL_VALUE_MAX)}${subSystemType} ${finalMessage}`;
 
-  return padRight(logString);
+  return logString;
 }
 
 export function printMessage(

--- a/packages/logger/logger-prettify/src/formatter.ts
+++ b/packages/logger/logger-prettify/src/formatter.ts
@@ -3,7 +3,7 @@ import { inspect } from 'util';
 
 import { LevelCode, calculateLevel, levelsColors, subSystemLevels } from './levels';
 import { PrettyOptionsExtended } from './types';
-import { formatLoggingDate, isObject, padLeft, padRight } from './utils';
+import { formatLoggingDate, isObject, padRight } from './utils';
 
 let LEVEL_VALUE_MAX = 0;
 for (const l in levelsColors) {

--- a/packages/logger/logger-prettify/src/utils.ts
+++ b/packages/logger/logger-prettify/src/utils.ts
@@ -8,10 +8,6 @@ export function isObject(obj: unknown): boolean {
   return _.isObject(obj) && _.isNull(obj) === false && _.isArray(obj) === false;
 }
 
-export function padLeft(message: string) {
-  return message.padStart(message.length + CUSTOM_PAD_LENGTH, ' ');
-}
-
 export function padRight(message: string, max = message.length + CUSTOM_PAD_LENGTH) {
   return message.padEnd(max, ' ');
 }

--- a/packages/logger/logger-prettify/src/utils.ts
+++ b/packages/logger/logger-prettify/src/utils.ts
@@ -19,5 +19,5 @@ export function padRight(message: string, max = message.length + CUSTOM_PAD_LENG
 export function formatLoggingDate(time: number, message: string): string {
   const timeFormatted = dayjs(time).format(FORMAT_DATE);
 
-  return `[${timeFormatted}]${message}`;
+  return `[${timeFormatted}] ${message}`;
 }

--- a/packages/logger/logger-prettify/test/__snapshots__/formatter.spec.ts.snap
+++ b/packages/logger/logger-prettify/test/__snapshots__/formatter.spec.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`formatter printMessage should display a bytes request 1`] = `"fatal<-- 200, user: null(127.0.0.1), req: 'GET /verdaccio', bytes: 0/150186 "`;
+exports[`formatter printMessage should display a bytes request 1`] = `"fatal<-- 200, user: null(127.0.0.1), req: 'GET /verdaccio', bytes: 0/150186"`;
 
-exports[`formatter printMessage should display a resource request 1`] = `"info <-- 127.0.0.1 requested 'GET /verdaccio' "`;
+exports[`formatter printMessage should display a resource request 1`] = `"info <-- 127.0.0.1 requested 'GET /verdaccio'"`;
 
-exports[`formatter printMessage should display a streaming request 1`] = `"fatal--> 304, req: 'GET https://registry.npmjs.org/verdaccio' (streaming) "`;
+exports[`formatter printMessage should display a streaming request 1`] = `"fatal--> 304, req: 'GET https://registry.npmjs.org/verdaccio' (streaming)"`;
 
-exports[`formatter printMessage should display an error request 1`] = `"fatal--> ERR, req: 'GET https://registry.fake.org/aaa', error: getaddrinfo ENOTFOUND registry.fake.org "`;
+exports[`formatter printMessage should display an error request 1`] = `"fatal--> ERR, req: 'GET https://registry.fake.org/aaa', error: getaddrinfo ENOTFOUND registry.fake.org"`;
 
-exports[`formatter printMessage should display an fatal request 1`] = `"fatal--> ERR, req: 'GET https://registry.fake.org/aaa', error: fatal error "`;
+exports[`formatter printMessage should display an fatal request 1`] = `"fatal--> ERR, req: 'GET https://registry.fake.org/aaa', error: fatal error"`;
 
-exports[`formatter printMessage should display config file 1`] = `"warn --- config file  - /Users/user/.config/verdaccio/config/config.yaml "`;
+exports[`formatter printMessage should display config file 1`] = `"warn --- config file  - /Users/user/.config/verdaccio/config/config.yaml"`;
 
-exports[`formatter printMessage should display custom log message 1`] = `"fatal--- custom - foo - undefined "`;
+exports[`formatter printMessage should display custom log message 1`] = `"fatal--- custom - foo - undefined"`;
 
-exports[`formatter printMessage should display trace level 1`] = `"trace--- [trace]  - foo "`;
+exports[`formatter printMessage should display trace level 1`] = `"trace--- [trace]  - foo"`;
 
-exports[`formatter printMessage should display trace level with pretty stamp 1`] = `"[formatted-date]trace--- [trace]  - foo "`;
+exports[`formatter printMessage should display trace level with pretty stamp 1`] = `"[formatted-date] trace--- [trace]  - foo"`;
 
-exports[`formatter printMessage should display version and http address 1`] = `"warn --- http address - http://localhost:4873/ - verdaccio/5.0.0 "`;
+exports[`formatter printMessage should display version and http address 1`] = `"warn --- http address - http://localhost:4873/ - verdaccio/5.0.0"`;

--- a/packages/logger/logger-prettify/test/index.spec.ts
+++ b/packages/logger/logger-prettify/test/index.spec.ts
@@ -17,7 +17,7 @@ describe('prettyFactory', () => {
         objectMode: true,
         write(chunk, enc, cb) {
           const formatted = pretty(JSON.parse(chunk));
-          expect(formatted).toBe('info --- test message ');
+          expect(formatted).toBe('info --- test message');
           cb();
           done();
         },

--- a/packages/logger/logger-prettify/test/utils.test.ts
+++ b/packages/logger/logger-prettify/test/utils.test.ts
@@ -1,8 +1,8 @@
-import { formatLoggingDate, padLeft, padRight } from '../src/utils';
+import { formatLoggingDate, padRight } from '../src/utils';
 
 describe('formatLoggingDate', () => {
   test('basic', () => {
-    expect(formatLoggingDate(1585411248203, ' message')).toEqual('[2020-03-28 16:00:48] message');
+    expect(formatLoggingDate(1585411248203, 'message')).toEqual('[2020-03-28 16:00:48] message');
   });
 });
 
@@ -13,8 +13,5 @@ describe('pad', () => {
 
   test('pad right 2', () => {
     expect(padRight('message right')).toEqual('message right ');
-  });
-  test('pad left', () => {
-    expect(padLeft('message left')).toEqual(' message left');
   });
 });


### PR DESCRIPTION
fixes: #4630

Previously, when colors were enabled, the log message always had a single space padded to the left, otherwise a single space was always padded to the right. This padding of the full log message seemed to be entirely unnecessary. Also, there was no explicit space set to appear between the timestamp and the log message, although when colors were enabled, the padding mentioned above would include a space, but only in that case.

Now, there's always a space between the timestamp and the log message, and there are no unnecessary spaces inserted at the beginning or end of the log message.  I tested locally with all four combinations of `format: pretty`, `format: pretty-timestamped`, `colors: false`, and `colors: true`, and I believe the spacing now appears correct.

`format: pretty` with `colors: false` or `colors: true`:

> ```
> info --- config file  - /var/lib/verdaccio/.config/verdaccio/config.yaml
> info --- using htpasswd file: /var/lib/verdaccio/.config/verdaccio/htpasswd
> info --- plugin successfully loaded: verdaccio-htpasswd
> info --- plugin successfully loaded: verdaccio-audit
> warn --- http address - http://127.0.0.1:4873/ - verdaccio/5.30.3
> ```

`format: pretty-timestamped` with `colors: false` or `colors: true`:

> ```
> [2024-05-07 05:47:46] info --- config file  - /var/lib/verdaccio/.config/verdaccio/config.yaml
> [2024-05-07 05:47:46] info --- using htpasswd file: /var/lib/verdaccio/.config/verdaccio/htpasswd
> [2024-05-07 05:47:46] info --- plugin successfully loaded: verdaccio-htpasswd
> [2024-05-07 05:47:46] info --- plugin successfully loaded: verdaccio-audit
> [2024-05-07 05:47:46] warn --- http address - http://127.0.0.1:4873/ - verdaccio/5.30.3
> ```
