### PR TITLE
chore: show complete config in _debug

### DIFF
--- a/.changeset/weak-windows-draw.md
+++ b/.changeset/weak-windows-draw.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/server': patch
+---
+
+chore: show complete config in \_debug

--- a/packages/server/express/src/debug/index.ts
+++ b/packages/server/express/src/debug/index.ts
@@ -1,8 +1,10 @@
 import { Application } from 'express';
 
+import { Config as IConfig } from '@verdaccio/types';
+
 import { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '../../types/custom';
 
-export default (app: Application, configPath?: string): void => {
+export default (app: Application, config: IConfig): void => {
   // Hook for tests only
   app.get(
     '/-/_debug',
@@ -15,7 +17,7 @@ export default (app: Application, configPath?: string): void => {
         pid: process.pid,
         // @ts-ignore
         main: process.main,
-        conf: configPath,
+        config,
         mem: process.memoryUsage(),
         gc: global.gc,
       });

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -60,7 +60,8 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<Ex
   );
 
   // Hook for tests only
-  if (config._debug) {
+  if (config._debug && app.get('env') !== 'production') {
+    logger.warn('debug hook is active and might reveal sensitive configuration data');
     hookDebug(app, config);
   }
 

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -61,7 +61,7 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<Ex
 
   // Hook for tests only
   if (config._debug) {
-    hookDebug(app, config.configPath);
+    hookDebug(app, config);
   }
 
   const plugins: pluginUtils.ExpressMiddleware<IConfig, {}, Auth>[] = await asyncLoadPlugin(

--- a/packages/server/express/test/server.spec.ts
+++ b/packages/server/express/test/server.spec.ts
@@ -117,4 +117,15 @@ describe('server api', () => {
     expect(res.body.mem).toBeDefined();
     expect(res.body.config).toBeDefined();
   });
+
+  test('should not display debug hook in production', async () => {
+    const node_env = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const app = await initializeServer('conf.yaml');
+    await supertest(app)
+      .get('/-/_debug')
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.NOT_FOUND);
+    process.env.NODE_ENV = node_env;
+  });
 });

--- a/packages/server/express/test/server.spec.ts
+++ b/packages/server/express/test/server.spec.ts
@@ -107,7 +107,7 @@ describe('server api', () => {
       .expect(HTTP_STATUS.NOT_FOUND);
   });
 
-  test('should  display debug hook if directly enabled', async () => {
+  test('should display debug hook if directly enabled', async () => {
     const app = await initializeServer('conf.yaml');
     const res = await supertest(app)
       .get('/-/_debug')
@@ -115,5 +115,6 @@ describe('server api', () => {
       .expect(HTTP_STATUS.OK);
     expect(res.body.pid).toEqual(process.pid);
     expect(res.body.mem).toBeDefined();
+    expect(res.body.config).toBeDefined();
   });
 });


### PR DESCRIPTION
Allows to see full config of a running server (obviously not for production)