### PR TITLE
chore(api): fix void return for some tests

### DIFF
--- a/.changeset/stupid-camels-build.md
+++ b/.changeset/stupid-camels-build.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/api': patch
+---
+
+chore(api): fix void return for some tests

--- a/packages/api/test/integration/package.spec.ts
+++ b/packages/api/test/integration/package.spec.ts
@@ -31,12 +31,13 @@ describe('package', () => {
       ['@scope/foo2', 'foo2-1.0.0.tgz'],
     ])('should fails if tarball does not exist', async (pkg, fileName) => {
       await publishVersion(app, pkg, '1.0.1');
-      return await supertest(app)
+      await supertest(app)
         .get(`/${pkg}/-/${fileName}`)
         .set(HEADERS.ACCEPT, HEADERS.JSON)
         .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.OCTET_STREAM)
         .expect(HTTP_STATUS.NOT_FOUND);
     });
+
     test.todo('check content length file header');
     test.todo('fails on file was aborted');
   });

--- a/packages/api/test/integration/publish.spec.ts
+++ b/packages/api/test/integration/publish.spec.ts
@@ -57,7 +57,7 @@ describe('publish', () => {
       async (pkgName) => {
         const app = await initializeServer('publish.yaml');
         await publishVersion(app, pkgName, '1.0.0');
-        return new Promise((resolve) => {
+        new Promise((resolve) => {
           publishVersion(app, pkgName, '1.0.0')
             .expect(HTTP_STATUS.CONFLICT)
             .then((response) => {
@@ -73,7 +73,7 @@ describe('publish', () => {
     describe('no proxies setup', () => {
       test.each([['foo', '@scope/foo']])('should publish a package', async (pkgName) => {
         const app = await initializeServer('publish.yaml');
-        return new Promise((resolve) => {
+        new Promise((resolve) => {
           publishVersion(app, pkgName, '1.0.0')
             .expect(HTTP_STATUS.CREATED)
             .then((response) => {
@@ -86,7 +86,7 @@ describe('publish', () => {
       test.each([['foo', '@scope/foo']])('should publish a new package', async (pkgName) => {
         const pkgMetadata = generatePackageMetadata(pkgName, '1.0.0');
         const app = await initializeServer('publish.yaml');
-        return new Promise((resolve) => {
+        new Promise((resolve) => {
           supertest(app)
             .put(`/${encodeURIComponent(pkgName)}`)
             .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)

--- a/packages/api/test/integration/star.spec.ts
+++ b/packages/api/test/integration/star.spec.ts
@@ -65,7 +65,7 @@ describe('star', () => {
     const app = await initializeServer('star.yaml');
     const token = await getNewToken(app, { name: userLogged, password: 'secretPass' });
     await publishVersion(app, pkgName, '1.0.0', undefined, token).expect(HTTP_STATUS.CREATED);
-    return supertest(app)
+    await supertest(app)
       .get(`/-/_view/starredByUser?key_xxxxx=other`)
       .set('Accept', HEADERS.JSON)
       .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)


### PR DESCRIPTION
Fixes tests that have void return like this:

`Argument of type 'Response' is not assignable to parameter of type 'void | PromiseLike<void>'.`
