### PR TITLE
Add OpenUPM to Verdaccio use cases

### DIFF
--- a/website/docs/who-is-using.md
+++ b/website/docs/who-is-using.md
@@ -28,6 +28,7 @@ _If you are using Verdaccio in your business and want to share your experience, 
 - [Hyperledger Caliper](https://github.com/hyperledger/caliper)
 - [secco](https://secco.lekoarts.de)
 - [Nx](https://nx.dev/)
+- [OpenUPM](https://openupm.com/docs/)
 
 #### Readme Recommendations {#readme-recommendations}
 


### PR DESCRIPTION
[OpenUPM](https://openupm.com) is a fascinating use case of Verdaccio for something completely unrelated to node or npm: A public website and repository for [Unity](https://unity.com) packages which is interactive, real-time 3D content.