### PR TITLE
chore: add config location and loglevel to startup log

### DIFF
--- a/.changeset/chilly-rivers-chew.md
+++ b/.changeset/chilly-rivers-chew.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/cli': patch
+---
+
+chore: add config location and loglevel to startup log

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -58,6 +58,8 @@ export class InitCommand extends Command {
       const configPathLocation = findConfigFile(this.config as string);
       const configParsed = parseConfigFile(configPathLocation);
       this.initLogger(configParsed);
+      logger.info({ file: configPathLocation }, 'using config file: @{file}');
+      logger.info('log level: %s', configParsed.log?.level || 'default');
       const { web } = configParsed;
 
       process.title = web?.title || DEFAULT_PROCESS_NAME;


### PR DESCRIPTION
Showing some more useful infos during startup:

![image](https://github.com/verdaccio/verdaccio/assets/59966492/5c83f024-bc56-4b29-8a52-a04db19464fe)
