### PR TITLE
fix: Dockerfile warning FromAsCasing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:21-alpine as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:21-alpine AS builder
 
 ENV NODE_ENV=development \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org

--- a/docker-examples/v5/plugins/docker-local-plugin/Dockerfile
+++ b/docker-examples/v5/plugins/docker-local-plugin/Dockerfile
@@ -1,7 +1,7 @@
 # Docs based on https://github.com/xlts-dev/verdaccio-prometheus-middleware#installation
 # Docker multi-stage build - https://docs.docker.com/develop/develop-images/multistage-build/
 # Use an alpine node image to install the plugin
-FROM node:lts-alpine as builder
+FROM node:lts-alpine AS builder
 
 RUN mkdir -p /verdaccio/plugins
 

--- a/docker-examples/v6/plugins/docker-build-install-plugin/Dockerfile
+++ b/docker-examples/v6/plugins/docker-build-install-plugin/Dockerfile
@@ -2,7 +2,7 @@
 
 # Docker multi-stage build - https://docs.docker.com/develop/develop-images/multistage-build/
 # Use an alpine node image to install the plugin
-FROM node:lts-alpine as builder
+FROM node:lts-alpine AS builder
 
 # Install the metrics middleware plugin
 # npm docs

--- a/docker-examples/v6/plugins/docker-local-plugin/Dockerfile
+++ b/docker-examples/v6/plugins/docker-local-plugin/Dockerfile
@@ -1,7 +1,7 @@
 # Docs based on https://github.com/xlts-dev/verdaccio-prometheus-middleware#installation
 # Docker multi-stage build - https://docs.docker.com/develop/develop-images/multistage-build/
 # Use an alpine node image to install the plugin
-FROM node:lts-alpine as builder
+FROM node:lts-alpine AS builder
 
 RUN mkdir -p /verdaccio/plugins
 


### PR DESCRIPTION
Recent versions of Docker raise the following warning:

```
 2 warnings found (use --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 3)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 19)
```

Solution: Change the `as` keyword to be in uppercase `AS`

