### PR TITLE
chore: bump user agent

### DIFF
--- a/.changeset/eleven-rocks-dream.md
+++ b/.changeset/eleven-rocks-dream.md
@@ -1,0 +1,5 @@
+---
+'verdaccio': patch
+---
+
+chore: bump user agent

--- a/packages/verdaccio/package.json
+++ b/packages/verdaccio/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "clean": "rimraf ./build",
     "lint": "eslint . --ext .js,.ts",
-    "test": "vitest run --testTimeout 50000",
+    "test": "vitest run --testTimeout 50000 --hookTimeout 20000",
     "ge:docs": "typedoc src/index.ts --tsconfig tsconfig.build.json --plugin typedoc-plugin-markdown",
     "type-check": "tsc --noEmit -p tsconfig.build.json",
     "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",

--- a/packages/verdaccio/src/server/request.ts
+++ b/packages/verdaccio/src/server/request.ts
@@ -139,7 +139,7 @@ export class ServerQuery {
   public constructor(url) {
     this.url = url.replace(/\/$/, '');
     debug('server url %s', this.url);
-    this.userAgent = 'node/v14.1.2 linux x64';
+    this.userAgent = 'node/v22.13.0 linux x64';
   }
 
   private request(options: any): Promise<ResponseAssert> {


### PR DESCRIPTION
- Updates user agent to a recent node version.
- Increased hooktimeout (to make it run on slower Windows)

Closes #4947