### PR TITLE
chore: version details and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ You can find more details about the different versions of Verdaccio, minimum req
 Install with npm:
 
 ```bash
-npm install -g verdaccio@next
+npm install -g verdaccio@next-8
 ```
 
 With `yarn`
 
 ```bash
-yarn global add verdaccio@next
+yarn global add verdaccio@next-8
 ```
 
 With `pnpm`
 
 ```bash
-pnpm i -g verdaccio@next
+pnpm i -g verdaccio@next-8
 ```
 
 or

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 > Looking for Verdaccio version 5 or 6? Version 6 is the latest version and successor to version 5. Version 6 requires Node.js 18 or higher and is maintained in the `6.x` branch.
 
-> The plugins for versions 5 and 6 are located at the [`verdaccio/monorepo`](https://github.com/verdaccio/monorepo) repository. Plugins for the `next` version are hosted in this project under the `./packages/plugins` folder.
+> The plugins for versions 5 and 6 are located at the [`verdaccio/monorepo`](https://github.com/verdaccio/monorepo) repository. Plugins for the `next-8` version are hosted in this project under the `./packages/plugins` folder.
 
 > Note that contributing guidelines might be different based on the branch.
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@
 
 ![verdaccio gif](https://cdn.verdaccio.dev/readme/readme-website.png)
 
-# Version Next (Development branch)
+# Version Next (Development Branch)
 
-> Looking for Verdaccio 6 version? Check the branch `6.x`
-> The plugins for the `v6.x` that are hosted within this organization are located
-> at the [`verdaccio/monorepo`](https://github.com/verdaccio/monorepo) repository, while for the `next` version
-> are hosted on this project `./packages/plugins`.
+> Looking for Verdaccio version 5 or 6? Version 6 is the latest version and successor to version 5. Version 6 requires Node.js 18 or higher and is maintained in the `6.x` branch.
+
+> The plugins for versions 5 and 6 are located at the [`verdaccio/monorepo`](https://github.com/verdaccio/monorepo) repository. Plugins for the `next` version are hosted in this project under the `./packages/plugins` folder.
 
 > Note that contributing guidelines might be different based on the branch.
 
@@ -35,6 +34,10 @@ Google Cloud Storage** or create your own plugin.
 
 [![Github](https://img.shields.io/github/stars/verdaccio/verdaccio.svg?style=social&label=Stars)](https://github.com/verdaccio/verdaccio/stargazers)
 [![StandWithUkraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/badges/StandWithUkraine.svg)](https://github.com/vshymanskyy/StandWithUkraine/blob/main/docs/README.md)
+
+## Versions
+
+You can find more details about the different versions of Verdaccio, minimum requirements, as well as links to associated npm packages and docker images in the [version history](VERSIONS.md).
 
 ## Install
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,16 +2,7 @@
 
 ## Supported versions
 
-The following table describes the versions of this project that are currently supported with security updates:
-
-| Version  | Supported                           |
-| -------- | ----------------------------------- |
-| 2.x      | :x:                                 |
-| 3.x      | :x:                                 |
-| 4.x      | :x:                                 |
-| 5.x      | :white_check_mark: (until Nov 2024) |
-| 6.x      | :white_check_mark:                  |
-| 7.x next | :x:                                 |
+You can find details about the supported versions of Verdaccio in the [version history](VERSIONS.md).
 
 ## Responsible disclosure security policy
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,13 +2,13 @@
 
 The following table describes the versions of this project:
 
-| Version          | Supported          | Minimum Node.js | Branch | Npm Tag            | Docker Images             |
-| ---------------- | -------------------| --------------- | ------ | ------------------ | ------------------------- |
-| 4.x              | :x: (deprecated)   | 10              | 4.x    | latest-4           | 4, 4.x, 4.x.x, 4.x-next   |
-| 5.x previous     | :x: (deprecated)   | 14              | 5.x    | latest-5           | 5, 5.x, 5.x.x, 5.x-next   |
-| _6.x current_    | :white_check_mark: | _18_            | _6.x_  | _latest-6, latest_ | _6, 6.x, 6.x.x, 6.x-next_ |
-| 7.x next         | :x:                | 18              | 7.x    | next-7             | 7.x-next                  |
-| 8.x experimental | :x:                | 18              | master | next-8             | nightly-master            |
+| Version          | Supported          | Minimum Node.js | Branch | Npm Tag          | Docker Images           | Helm Charts |
+| ---------------- | -------------------| --------------- | ------ | ---------------- | ----------------------- | ----------- |
+| 4.x              | :x: (deprecated)   | 10              | 4.x    | latest-4         | 4, 4.x, 4.x.x, 4.x-next | 3.x         |
+| 5.x previous     | :x: (deprecated)   | 14              | 5.x    | latest-5         | 5, 5.x, 5.x.x, 5.x-next | 4.0 - 4.18  |
+| 6.x current      | :white_check_mark: | 18              | 6.x    | latest-6, latest | 6, 6.x, 6.x.x, 6.x-next | 4.19 - ...  |
+| 7.x next         | :x:                | 18              | 7.x    | next-7           | 7.x-next                | n/a         |
+| 8.x experimental | :x:                | 18              | master | next-8           | nightly-master          | n/a         |
 
 ## Npm Registry
 
@@ -17,3 +17,7 @@ The official Verdaccio npm packages are located at https://www.npmjs.com/package
 ## Docker Hub
 
 The official Verdaccio Docker Images are found at https://hub.docker.com/r/verdaccio/verdaccio.
+
+## Helms Charts
+
+The official Verdaccio Helm Charts are found at https://artifacthub.io/packages/helm/verdaccio/verdaccio.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,20 @@
+# Versions
+
+The following table describes the versions of this project:
+
+| Version          | Supported                           | Minimum Node.js | Branch | Npm Tag          | Docker Images           |
+| ---------------- | ----------------------------------- | --------------- | ------ | ---------------- | ----------------------- |
+| 3.x              | :x:                                 | 10              | :x:    | latest-3         | 3, 3.x, 3.x.x, 3.x-next |
+| 4.x              | :x:                                 | 10              | 4.x    | latest-4         | 4, 4.x, 4.x.x, 4.x-next |
+| 5.x previous     | :white_check_mark: (until Nov 2024) | 14              | 5.x    | latest-5         | 5, 5.x, 5.x.x, 5.x-next |
+| 6.x current      | :white_check_mark:                  | 18              | 6.x    | latest-6, latest | 6, 6.x, 6.x.x, 6.x-next |
+| 7.x next         | :x:                                 | 18              | 7.x    | next-7           | 7.x-next                |
+| 8.x experimental | :x:                                 | 18              | master | next-8           | nightly-master          |
+
+## Npm Registry
+
+The official Verdaccio npm packages are located are https://www.npmjs.com/package/verdaccio.
+
+## Docker Hub
+
+The official Verdaccio Docker Images are found at https://hub.docker.com/r/verdaccio/verdaccio.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,14 +2,15 @@
 
 The following table describes the versions of this project:
 
-| Version          | Supported                           | Minimum Node.js | Branch | Npm Tag          | Docker Images           |
-| ---------------- | ----------------------------------- | --------------- | ------ | ---------------- | ----------------------- |
-| 3.x              | :x:                                 | 10              | :x:    | latest-3         | 3, 3.x, 3.x.x, 3.x-next |
-| 4.x              | :x:                                 | 10              | 4.x    | latest-4         | 4, 4.x, 4.x.x, 4.x-next |
-| 5.x previous     | :white_check_mark: (until Nov 2024) | 14              | 5.x    | latest-5         | 5, 5.x, 5.x.x, 5.x-next |
-| 6.x current      | :white_check_mark:                  | 18              | 6.x    | latest-6, latest | 6, 6.x, 6.x.x, 6.x-next |
-| 7.x next         | :x:                                 | 18              | 7.x    | next-7           | 7.x-next                |
-| 8.x experimental | :x:                                 | 18              | master | next-8           | nightly-master          |
+| Version          | Supported                           | Minimum Node.js | Branch | Npm Tag            | Docker Images             |
+| ---------------- | ----------------------------------- | --------------- | ------ | ------------------ | ------------------------- |
+| 2.x              | :x: (deprecated)                    | 8               | :x:    | latest-2           | 2, 2.x, 2.x.x             |
+| 3.x              | :x: (deprecated)                    | 10              | :x:    | latest-3           | 3, 3.x, 3.x.x, 3.x-next   |
+| 4.x              | :x: (deprecated)                    | 10              | 4.x    | latest-4           | 4, 4.x, 4.x.x, 4.x-next   |
+| 5.x previous     | :white_check_mark: (until Nov 2024) | 14              | 5.x    | latest-5           | 5, 5.x, 5.x.x, 5.x-next   |
+| _6.x current_    | :white_check_mark:                  | _18_            | _6.x_  | _latest-6, latest_ | _6, 6.x, 6.x.x, 6.x-next_ |
+| 7.x next         | :x:                                 | 18              | 7.x    | next-7             | 7.x-next                  |
+| 8.x experimental | :x:                                 | 18              | master | next-8             | nightly-master            |
 
 ## Npm Registry
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,8 +4,6 @@ The following table describes the versions of this project:
 
 | Version          | Supported                           | Minimum Node.js | Branch | Npm Tag            | Docker Images             |
 | ---------------- | ----------------------------------- | --------------- | ------ | ------------------ | ------------------------- |
-| 2.x              | :x: (deprecated)                    | 8               | :x:    | latest-2           | 2, 2.x, 2.x.x             |
-| 3.x              | :x: (deprecated)                    | 10              | :x:    | latest-3           | 3, 3.x, 3.x.x, 3.x-next   |
 | 4.x              | :x: (deprecated)                    | 10              | 4.x    | latest-4           | 4, 4.x, 4.x.x, 4.x-next   |
 | 5.x previous     | :white_check_mark: (until Nov 2024) | 14              | 5.x    | latest-5           | 5, 5.x, 5.x.x, 5.x-next   |
 | _6.x current_    | :white_check_mark:                  | _18_            | _6.x_  | _latest-6, latest_ | _6, 6.x, 6.x.x, 6.x-next_ |
@@ -14,7 +12,7 @@ The following table describes the versions of this project:
 
 ## Npm Registry
 
-The official Verdaccio npm packages are located are https://www.npmjs.com/package/verdaccio.
+The official Verdaccio npm packages are located at https://www.npmjs.com/package/verdaccio.
 
 ## Docker Hub
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,13 +2,13 @@
 
 The following table describes the versions of this project:
 
-| Version          | Supported                           | Minimum Node.js | Branch | Npm Tag            | Docker Images             |
-| ---------------- | ----------------------------------- | --------------- | ------ | ------------------ | ------------------------- |
-| 4.x              | :x: (deprecated)                    | 10              | 4.x    | latest-4           | 4, 4.x, 4.x.x, 4.x-next   |
-| 5.x previous     | :white_check_mark: (until Nov 2024) | 14              | 5.x    | latest-5           | 5, 5.x, 5.x.x, 5.x-next   |
-| _6.x current_    | :white_check_mark:                  | _18_            | _6.x_  | _latest-6, latest_ | _6, 6.x, 6.x.x, 6.x-next_ |
-| 7.x next         | :x:                                 | 18              | 7.x    | next-7             | 7.x-next                  |
-| 8.x experimental | :x:                                 | 18              | master | next-8             | nightly-master            |
+| Version          | Supported          | Minimum Node.js | Branch | Npm Tag            | Docker Images             |
+| ---------------- | -------------------| --------------- | ------ | ------------------ | ------------------------- |
+| 4.x              | :x: (deprecated)   | 10              | 4.x    | latest-4           | 4, 4.x, 4.x.x, 4.x-next   |
+| 5.x previous     | :x: (deprecated)   | 14              | 5.x    | latest-5           | 5, 5.x, 5.x.x, 5.x-next   |
+| _6.x current_    | :white_check_mark: | _18_            | _6.x_  | _latest-6, latest_ | _6, 6.x, 6.x.x, 6.x-next_ |
+| 7.x next         | :x:                | 18              | 7.x    | next-7             | 7.x-next                  |
+| 8.x experimental | :x:                | 18              | master | next-8             | nightly-master            |
 
 ## Npm Registry
 


### PR DESCRIPTION
The update to the readme and a table with the historical details clarifies the current state. I understand that there will be some consolidation of versions/branches. I will update the table when the time comes.

I think you should update the npm tags a bit. 

Currently:

```bash
> npm dist-tag ls verdaccio
4-next: 4.13.2
latest-6: 6.0.0-rc.1
latest: 6.0.1
next-7: 7.0.0-next-7.20
next-8: 8.0.0-next-8.3
previous: 4.12.2
```

Suggested:

```bash
> npm dist-tag rm verdaccio 4-next
> npm dist-tag rm verdaccio previous
> npm dist-tag rm verdaccio latest-6
> npm dist-tag add verdaccio@6.0.1 latest-6
> npm dist-tag add verdaccio@5.32.2 latest-5
# and if you like for consistency...
> npm dist-tag add verdaccio@4.13.2 latest-4
> npm dist-tag add verdaccio@3.13.1 latest-3
> npm dist-tag add verdaccio@2.7.4 latest-2
```
