### PR TITLE
chore(tests): temp folder naming

### DIFF
--- a/.changeset/silent-bags-listen.md
+++ b/.changeset/silent-bags-listen.md
@@ -1,0 +1,9 @@
+---
+'@verdaccio/logger-commons': patch
+'@verdaccio/local-storage': patch
+'@verdaccio/test-helper': patch
+'@verdaccio/core': patch
+'verdaccio': patch
+---
+
+chore(tests): temp folder naming

--- a/packages/core/core/src/file-utils.ts
+++ b/packages/core/core/src/file-utils.ts
@@ -14,7 +14,7 @@ const { mkdir, mkdtemp } = fs.promises ? fs.promises : require('fs/promises');
  * @returns string
  */
 export async function createTempFolder(prefix: string): Promise<string> {
-  return await mkdtemp(path.join(os.tmpdir(), prefix));
+  return await mkdtemp(path.join(os.tmpdir(), 'verdaccio-' + prefix + '-'));
 }
 
 /**

--- a/packages/logger/logger-commons/test/logger.spec.ts
+++ b/packages/logger/logger-commons/test/logger.spec.ts
@@ -13,7 +13,7 @@ async function readLogFile(path: string) {
 }
 
 async function createLogFile() {
-  const folder = await fileUtils.createTempFolder('logger-1');
+  const folder = await fileUtils.createTempFolder('logger');
   const file = join(folder, 'logger.log');
   return file;
 }

--- a/packages/plugins/local-storage/tests/local-database.test.ts
+++ b/packages/plugins/local-storage/tests/local-database.test.ts
@@ -30,7 +30,7 @@ let locaDatabase: pluginUtils.Storage<{}>;
 describe('Local Database', () => {
   let tmpFolder;
   beforeEach(async () => {
-    tmpFolder = await fileUtils.createTempFolder('local-storage-plugin-');
+    tmpFolder = await fileUtils.createTempFolder('local-storage-plugin');
     const tempFolder = path.join(tmpFolder, 'verdaccio-test.yaml');
     locaDatabase = new LocalDatabase(
       // @ts-expect-error
@@ -58,7 +58,7 @@ describe('Local Database', () => {
     mockmkdir.mockImplementation(() => {
       throw Error();
     });
-    const tmpFolder = await fileUtils.createTempFolder('local-storage-plugin-');
+    const tmpFolder = await fileUtils.createTempFolder('local-storage-plugin');
     const tempFolder = path.join(tmpFolder, 'verdaccio-test.yaml');
     const instance = new LocalDatabase(
       // @ts-expect-error

--- a/packages/plugins/local-storage/tests/local-fs.test.ts
+++ b/packages/plugins/local-storage/tests/local-fs.test.ts
@@ -4,7 +4,6 @@ import { Readable } from 'stream';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { fileUtils } from '@verdaccio/core';
-import { createTempFolder } from '@verdaccio/test-helper';
 import { Logger, Manifest } from '@verdaccio/types';
 
 import LocalDriver from '../src/local-fs';
@@ -78,15 +77,16 @@ describe('Local FS test', () => {
     test('should write a tarball', () =>
       new Promise((done) => {
         const abort = new AbortController();
-        const tmp = createTempFolder('local-fs-write-tarball');
-        const localFs = new LocalDriver(tmp, logger);
-        const readableStream = Readable.from('foooo');
-        // TODO: verify file exist
-        localFs.writeTarball('juan-1.0.0.tgz', { signal: abort.signal }).then((stream) => {
-          stream.on('finish', () => {
-            done(true);
+        fileUtils.createTempFolder('local-fs-write-tarball').then((tmp) => {
+          const localFs = new LocalDriver(tmp, logger);
+          const readableStream = Readable.from('foooo');
+          // TODO: verify file exist
+          localFs.writeTarball('juan-1.0.0.tgz', { signal: abort.signal }).then((stream) => {
+            stream.on('finish', () => {
+              done(true);
+            });
+            readableStream.pipe(stream);
           });
-          readableStream.pipe(stream);
         });
       }));
   });

--- a/packages/plugins/local-storage/tests/token.test.ts
+++ b/packages/plugins/local-storage/tests/token.test.ts
@@ -22,7 +22,7 @@ describe('Local Database', () => {
   let tmpFolder;
   let locaDatabase;
   beforeEach(async () => {
-    tmpFolder = await fileUtils.createTempFolder('local-storage-plugin-');
+    tmpFolder = await fileUtils.createTempFolder('local-storage-plugin');
     const tempFolder = path.join(tmpFolder, 'verdaccio-test.yaml');
     const writeMock = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
     locaDatabase = new LocalDatabase( // @ts-expect-error

--- a/packages/tools/helpers/src/index.ts
+++ b/packages/tools/helpers/src/index.ts
@@ -6,4 +6,3 @@ export { addNewVersion } from './addNewVersion';
 export { generatePublishNewVersionManifest } from './generatePublishNewVersionManifest';
 export { initializeServer } from './initializeServer';
 export { publishVersion } from './actions';
-export { createTempFolder } from './utils';

--- a/packages/tools/helpers/src/utils.ts
+++ b/packages/tools/helpers/src/utils.ts
@@ -1,17 +1,3 @@
-import fs from 'fs-extra';
-import os from 'os';
-import path from 'path';
-
-/**
- * Create a temporary folder.
- * @param prefix The prefix of the folder name.
- * @returns string
- * @deprecated use @verdaccio/core:createTempFolder async function instead
- */
-export function createTempFolder(prefix: string): string {
-  return fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), prefix));
-}
-
 export const getTarball = (name: string): string => {
   const r = name.split('/');
   if (r.length === 1) {

--- a/packages/verdaccio/src/server/registry.ts
+++ b/packages/verdaccio/src/server/registry.ts
@@ -61,7 +61,7 @@ export class Registry {
     config: Partial<ConfigYaml>
   ): Promise<{ tempFolder: string; configPath: string; yamlContent: string }> {
     debug(`fromConfigToPath`);
-    const tempFolder = await fileUtils.createTempFolder('registry-');
+    const tempFolder = await fileUtils.createTempFolder('registry');
     debug(`tempFolder %o`, tempFolder);
     const yamlContent = fromJStoYAML(config) as string;
     const configPath = path.join(tempFolder, 'registry.yaml');


### PR DESCRIPTION
This improves the naming of temp folders. You can more easily identify them to clean up leftovers.

![image](https://github.com/user-attachments/assets/8c3780ab-bcec-4a14-9006-41e18a970e70)

PS: There's a little bug in the promise version that doesn't replace the XXXXXX properly (
https://github.com/nodejs/node/pull/53776).