### PR TITLE
feat(proxy): pick proxy agents by target URL's protocol to allow `http_proxy` works with https URLs and `https_proxy` works with http URLs.

### DIFF
--- a/.changeset/afraid-panthers-attend.md
+++ b/.changeset/afraid-panthers-attend.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/proxy': patch
+---
+
+[Proposal] Pick proxy agents by target URL's protocol

--- a/.changeset/afraid-panthers-attend.md
+++ b/.changeset/afraid-panthers-attend.md
@@ -2,4 +2,4 @@
 '@verdaccio/proxy': patch
 ---
 
-[Proposal] Pick proxy agents by target URL's protocol
+feat(proxy): pick proxy agents by target URL's protocol to allow `http_proxy` works with https URLs and `https_proxy` works with http URLs. ([#4915](https://github.com/verdaccio/verdaccio/pull/4915) by [fix777](https://github.com/fix777))

--- a/packages/proxy/src/agent.ts
+++ b/packages/proxy/src/agent.ts
@@ -47,7 +47,7 @@ class CustomAgents {
   }
 
   private getParsedUrl() {
-    return this.proxy ? new URL(this.proxy) : new URL(this.url);
+    return new URL(this.url);
   }
 }
 

--- a/packages/proxy/test/custom-agents.spec.ts
+++ b/packages/proxy/test/custom-agents.spec.ts
@@ -1,0 +1,18 @@
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
+import { describe, expect, test } from 'vitest';
+
+import CustomAgents from '../src/agent';
+
+describe('CustomAgents', () => {
+  test('Create a HttpProxyAgent instance if the target URL uses HTTP', () => {
+    const agent = new CustomAgents('http://registry.npmjs.org', 'http://127.0.0.1:7890', {}).get();
+    expect(agent.http).toBeInstanceOf(HttpProxyAgent);
+    expect(agent.https).toBeUndefined();
+  });
+
+  test('Create a HttpsProxyAgent instance if the target URL uses HTTPS', () => {
+    const agent = new CustomAgents('https://registry.npmjs.org', 'http://127.0.0.1:7890', {}).get();
+    expect(agent.http).toBeUndefined();
+    expect(agent.https).toBeInstanceOf(HttpsProxyAgent);
+  });
+});


### PR DESCRIPTION
## Problem Statement

`https_proxy` only works with `https` URLs, not `http` URLs.

For instance,
I have https proxy config as below, then fetch tar ball from `http://127.0.0.1:4873/jquery/-/jquery-0.0.1.tgz`.
```yaml
uplinks:
  npmjs:
    url: https://registry.npmjs.org/

packages:
  '**':
    access: $all
    publish: $authenticated
    unpublish: $authenticated
    proxy: npmjs

https_proxy: http://127.0.0.1:7890
```
- `CustomAgents` instantiated a `HttpProxyAgent` because of the `http` protocol of the `proxy` URL.
- `got` found no `HTTPS` agent, so no proxy agent used for requests to `npmjs` uplink.

## Proposed Solution

Allow `https_proxy` with `http` URLs. It's simple to setup a `http` proxy locally. So we can pick up the corresponding proxy agent by the protocol of the target request URL.

## Technical Details

Parse URL from `this.url` even if `this.proxy` exists.

```diff
class CustomAgents {
  // ...

  private getParsedUrl() {
-   return this.proxy ? new URL(this.proxy) : new URL(this.url);
+   return new URL(this.url);
  }
}
```

## Benefits

- `http_proxy` works with `https` URLs.
- `https_proxy` works with `http` URLs.

## Testing Plan

Unit tests have been added to cover `https_proxy` with `http` URLs scenarios.

