### PR TITLE
chore: fix typedocs warnings

### DIFF
--- a/.changeset/healthy-ducks-drive.md
+++ b/.changeset/healthy-ducks-drive.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/types': patch
+'@verdaccio/config': patch
+---
+
+chore: fix typedocs warnings

--- a/packages/config/src/user.ts
+++ b/packages/config/src/user.ts
@@ -25,7 +25,7 @@ export const defaultNonLoggedUserRoles = [
 
 /**
  * Create a RemoteUser object
- * @return {Object} { name: xx, pluginGroups: [], real_groups: [] }
+ * @return {Object} \{ name: xx, pluginGroups: [], real_groups: [] \}
  */
 export function createRemoteUser(name: string, pluginGroups: string[]): RemoteUser {
   const isGroupValid: boolean = Array.isArray(pluginGroups);
@@ -42,7 +42,7 @@ export function createRemoteUser(name: string, pluginGroups: string[]): RemoteUs
 
 /**
  * Builds an anonymous remote user in case none is logged in.
- * @return {Object} { name: xx, groups: [], real_groups: [] }
+ * @return {Object} \{ name: xx, groups: [], real_groups: [] \}
  */
 export function createAnonymousRemoteUser(): RemoteUser {
   return {

--- a/packages/core/types/src/plugins/storage.ts
+++ b/packages/core/types/src/plugins/storage.ts
@@ -23,11 +23,11 @@ export interface ITokenActions {
 /**
  * This method expect return a Package object
  * eg:
- * {
+ * \{
  *   name: string;
  *   time: number;
  *   ... and other props
- * }
+ * \}
  *
  * The `cb` callback object will be executed if:
  *  - it might return object (truly)


### PR DESCRIPTION
Ref https://typedoc.org/guides/doccomments/#escaping-comments

Fixes the following warnings:

```
/home/runner/work/verdaccio/verdaccio/packages/config/src/user.ts:28:20 - warning Encountered an unescaped open brace without an inline tag
28     * @return {Object} { name: xx, pluginGroups: [], real_groups: [] }
/home/runner/work/verdaccio/verdaccio/packages/config/src/user.ts:28:66 - warning Unmatched closing brace
28     * @return {Object} { name: xx, pluginGroups: [], real_groups: [] }
/home/runner/work/verdaccio/verdaccio/packages/config/src/user.ts:45:20 - warning Encountered an unescaped open brace without an inline tag
45     * @return {Object} { name: xx, groups: [], real_groups: [] }
/home/runner/work/verdaccio/verdaccio/packages/config/src/user.ts:45:60 - warning Unmatched closing brace
45     * @return {Object} { name: xx, groups: [], real_groups: [] }
/home/runner/work/verdaccio/verdaccio/packages/core/types/src/plugins/storage.ts:26:3 - warning Encountered an unescaped open brace without an inline tag
26     * {
/home/runner/work/verdaccio/verdaccio/packages/core/types/src/plugins/storage.ts:30:3 - warning Unmatched closing brace
30     * }
```