### PR TITLE
chore(logger): avoid message if level remains the same

### DIFF
--- a/.changeset/clean-beds-wash.md
+++ b/.changeset/clean-beds-wash.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/logger-commons': patch
+---
+
+chore(logger): avoid message if level remains the same

--- a/packages/logger/logger-commons/src/logger.ts
+++ b/packages/logger/logger-commons/src/logger.ts
@@ -93,7 +93,10 @@ export function createLogger(
   /* eslint-disable */
   /* istanbul ignore next */
   if (process.env.DEBUG) {
-    logger.on('level-change', (lvl, val, prevLvl, prevVal) => {
+    logger.on('level-change', (lvl, val, prevLvl, prevVal, instance) => {
+      if (logger !== instance) {
+        return;
+      }
       debug('%s (%d) was changed to %s (%d)', lvl, val, prevLvl, prevVal);
     });
   }


### PR DESCRIPTION
This avoids getting debug messages like `"http (25) was changed to http (25)"`

Ref: https://getpino.io/#/docs/api?id=event-39level-change39