### PR TITLE
feat: verdaccio-audit support timeout option

### DIFF
--- a/.changeset/many-bees-tickle.md
+++ b/.changeset/many-bees-tickle.md
@@ -1,0 +1,5 @@
+---
+'verdaccio-audit': minor
+---
+
+feat: verdaccio-audit support timeout option

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -187,6 +187,7 @@ server:
 middlewares:
   audit:
     enabled: true
+    # timeout: 10000
 
 # https://verdaccio.org/docs/logger
 # log settings

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -193,6 +193,7 @@ server:
 middlewares:
   audit:
     enabled: true
+    # timeout: 10000
 
 # https://verdaccio.org/docs/logger
 # log settings

--- a/packages/plugins/audit/README.md
+++ b/packages/plugins/audit/README.md
@@ -26,6 +26,7 @@ middlewares:
   audit:
     enabled: true
     strict_ssl: true # optional, defaults to true
+    timeout: 1000
 ```
 
 ### Strict SSL

--- a/packages/plugins/audit/src/audit.ts
+++ b/packages/plugins/audit/src/audit.ts
@@ -61,7 +61,10 @@ export default class ProxyAudit
 
         const controller = new AbortController();
 
-        setTimeout(() => controller.abort(`Fetch ${auditEndpoint} timeout ${this.timeout}ms`), this.timeout);
+        setTimeout(
+          () => controller.abort(`Fetch ${auditEndpoint} timeout ${this.timeout}ms`),
+          this.timeout
+        );
 
         const response = await fetch(auditEndpoint, {
           ...requestOptions,

--- a/packages/plugins/audit/src/audit.ts
+++ b/packages/plugins/audit/src/audit.ts
@@ -19,11 +19,13 @@ export default class ProxyAudit
   public enabled: boolean;
   public logger: Logger;
   public strict_ssl: boolean;
+  public timeout: number;
 
   public constructor(config: ConfigAudit, options: pluginUtils.PluginOptions) {
     super(config, options);
     this.enabled = config.enabled || false;
     this.strict_ssl = config.strict_ssl !== undefined ? config.strict_ssl : true;
+    this.timeout = config.timeout ?? 1000 * 60 * 1;
     this.logger = options.logger;
   }
 
@@ -57,7 +59,14 @@ export default class ProxyAudit
         const auditEndpoint = `${REGISTRY_DOMAIN}${req.baseUrl}${req.route.path}`;
         this.logger.debug('fetching audit from ' + auditEndpoint);
 
-        const response = await fetch(auditEndpoint, requestOptions);
+        const controller = new AbortController();
+
+        setTimeout(() => controller.abort(`Fetch ${auditEndpoint} timeout ${this.timeout}ms`), this.timeout);
+
+        const response = await fetch(auditEndpoint, {
+          ...requestOptions,
+          signal: controller.signal,
+        });
 
         if (response.ok) {
           res.status(response.status).send(await response.json());

--- a/packages/plugins/audit/src/types.ts
+++ b/packages/plugins/audit/src/types.ts
@@ -2,4 +2,5 @@ export interface ConfigAudit {
   enabled: boolean;
   max_body?: string;
   strict_ssl?: boolean;
+  timeout?: number;
 }

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -364,6 +364,7 @@ a built-in middleware plugin to handle this command.
 middlewares:
   audit:
     enabled: true
+    # timeout: 10000
 ```
 
 ### Experiments {#experiments}

--- a/website/versioned_docs/version-5.x/config.md
+++ b/website/versioned_docs/version-5.x/config.md
@@ -387,6 +387,7 @@ a built-in middleware plugin to handle this command.
 middlewares:
   audit:
     enabled: true
+    # timeout: 10000
 ```
 
 ### Experiments {#experiments}


### PR DESCRIPTION
For exec `npm install` hangs. #2335