### PR TITLE
docs: update logger level precedence stated in docs

### DIFF
--- a/website/docs/logger.md
+++ b/website/docs/logger.md
@@ -35,5 +35,5 @@ Note: Rotating log stream is not supported in cluster mode. [See here](https://g
 | type     | string  | No       | [stdout, file]                                 | all     | define the output                                 |
 | path     | string  | No       | verdaccio.log                                  | all     | if type is file, define the location of that file |
 | format   | string  | No       | [pretty, pretty-timestamped]                   | all     | output format                                     |
-| level    | string  | No       | [fatal, error, warn, http, info, debug, trace] | all     | verbose level                                     |
+| level    | string  | No       | [fatal, error, warn, info, http, debug, trace] | all     | verbose level                                     |
 | colors   | boolean | No       | false                                          | v5.7.0  | disable or enable colors                          |

--- a/website/versioned_docs/version-5.x/logger.md
+++ b/website/versioned_docs/version-5.x/logger.md
@@ -35,5 +35,5 @@ Note: Rotating log stream is not supported in cluster mode. [See here](https://g
 | type     | string  | No       | [stdout, file]                                 | all     | define the output                                 |
 | path     | string  | No       | verdaccio.log                                  | all     | if type is file, define the location of that file |
 | format   | string  | No       | [pretty, pretty-timestamped]                   | all     | output format                                     |
-| level    | string  | No       | [fatal, error, warn, http, info, debug, trace] | all     | verbose level                                     |
+| level    | string  | No       | [fatal, error, warn, info, http, debug, trace] | all     | verbose level                                     |
 | colors   | boolean | No       | false                                          | v5.7.0  | disable or enable colors                          |

--- a/website/versioned_docs/version-6.x/logger.md
+++ b/website/versioned_docs/version-6.x/logger.md
@@ -35,5 +35,5 @@ Note: Rotating log stream is not supported in cluster mode. [See here](https://g
 | type     | string  | No       | [stdout, file]                                 | all     | define the output                                 |
 | path     | string  | No       | verdaccio.log                                  | all     | if type is file, define the location of that file |
 | format   | string  | No       | [pretty, pretty-timestamped]                   | all     | output format                                     |
-| level    | string  | No       | [fatal, error, warn, http, info, debug, trace] | all     | verbose level                                     |
+| level    | string  | No       | [fatal, error, warn, info, http, debug, trace] | all     | verbose level                                     |
 | colors   | boolean | No       | false                                          | v5.7.0  | disable or enable colors                          |


### PR DESCRIPTION
docs: update logger level precedence stated in docs, moving http between `info` and `debug`

Fixes #4654