### PR TITLE
chore: improve startup logging

### DIFF
--- a/.changeset/thick-avocados-provide.md
+++ b/.changeset/thick-avocados-provide.md
@@ -1,0 +1,13 @@
+---
+'@verdaccio/local-storage': patch
+'@verdaccio/server': patch
+'@verdaccio/core': patch
+'@verdaccio/node-api': patch
+'@verdaccio/loaders': patch
+'@verdaccio/store': patch
+'@verdaccio/auth': patch
+'@verdaccio/cli': patch
+'@verdaccio/web': patch
+---
+
+chore: improve startup logging

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -5,6 +5,7 @@ import { HTPasswd } from 'verdaccio-htpasswd';
 import { createAnonymousRemoteUser, createRemoteUser } from '@verdaccio/config';
 import {
   API_ERROR,
+  PLUGIN_CATEGORY,
   SUPPORT_ERRORS,
   TOKEN_BASIC,
   TOKEN_BEARER,
@@ -116,7 +117,8 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
           typeof allow_publish !== 'undefined'
         );
       },
-      this.config?.serverSettings?.pluginPrefix
+      this.config?.serverSettings?.pluginPrefix,
+      PLUGIN_CATEGORY.AUTHENTICATION
     );
   }
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -59,7 +59,6 @@ export class InitCommand extends Command {
       const configParsed = parseConfigFile(configPathLocation);
       this.initLogger(configParsed);
       logger.info({ file: configPathLocation }, 'using config file: @{file}');
-      logger.info('log level: %s', configParsed.log?.level || 'default');
       const { web } = configParsed;
 
       process.title = web?.title || DEFAULT_PROCESS_NAME;
@@ -67,6 +66,9 @@ export class InitCommand extends Command {
       const { version, name } = require('../../package.json');
 
       await initServer(configParsed, this.port as string, version, name);
+
+      const logLevel = configParsed.log?.level || 'default';
+      logger.info({ logLevel }, 'log level: @{logLevel}');
       logger.info('server started');
     } catch (err: any) {
       console.error(err);

--- a/packages/core/core/src/constants.ts
+++ b/packages/core/core/src/constants.ts
@@ -119,3 +119,11 @@ export enum HtpasswdHashAlgorithm {
   crypt = 'crypt',
   bcrypt = 'bcrypt',
 }
+
+export const PLUGIN_CATEGORY = {
+  AUTHENTICATION: 'authentication',
+  MIDDLEWARE: 'middleware',
+  STORAGE: 'storage',
+  FILTER: 'filter',
+  THEME: 'theme',
+};

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -24,6 +24,7 @@ export {
   DEFAULT_USER,
   USERS,
   MAINTAINERS,
+  PLUGIN_CATEGORY,
   HtpasswdHashAlgorithm,
 } from './constants';
 const validationUtils = validatioUtils;

--- a/packages/loaders/src/plugin-async-loader.ts
+++ b/packages/loaders/src/plugin-async-loader.ts
@@ -50,7 +50,8 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
   pluginConfigs: any = {},
   params: Params,
   sanityCheck: (plugin: PluginType<T>) => boolean,
-  prefix: string = 'verdaccio'
+  prefix: string = 'verdaccio',
+  pluginCategory: string = ''
 ): Promise<PluginType<T>[]> {
   const pluginsIds = Object.keys(pluginConfigs);
   const { config } = params;
@@ -75,7 +76,7 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
       }
 
       logger.debug({ path: pluginsPath }, 'plugins folder defined, loading plugins from @{path} ');
-      // throws if is nto a directory
+      // throws if is not a directory
       try {
         await isDirectory(pluginsPath);
         const pluginDir = pluginsPath;
@@ -93,6 +94,10 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
             continue;
           }
           plugins.push(plugin);
+          logger.info(
+            { prefix, pluginId, pluginCategory },
+            'plugin @{prefix}-@{pluginId} successfully loaded (@{pluginCategory})'
+          );
           continue;
         }
       } catch (err: any) {
@@ -118,6 +123,10 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
           continue;
         }
         plugins.push(plugin);
+        logger.info(
+          { prefix, pluginId, pluginCategory },
+          'plugin @{prefix}-@{pluginId} successfully loaded (@{pluginCategory})'
+        );
         continue;
       } else {
         logger.error(

--- a/packages/node-api/src/server.ts
+++ b/packages/node-api/src/server.ts
@@ -78,6 +78,20 @@ export function createServerFactory(config: ConfigYaml, addr, app) {
     serverFactory = http.createServer(app);
   }
 
+  // List of all routes registered in the app
+  function printRoutes(layer) {
+    if (layer.route) {
+      debug('%s (%s)', layer.route.path, Object.keys(layer.route.methods).join(', '));
+    } else if (layer.name === 'router') {
+      layer.handle.stack.forEach((nestedLayer) => {
+        printRoutes(nestedLayer);
+      });
+    }
+  }
+
+  debug('registered routes:');
+  app._router.stack.forEach(printRoutes);
+
   if (
     config.server &&
     typeof config.server.keepAliveTimeout !== 'undefined' &&
@@ -146,8 +160,8 @@ export async function initServer(
                   pathname: '/',
                 })
           }`;
-          logger.info(`http address ${addressServer}`);
-          logger.info(`version: ${version}`);
+          logger.info({ addressServer }, 'http address: @{addressServer}');
+          logger.info({ version }, 'version: @{version}');
           resolve();
         })
         .on('error', function (err): void {

--- a/packages/plugins/local-storage/src/local-database.ts
+++ b/packages/plugins/local-storage/src/local-database.ts
@@ -46,7 +46,7 @@ class LocalDatabase extends pluginUtils.Plugin<{}> implements Storage {
     debug('config path %o', config.configPath);
     this.path = _dbGenPath(DB_NAME, config);
     this.storages = this._getCustomPackageLocalStorages();
-    this.logger.info({ path: this.path }, 'local storage path @{path}');
+    this.logger.info({ path: this.path }, 'local storage path: @{path}');
     debug('plugin storage path %o', this.path);
   }
 

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -8,7 +8,7 @@ import AuditMiddleware from 'verdaccio-audit';
 import apiEndpoint from '@verdaccio/api';
 import { Auth } from '@verdaccio/auth';
 import { Config as AppConfig } from '@verdaccio/config';
-import { API_ERROR, errorUtils, pluginUtils } from '@verdaccio/core';
+import { API_ERROR, PLUGIN_CATEGORY, errorUtils, pluginUtils } from '@verdaccio/core';
 import { asyncLoadPlugin } from '@verdaccio/loaders';
 import { logger } from '@verdaccio/logger';
 import {
@@ -72,7 +72,9 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<an
     },
     function (plugin) {
       return typeof plugin.register_middlewares !== 'undefined';
-    }
+    },
+    config?.serverSettings?.pluginPrefix ?? 'verdaccio',
+    PLUGIN_CATEGORY.MIDDLEWARE
   );
 
   if (plugins.length === 0) {

--- a/packages/store/src/local-storage.ts
+++ b/packages/store/src/local-storage.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import buildDebug from 'debug';
 import _ from 'lodash';
 
-import { errorUtils, pluginUtils } from '@verdaccio/core';
+import { PLUGIN_CATEGORY, errorUtils, pluginUtils } from '@verdaccio/core';
 import { asyncLoadPlugin } from '@verdaccio/loaders';
 import LocalDatabase from '@verdaccio/local-storage';
 import { Config, Logger } from '@verdaccio/types';
@@ -75,7 +75,8 @@ class LocalStorage {
       (plugin) => {
         return typeof plugin.getPackageStorage !== 'undefined';
       },
-      this.config?.serverSettings?.pluginPrefix
+      this.config?.serverSettings?.pluginPrefix,
+      PLUGIN_CATEGORY.STORAGE
     );
 
     if (plugins.length > 1) {

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -15,6 +15,7 @@ import {
   HEADER_TYPE,
   HTTP_STATUS,
   MAINTAINERS,
+  PLUGIN_CATEGORY,
   SUPPORT_ERRORS,
   USERS,
   errorUtils,
@@ -664,7 +665,8 @@ class Storage {
         (plugin: pluginUtils.ManifestFilter<Config>) => {
           return typeof plugin.filter_metadata !== 'undefined';
         },
-        this.config?.serverSettings?.pluginPrefix
+        this.config?.serverSettings?.pluginPrefix,
+        PLUGIN_CATEGORY.FILTER
       );
       debug('filters available %o', this.filters.length);
     }

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import _ from 'lodash';
 
+import { PLUGIN_CATEGORY } from '@verdaccio/core';
 import { asyncLoadPlugin } from '@verdaccio/loaders';
 import { logger } from '@verdaccio/logger';
 import { webMiddleware } from '@verdaccio/middleware';
@@ -22,7 +23,8 @@ export async function loadTheme(config: any) {
          */
         return plugin.staticPath && plugin.manifest && plugin.manifestFiles;
       },
-      config?.serverSettings?.pluginPrefix ?? 'verdaccio-theme'
+      config?.serverSettings?.pluginPrefix ?? 'verdaccio-theme',
+      PLUGIN_CATEGORY.THEME
     );
     if (plugin.length > 1) {
       logger.warn('multiple ui themes are not supported , only the first plugin is used used');


### PR DESCRIPTION
- added list of successfully loaded plugins with plugin category
- a few cosmetic changes to the output
- allow middleware plugins to use plugin prefix (like the other categories)
- added list of registered routes to debug output for "verdaccio:node-api"

Example startup log:

![image](https://github.com/user-attachments/assets/fe69c433-1c4a-479e-b11c-e533dd9b3565)

Example route list (some active plugins):

![image](https://github.com/user-attachments/assets/6537ee5a-c72e-421b-982c-fb75b2fa95b8)
