### PR TITLE
fix: typo in config docs regarding check_owners

### DIFF
--- a/.changeset/thin-snails-flow.md
+++ b/.changeset/thin-snails-flow.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/config': patch
+'@verdaccio/website': patch
+---
+
+fix: typo in config docs regarding check_owners

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -120,7 +120,7 @@ server:
 # https://verdaccio.org/docs/configuration#offline-publish
 # publish:
 #   allow_offline: false
-#   check_owner: false
+#   check_owners: false
 
 # https://verdaccio.org/docs/configuration#url-prefix
 # url_prefix: /verdaccio/

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -126,7 +126,7 @@ server:
 # https://verdaccio.org/docs/configuration#offline-publish
 # publish:
 #   allow_offline: false
-#   check_owner: false
+#   check_owners: false
 
 # https://verdaccio.org/docs/configuration#url-prefix
 # url_prefix: /verdaccio/

--- a/website/docs/config.md
+++ b/website/docs/config.md
@@ -194,11 +194,11 @@ publish:
 
 ### Checking Package Ownership {#chec-owner}
 
-By default, [package access](packages.md) defines who is allowed to publish and unpublish packages. By setting `check_owner` to _true_, only package owners are allowed to make changes to a package. The first owner of a package is the user who published the first version. Further owners can be added or removed using [`npm owner`](https://docs.npmjs.com/cli/v10/commands/npm-owner). You can find the list of current owners in the package manifest under `maintainers`.
+By default, [package access](packages.md) defines who is allowed to publish and unpublish packages. By setting `check_owners` to _true_, only package owners are allowed to make changes to a package. The first owner of a package is the user who published the first version. Further owners can be added or removed using [`npm owner`](https://docs.npmjs.com/cli/v10/commands/npm-owner). You can find the list of current owners using `npm owner list` or by checking the package manifest under `maintainers`.
 
 ```yaml
 publish:
-  check_owner: false
+  check_owners: false
 ```
 
 <small>Since: `verdaccio@2.3.6` due [#223](https://github.com/verdaccio/verdaccio/pull/223)</small>


### PR DESCRIPTION
The option is called `check_owners` (since there could be several maintainers). Code was correct but the docs were missing the 's'. 