### PR TITLE
Increase size limit to 60mb, fixing `request entity too large`

### DIFF
--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -42,6 +42,7 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<an
   }
   app.use(cors());
   app.use(rateLimit(config.serverSettings.rateLimit));
+  app.use(express.json({ limit: 60 * 1024 * 1024 }));
 
   const errorReportingMiddlewareWrap = errorReportingMiddleware(logger);
 


### PR DESCRIPTION
I ran into an issue where the package I wanted to publish was >60mb.
Verdaccio refused it with this error:
```
http <-- 413, user: user(::ffff:127.0.0.1), req: 'PUT /@storybook%2fcore', error: request entity too large
http <-- 413, user: user(::ffff:127.0.0.1), req: 'PUT /@storybook%2fcore', error: request entity too large
```

...After some digging I found here:
https://expressjs.com/en/5x/api.html#express.json
...that I could increase the size limit using the code I contributed in this PR.

I'm not sure is this number should be fixed (it solved my personal issue).
Likely it should be configurable.

Also reported on discord:
https://discord.com/channels/388674437219745793/388675051710447616/1248656948044365854

Here's the problem occurring on the storybook CI:
https://app.circleci.com/pipelines/github/storybookjs/storybook/77731/workflows/30368aed-2696-41ea-aa2b-d0781abdf0d1/jobs/665740

I've verified this change fixes my problem by manually editing the dist files in `node_modules`.