### PR TITLE
fix(middleware): pass version to allow check

### DIFF
--- a/.changeset/angry-doors-tan.md
+++ b/.changeset/angry-doors-tan.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/middleware': patch
+---
+
+fix(middleware): pass version to allow check

--- a/packages/middleware/src/middlewares/allow.ts
+++ b/packages/middleware/src/middlewares/allow.ts
@@ -28,21 +28,21 @@ export function allow<T>(
         : req.params.version
           ? req.params.version
           : undefined;
-      const remote = req.remote_user;
+      const remote_user = req.remote_user;
       debug(
         'check if user %o can %o package %o version %o',
-        remote?.name,
+        remote_user?.name,
         action,
         packageName,
         packageVersion
       );
       beforeAll?.(
-        { action, user: remote?.name },
+        { action, user: remote_user?.name },
         `[middleware/allow][@{action}] allow for @{user}`
       );
       auth['allow_' + action](
         { packageName, packageVersion },
-        remote,
+        remote_user,
         function (error, allowed): void {
           req.resume();
           if (error) {
@@ -51,7 +51,7 @@ export function allow<T>(
           } else if (allowed) {
             debug('user is allowed to %o', action);
             afterAll?.(
-              { action, user: remote?.name },
+              { action, user: remote_user?.name },
               `[middleware/allow][@{action}] allowed for @{user}`
             );
             next();

--- a/packages/middleware/src/middlewares/allow.ts
+++ b/packages/middleware/src/middlewares/allow.ts
@@ -1,7 +1,11 @@
+import buildDebug from 'debug';
+
 import { API_ERROR, errorUtils } from '@verdaccio/core';
 import { getVersionFromTarball } from '@verdaccio/utils';
 
 import { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '../types';
+
+const debug = buildDebug('verdaccio:middleware:allow');
 
 export function allow<T>(
   auth: T,
@@ -21,8 +25,17 @@ export function allow<T>(
         : req.params.package;
       const packageVersion = req.params.filename
         ? getVersionFromTarball(req.params.filename)
-        : undefined;
+        : req.params.version
+          ? req.params.version
+          : undefined;
       const remote = req.remote_user;
+      debug(
+        'check if user %o can %o package %o version %o',
+        remote?.name,
+        action,
+        packageName,
+        packageVersion
+      );
       beforeAll?.(
         { action, user: remote?.name },
         `[middleware/allow][@{action}] allow for @{user}`
@@ -33,8 +46,10 @@ export function allow<T>(
         function (error, allowed): void {
           req.resume();
           if (error) {
+            debug('user is NOT allowed to %o', action);
             next(error);
           } else if (allowed) {
+            debug('user is allowed to %o', action);
             afterAll?.(
               { action, user: remote?.name },
               `[middleware/allow][@{action}] allowed for @{user}`

--- a/packages/middleware/test/allow.spec.ts
+++ b/packages/middleware/test/allow.spec.ts
@@ -1,22 +1,16 @@
 import request from 'supertest';
 
 import { HTTP_STATUS } from '@verdaccio/core';
-import { logger, setup } from '@verdaccio/logger';
 
 import { allow } from '../src';
 import { getApp } from './helper';
 
-setup({});
-
 test('should allow request', async () => {
-  const can = allow(
-    {
-      allow_publish: (params, remove, cb) => {
-        return cb(null, true);
-      },
+  const can = allow({
+    allow_publish: (params, remove, cb) => {
+      return cb(null, true);
     },
-    logger
-  );
+  });
   const app = getApp([]);
   // @ts-ignore
   app.get('/:package', can('publish'), (req, res) => {
@@ -27,14 +21,11 @@ test('should allow request', async () => {
 });
 
 test('should allow scope request', async () => {
-  const can = allow(
-    {
-      allow_publish: (params, remove, cb) => {
-        return cb(null, true);
-      },
+  const can = allow({
+    allow_publish: (params, remove, cb) => {
+      return cb(null, true);
     },
-    logger
-  );
+  });
   const app = getApp([]);
   // @ts-ignore
   app.get('/:package/:scope', can('publish'), (req, res) => {
@@ -45,14 +36,11 @@ test('should allow scope request', async () => {
 });
 
 test('should allow filename request', async () => {
-  const can = allow(
-    {
-      allow_publish: (params, remove, cb) => {
-        return cb(null, true);
-      },
+  const can = allow({
+    allow_publish: (params, remove, cb) => {
+      return cb(null, true);
     },
-    logger
-  );
+  });
   const app = getApp([]);
   // @ts-ignore
   app.get('/:filename', can('publish'), (req, res) => {
@@ -63,14 +51,11 @@ test('should allow filename request', async () => {
 });
 
 test('should not allow request', async () => {
-  const can = allow(
-    {
-      allow_publish: (params, remove, cb) => {
-        return cb(null, false);
-      },
+  const can = allow({
+    allow_publish: (params, remove, cb) => {
+      return cb(null, false);
     },
-    logger
-  );
+  });
   const app = getApp([]);
   // @ts-ignore
   app.get('/sec', can('publish'), (req, res) => {
@@ -81,17 +66,44 @@ test('should not allow request', async () => {
 });
 
 test('should handle error request', async () => {
-  const can = allow(
-    {
-      allow_publish: (params, remove, cb) => {
-        return cb(Error('foo error'));
-      },
+  const can = allow({
+    allow_publish: (params, remove, cb) => {
+      return cb(Error('foo error'));
     },
-    logger
-  );
+  });
   const app = getApp([]);
   // @ts-ignore
   app.get('/err', can('publish'));
 
   return request(app).get('/err').expect(HTTP_STATUS.INTERNAL_ERROR);
+});
+
+test('should allow request with version', async () => {
+  const can = allow({
+    allow_publish: (params, remove, cb) => {
+      return params.packageVersion === '1.0.0' ? cb(null, true) : cb(null, false);
+    },
+  });
+  const app = getApp([]);
+  // @ts-ignore
+  app.get('/:package/:version', can('publish'), (req, res) => {
+    res.status(HTTP_STATUS.OK).json({});
+  });
+
+  return request(app).get('/pacman/1.0.0').expect(HTTP_STATUS.OK);
+});
+
+test('should not allow request with version', async () => {
+  const can = allow({
+    allow_publish: (params, remove, cb) => {
+      return params.packageVersion === '1.0.0' ? cb(null, true) : cb(null, false);
+    },
+  });
+  const app = getApp([]);
+  // @ts-ignore
+  app.get('/:package/:version', can('publish'), (req, res) => {
+    res.status(HTTP_STATUS.OK).json({});
+  });
+
+  return request(app).get('/pacman/2.0.0').expect(HTTP_STATUS.INTERNAL_ERROR);
 });


### PR DESCRIPTION
If a specific version is requested from the registry, the version is now passed on to the auth plugin for the allow check.

Example: http://localhost:4873/pacman/1.0.0

Before: 

```js
allow_access( { packageName: 'pacman', packageVersion: undefined } );
```

After: 

```js
allow_access( { packageName: 'pacman', packageVersion: '1.0.0' } );
```

