### PR TITLE
fix(middleware): error 404 when getting scoped tarballs

### DIFF
--- a/.changeset/lucky-crabs-enjoy.md
+++ b/.changeset/lucky-crabs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/middleware': patch
+---
+
+fix(middleware): error 404 when getting scoped tarballs

--- a/packages/middleware/test/encode.spec.ts
+++ b/packages/middleware/test/encode.spec.ts
@@ -1,16 +1,23 @@
+/* eslint-disable no-console */
 import request from 'supertest';
-import { expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import { HTTP_STATUS } from '@verdaccio/core';
 
 import { encodeScopePackage } from '../src';
 import { getApp } from './helper';
 
-test('encode is json', async () => {
+const testHosts = [
+  'localhost:4873', // with port
+  'myregistry.com', // no port
+  '42.42.42.42', // ip
+  '[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443', // ip6
+];
+
+test('encode is json with relative path', async () => {
   const app = getApp([]);
   // @ts-ignore
   app.use(encodeScopePackage);
-  // @ts-ignore
   app.get('/:id', (req, res) => {
     const { id } = req.params;
     res.status(HTTP_STATUS.OK).json({ id });
@@ -21,84 +28,156 @@ test('encode is json', async () => {
   expect(res.status).toEqual(HTTP_STATUS.OK);
 });
 
-test('packages with version/scope', async () => {
+describe('packages requests', () => {
   const app = getApp([]);
   // @ts-ignore
   app.use(encodeScopePackage);
-  // @ts-ignore
   app.get('/:package/:version?', (req, res) => {
     const { package: pkg, version } = req.params;
     res.status(HTTP_STATUS.OK).json({ package: pkg, version });
   });
 
-  const res = await request(app).get('/foo');
-  expect(res.body).toEqual({ package: 'foo' });
-  expect(res.status).toEqual(HTTP_STATUS.OK);
+  test('just package', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/foo').set('host', host);
+      expect(res.body).toEqual({ package: 'foo' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res2 = await request(app).get('/foo/1.0.0');
-  expect(res2.body).toEqual({ package: 'foo', version: '1.0.0' });
-  expect(res2.status).toEqual(HTTP_STATUS.OK);
+  test('package with version', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/foo/1.0.0').set('host', host);
+      expect(res.body).toEqual({ package: 'foo', version: '1.0.0' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res3 = await request(app).get('/@scope/foo');
-  expect(res3.body).toEqual({ package: '@scope/foo' });
-  expect(res3.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/@scope/foo').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res4 = await request(app).get('/@scope/foo/1.0.0');
-  expect(res4.body).toEqual({ package: '@scope/foo', version: '1.0.0' });
-  expect(res4.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package with version', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/@scope/foo/1.0.0').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo', version: '1.0.0' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res5 = await request(app).get('/@scope%2ffoo');
-  expect(res5.body).toEqual({ package: '@scope/foo' });
-  expect(res5.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package with encoded path', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/@scope%2ffoo').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res6 = await request(app).get('/@scope%2ffoo/1.0.0');
-  expect(res6.body).toEqual({ package: '@scope/foo', version: '1.0.0' });
-  expect(res6.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package and version with encoded path', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/@scope%2ffoo/1.0.0').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo', version: '1.0.0' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res7 = await request(app).get('/%40scope%2ffoo');
-  expect(res7.body).toEqual({ package: '@scope/foo' });
-  expect(res7.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package with encoded @ and path ', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/%40scope%2ffoo').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res8 = await request(app).get('/%40scope%2ffoo/1.0.0');
-  expect(res8.body).toEqual({ package: '@scope/foo', version: '1.0.0' });
-  expect(res8.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package and version with encoded @ and path', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/%40scope%2ffoo/1.0.0').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo', version: '1.0.0' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res9 = await request(app).get('/%40scope/foo');
-  expect(res9.body).toEqual({ package: '@scope/foo' });
-  expect(res9.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package with encoded @', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/%40scope/foo').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res10 = await request(app).get('/%40scope/foo/1.0.0');
-  expect(res10.body).toEqual({ package: '@scope/foo', version: '1.0.0' });
-  expect(res10.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package and version with encoded @', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/%40scope/foo/1.0.0').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo', version: '1.0.0' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 });
 
-test('tarballs with and without scope', async () => {
+describe('tarball requests', () => {
   const app = getApp([]);
   // @ts-ignore
   app.use(encodeScopePackage);
-  // @ts-ignore
   app.get('/:package/-/:filename', (req, res) => {
     const { package: pkg, filename } = req.params;
     res.status(HTTP_STATUS.OK).json({ package: pkg, filename });
   });
 
-  const res = await request(app).get('/foo/-/foo-1.2.3.tgz');
-  expect(res.body).toEqual({ package: 'foo', filename: 'foo-1.2.3.tgz' });
-  expect(res.status).toEqual(HTTP_STATUS.OK);
+  test('just package', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/foo/-/foo-1.2.3.tgz').set('host', host);
+      expect(res.body).toEqual({ package: 'foo', filename: 'foo-1.2.3.tgz' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res2 = await request(app).get('/@scope/foo/-/foo-1.2.3.tgz');
-  expect(res2.body).toEqual({ package: '@scope/foo', filename: 'foo-1.2.3.tgz' });
-  expect(res2.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/@scope/foo/-/foo-1.2.3.tgz').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo', filename: 'foo-1.2.3.tgz' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res3 = await request(app).get('/@scope%2ffoo/-/foo-1.2.3.tgz');
-  expect(res3.body).toEqual({ package: '@scope/foo', filename: 'foo-1.2.3.tgz' });
-  expect(res3.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package with encoded path', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/@scope%2ffoo/-/foo-1.2.3.tgz').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo', filename: 'foo-1.2.3.tgz' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res4 = await request(app).get('/%40scope%2ffoo/-/foo-1.2.3.tgz');
-  expect(res4.body).toEqual({ package: '@scope/foo', filename: 'foo-1.2.3.tgz' });
-  expect(res4.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package with encoded @ and path', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/%40scope%2ffoo/-/foo-1.2.3.tgz').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo', filename: 'foo-1.2.3.tgz' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
 
-  const res5 = await request(app).get('/%40scope/foo/-/foo-1.2.3.tgz');
-  expect(res5.body).toEqual({ package: '@scope/foo', filename: 'foo-1.2.3.tgz' });
-  expect(res5.status).toEqual(HTTP_STATUS.OK);
+  test('scoped package with encoded @', () => {
+    testHosts.forEach(async (host) => {
+      const res = await request(app).get('/%40scope/foo/-/foo-1.2.3.tgz').set('host', host);
+      expect(res.body).toEqual({ package: '@scope/foo', filename: 'foo-1.2.3.tgz' });
+      expect(res.status).toEqual(HTTP_STATUS.OK);
+    });
+  });
+});
+
+test('invalid url', async () => {
+  const app = getApp([]);
+  // @ts-ignore
+  app.use(encodeScopePackage);
+  app.get('/:id', (req, res) => {
+    const { id } = req.params;
+    res.status(HTTP_STATUS.OK).json({ id });
+  });
+
+  const res = await request(app).get('/foo').set('host', 'invalid::host');
+  expect(res.status).toEqual(HTTP_STATUS.BAD_REQUEST);
+  expect(res.text).toContain('Invalid URL');
 });


### PR DESCRIPTION
The following issues are all related: https://github.com/verdaccio/verdaccio/issues/3517, https://github.com/verdaccio/verdaccio/issues/3530, https://github.com/verdaccio/verdaccio/issues/4070 and can be closed by this PR :-)

It took me several weeks of intensive debugging and tracing to find the cause (more below). As usual, the fix is quite easy once you know what's wrong.

### Symptom

Trying to fetch tarballs of *scoped* packages is failing with a 404 error.

### Root Cause

The encoding/decoding of request URLs did not work correctly if the URL contained a "@scope". 

### Background

The slash in `@scope/package` needs to be escaped, or the express router will not direct the request to the correct handler (example: `http://localhost:4873/@types/lodash/-/lodash-4.17.9.tgz`). Curiously, the [existing routine](https://github.com/verdaccio/verdaccio/blob/master/packages/middleware/src/middlewares/encode-pkg.ts#L13-L30) was working well in CI tests and when running locally. However, it was failing consistently when executed in a GitHub action. This made finding the cause very hard since I could not reproduce it on my machine.

I added logging and tests to Verdaccio (#4847, #4874). Tests passed but there was *no* logging of the tarball requests in Verdaccio even with `loglevel=trace` and `debug=verdaccio:*`. 👀 

I set the npm logging to `silly` but there were *no* npm log entries showing when and how these tarballs were requested from Verdaccio. Nevertheless, npm somehow got all the required tarballs and installed them properly. 🙄 

### Debugging

Let's debug npm and find out why there's no log. 😁 The requests are handled in `npm/pacote` and then passed on to `npm/npm-registry-fetch`. It turns out there's a bug and requests for tarballs already cached were not logged at all! 😠  

I contributed two patches to npm https://github.com/npm/pacote/pull/403 and https://github.com/npm/npm-registry-fetch/pull/273 which will soon become part of npm. 😃 

### Disable Caching

Now I could see the cache hits. So let's ensure we start all tests clean with `npm cache clear --force`. Another way is to skip caching with `npm config set prefernline=true`. Now npm shows an HTTP fetch in the log. But why was Verdaccio still not handling the request? 

### Aha-Moment

The new verdaccio debug messages showed for scoped package manifest:

```
verdaccio:middleware:encode encodeScopePackage: 'http://localhost:4873/@jest%2fglobals' -> 'http://localhost:4873/@jest%2fglobals'
```

and for scoped tarballs:

```
verdaccio:middleware:encode encodeScopePackage: 'http://localhost:4873/@types/yargs-parser/-/yargs-parser-21.0.3.tgz' -> 'http://localhost:4873/@types/yargs-parser/-/yargs-parser-21.0.3.tgz'
```

npm already escapes the `/` when requesting a manifest but it does *not*  when requesting a tarball 💥. 

Why are the Verdaccio tests that cover this [exact case](https://github.com/verdaccio/verdaccio/blob/f5f6e88d7a46761a97cfa8cca9235047624c28ff/packages/middleware/test/encode.spec.ts#L89-L91) passing? 🤔 

The tests had a bug and only the first supertest request was processed correctly. The subsequent requests returned the same result as the first one (because of `const`?). Once I separated the tests and added various hostnames, it was clear that the `regex` in `encodeScopePackage` was not correct:

https://github.com/verdaccio/verdaccio/blob/f5f6e88d7a46761a97cfa8cca9235047624c28ff/packages/middleware/src/middlewares/encode-pkg.ts#L26

The regex assumed that the scoped package was at the beginning of the request URL (`^`). However, the URL includes protocol and hostname, too. 

### Solution

I refactored `encodeScopePackage` and the corresponding tests to handle relative and absolute URLs. It also validates that the `regex` works with various types of hostnames. 

### Lessons

- More tests are good
- Tests can pass because of bugs in the test
- Caching can mess with tests
- Using Verdaccio can lead to improvements in npm 
  
Now this major annoyance has been eliminated. Happy Verdaccio, everyone 🎉 🍰 



