### PR TITLE
chore: add info to log when local storage is used

### DIFF
--- a/.changeset/healthy-zoos-lie.md
+++ b/.changeset/healthy-zoos-lie.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/store': patch
+---
+
+chore: add info to log when local storage is used

--- a/packages/store/src/local-storage.ts
+++ b/packages/store/src/local-storage.ts
@@ -60,7 +60,12 @@ class LocalStorage {
     if (_.isNil(Storage)) {
       assert(this.config.storage, 'CONFIG: storage path not defined');
       debug('no custom storage found, loading default storage @verdaccio/local-storage');
-      return new LocalDatabase(config, logger);
+      const localStorage = new LocalDatabase(config, logger);
+      logger.info(
+        { pluginCategory: PLUGIN_CATEGORY.STORAGE },
+        'plugin @verdaccio/local-storage successfully loaded (@{pluginCategory})'
+      );
+      return localStorage;
     }
     return Storage as PluginStorage;
   }


### PR DESCRIPTION
The local storage plugin was missing from the startup log messages. 