### PR TITLE
chore(core): typing, naming, and docs of parameters

### DIFF
--- a/.changeset/curvy-rockets-camp.md
+++ b/.changeset/curvy-rockets-camp.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/core': patch
+---
+
+chore(core): typing, naming, and docs of parameters


### PR DESCRIPTION
This should make it easier to understand the plugin interfaces:

- No functional changes
- Grouping of types/interfaces by plugin category
- Added some comments and links to docs
- Consistent naming of parameters
- Replace `any` type