### PR TITLE
Introducing Verdaccio Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Google Cloud Storage** or create your own plugin.
 [![docker pulls](https://img.shields.io/docker/pulls/verdaccio/verdaccio.svg?maxAge=43200)](https://verdaccio.org/docs/en/docker.html)
 [![backers](https://opencollective.com/verdaccio/tiers/backer/badge.svg?label=Backer&color=brightgreen)](https://opencollective.com/verdaccio)
 [![stackshare](https://img.shields.io/badge/Follow%20on-StackShare-blue.svg?logo=stackshare&style=flat)](https://stackshare.io/verdaccio)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Verdaccio%20Guru-006BFF)](https://gurubase.io/g/verdaccio)
 
 [![discord](https://img.shields.io/discord/388674437219745793.svg)](http://chat.verdaccio.org/)
 [![MIT](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/verdaccio/verdaccio/blob/master/LICENSE)


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Verdaccio Guru](https://gurubase.io/g/verdaccio) has been manually added to Gurubase. Verdaccio Guru uses the data from this repo and data from the [docs](https://verdaccio.org) to answer questions by leveraging the LLM.

This PR introduces the "Verdaccio Guru", showcasing that Verdaccio now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Verdaccio Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Verdaccio documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Verdaccio Guru in Gurubase, just let us know that's totally fine.
