### PR TITLE
fix: code scan issues

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,16 +5,10 @@ on:
     paths:
       - .github/workflows/codeql-analysis.yml
       - 'packages/**'
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
   pull_request:
     paths:
       - .github/workflows/codeql-analysis.yml
       - 'packages/**'
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.txt'
   schedule:
     - cron: '0 2 * * 4'
 


### PR DESCRIPTION
We can't have both `paths` and `paths-ignore`. 

![image](https://github.com/user-attachments/assets/573a0c81-f529-4acc-ad80-f0b8107ab447)

Ref https://github.com/verdaccio/verdaccio/pull/4888