### PR TITLE
fix(middleware): allow content-type with charset

### DIFF
--- a/.changeset/fifty-falcons-design.md
+++ b/.changeset/fifty-falcons-design.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/middleware': patch
+---
+
+fix(middleware): allow content-type with charset

--- a/packages/middleware/src/middlewares/media.ts
+++ b/packages/middleware/src/middlewares/media.ts
@@ -4,7 +4,18 @@ import { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '../types';
 
 export function media(expect: string | null): any {
   return function (req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer): void {
-    if (req.headers[HEADER_TYPE.CONTENT_TYPE] !== expect) {
+    const header = req.headers[HEADER_TYPE.CONTENT_TYPE];
+    if (!header) {
+      next(
+        errorUtils.getCode(
+          HTTP_STATUS.UNSUPPORTED_MEDIA,
+          'content-type is missing, expect: ' + expect
+        )
+      );
+      return;
+    }
+
+    if (typeof header !== 'string' || header.split(';')[0].trim() !== expect) {
       next(
         errorUtils.getCode(
           HTTP_STATUS.UNSUPPORTED_MEDIA,

--- a/packages/middleware/test/media.spec.ts
+++ b/packages/middleware/test/media.spec.ts
@@ -20,6 +20,19 @@ test('media is json', async () => {
     .expect(200);
 });
 
+test('media is json with charset', async () => {
+  const app = getApp([]);
+  app.get('/json', media(mime.getType('json')), (req, res) => {
+    res.status(200).json();
+  });
+
+  return request(app)
+    .get('/json')
+    .set(HEADERS.CONTENT_TYPE, 'application/json; charset=utf-8')
+    .expect('Content-Type', /json/)
+    .expect(200);
+});
+
 test('media is not json', async () => {
   const app = getApp([]);
   app.get('/json', media(mime.getType('json')), (req, res) => {

--- a/packages/middleware/test/media.spec.ts
+++ b/packages/middleware/test/media.spec.ts
@@ -45,3 +45,12 @@ test('media is not json', async () => {
     .expect('Content-Type', /html/)
     .expect(HTTP_STATUS.UNSUPPORTED_MEDIA);
 });
+
+test('missing content-type', async () => {
+  const app = getApp([]);
+  app.get('/json', media(mime.getType('json')), (req, res) => {
+    res.status(HTTP_STATUS.OK).json({});
+  });
+
+  return request(app).get('/json').expect(HTTP_STATUS.UNSUPPORTED_MEDIA);
+});


### PR DESCRIPTION
Avoid errors when using `"Content-type: application/json; charset=utf-8"` 
(instead of just `"Content-type: application/json"`)