### PR TITLE
chore: avoid vitest warning

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,3 +1,4 @@
+// @ts-check
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({


### PR DESCRIPTION
Renaming to `.mjs` removes the warnings during test execution:

 "The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details."