### PR TITLE
fix: update fields for abbreviated manifest

### DIFF
--- a/.changeset/rich-shrimps-check.md
+++ b/.changeset/rich-shrimps-check.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/types': patch
+'@verdaccio/store': patch
+---
+
+fix: update fields for abbreviated manifest

--- a/packages/core/types/src/manifest.ts
+++ b/packages/core/types/src/manifest.ts
@@ -124,6 +124,7 @@ export interface Version {
   optionalDependencies?: Dependencies;
   peerDependenciesMeta?: PeerDependenciesMeta;
   bundleDependencies?: Dependencies;
+  acceptDependencies?: Dependencies;
   keywords?: string | string[];
   nodeVersion?: string;
   _id: string;
@@ -179,6 +180,7 @@ export interface FullRemoteManifest {
   time: GenericBody;
   versions: Versions;
   maintainers?: Author[];
+  contributors?: Author[];
   /** store the latest readme **/
   readme?: string;
   /** store star assigned to this packages by users */
@@ -223,7 +225,6 @@ export type AbbreviatedVersion = Pick<
   Version,
   | 'name'
   | 'version'
-  | 'description'
   | 'dependencies'
   | 'devDependencies'
   | 'bin'
@@ -231,6 +232,15 @@ export type AbbreviatedVersion = Pick<
   | 'engines'
   | 'funding'
   | 'peerDependencies'
+  | 'cpu'
+  | 'deprecated'
+  | 'directories'
+  | 'hasInstallScript'
+  | 'optionalDependencies'
+  | 'os'
+  | 'peerDependenciesMeta'
+  | 'acceptDependencies'
+  | '_hasShrinkwrap'
 >;
 
 export interface AbbreviatedVersions {

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -502,7 +502,6 @@ class Storage {
         const _version_abbreviated = {
           name: _version.name,
           version: _version.version,
-          description: _version.description,
           deprecated: _version.deprecated,
           bin: _version.bin,
           dist: _version.dist,
@@ -514,6 +513,10 @@ class Storage {
           peerDependencies: _version.peerDependencies,
           optionalDependencies: _version.optionalDependencies,
           bundleDependencies: _version.bundleDependencies,
+          cpu: _version.cpu,
+          os: _version.os,
+          peerDependenciesMeta: _version.peerDependenciesMeta,
+          acceptDependencies: _version.acceptDependencies,
           // npm cli specifics
           _hasShrinkwrap: _version._hasShrinkwrap,
           hasInstallScript: _version.hasInstallScript,

--- a/packages/store/test/storage.spec.ts
+++ b/packages/store/test/storage.spec.ts
@@ -1592,7 +1592,6 @@ describe('storage', () => {
         expect(Object.keys(version)).toEqual([
           'name',
           'version',
-          'description',
           'deprecated',
           'bin',
           'dist',
@@ -1604,6 +1603,10 @@ describe('storage', () => {
           'peerDependencies',
           'optionalDependencies',
           'bundleDependencies',
+          'cpu',
+          'os',
+          'peerDependenciesMeta',
+          'acceptDependencies',
           '_hasShrinkwrap',
           'hasInstallScript',
         ]);


### PR DESCRIPTION
After comparing to [npm docs](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md#abbreviated-version-object) and running tests comparing npm fetches to Verdaccio, I found some fields missing in the abbreviated manifest format like `cpu` and `os`. Also `description` is included but should not be since it's not relevant for package installation. 



