### PR TITLE
feat(ui-components): update hover background color of package list

### DIFF
--- a/.changeset/real-seahorses-change.md
+++ b/.changeset/real-seahorses-change.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': minor
+---
+
+update hover background color of package list

--- a/packages/ui-components/src/components/Package/styles.ts
+++ b/packages/ui-components/src/components/Package/styles.ts
@@ -71,8 +71,7 @@ export const GridRightAligned = styled(Grid)({
 
 export const Wrapper = styled(List)<{ theme?: Theme }>(({ theme }) => ({
   '&:hover': {
-    backgroundColor:
-      theme.palette.mode == 'dark' ? theme.palette.secondary.main : theme.palette.greyLight2,
+    backgroundColor: theme.palette.action.hover,
   },
 }));
 


### PR DESCRIPTION
This color was fixed in #4687 and looks too dark.
Use the original hover color defined in [@mui/material](https://github.com/mui/material-ui/blob/v5.16.5/packages/mui-material/src/styles/createPalette.js#L36)

Old:
![Snipaste_2024-12-23_14-17-48](https://github.com/user-attachments/assets/d41d1b95-53fc-4068-bef9-cd7bbe9f4142)
![Snipaste_2024-12-23_14-47-45](https://github.com/user-attachments/assets/f8f4bc98-4f6e-432c-8df4-cd594a18d752)

New:
![Snipaste_2024-12-23_14-46-44](https://github.com/user-attachments/assets/2480d90a-05ab-4f6d-8ce2-9697eb602357)
![Snipaste_2024-12-23_14-47-12](https://github.com/user-attachments/assets/01b24c58-4828-4f40-9ee3-009930457ffb)
