### PR TITLE
fix: error E409 "username is already registered" (adduser)

### DIFF
--- a/.changeset/green-eagles-boil.md
+++ b/.changeset/green-eagles-boil.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/auth': patch
+'@verdaccio/api': patch
+---
+
+fix: E409 username is already registered (adduser)

--- a/packages/api/src/user.ts
+++ b/packages/api/src/user.ts
@@ -28,7 +28,11 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
     function (req: $RequestExtend, res: Response, next: $NextFunctionVer): void {
       debug('verifying user');
 
-      if (typeof req.remote_user.name !== 'string' || req.remote_user.name === '') {
+      if (
+        !req.remote_user ||
+        typeof req.remote_user.name !== 'string' ||
+        req.remote_user.name === ''
+      ) {
         debug('user not logged in');
         res.status(HTTP_STATUS.OK);
         return next({ ok: false });

--- a/packages/auth/src/utils.ts
+++ b/packages/auth/src/utils.ts
@@ -166,7 +166,9 @@ export function getDefaultPlugins(logger: Logger): pluginUtils.Auth<Config> {
 
     adduser(_user: string, _password: string, cb: pluginUtils.AuthUserCallback): void {
       debug('triggered default adduser method');
-      return cb(errorUtils.getConflict(API_ERROR.BAD_USERNAME_PASSWORD));
+      // since adduser is not implemented but optional, continue without error
+      // this assumes that the user is added by an external system
+      cb(null, true);
     },
 
     // @ts-ignore

--- a/packages/auth/test/auth-utils.spec.ts
+++ b/packages/auth/test/auth-utils.spec.ts
@@ -123,11 +123,12 @@ describe('Auth utilities', () => {
       });
     });
 
-    test('add user should fail by default (default)', () => {
+    test('add user should not fail by default (default)', () => {
       const plugin = getDefaultPlugins({ trace: vi.fn() });
       // @ts-ignore
-      plugin.adduser('foo', 'bar', (error: any) => {
-        expect(error).toEqual(errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
+      plugin.adduser('foo', 'bar', (error: any, access: any) => {
+        expect(error).toEqual(null);
+        expect(access).toEqual(true);
       });
     });
   });


### PR DESCRIPTION
If neither `adduser` nor `add_user` are implemented by the authentication plugin, we assume that users are added by an external system and no error is raised.

Closes #3734

Also fixes an unexpected error that can happen if the implementation of `authenticate` is incomplete:

![image](https://github.com/user-attachments/assets/3b77c0ed-7874-4549-9f4a-96f4ed529ae9)

### Before

![image](https://github.com/user-attachments/assets/b78ff632-69f5-40fa-9605-2f73b0dbf182)

![image](https://github.com/user-attachments/assets/cb98146f-d7b8-471b-a029-d634a8277df0)

### After

![image](https://github.com/user-attachments/assets/df3ecb91-aefb-4c1a-95e4-f7b4e7d591ab)

![image](https://github.com/user-attachments/assets/c3bcc6b0-bb6f-4168-8d17-6483ad02fcd7)

