### PR TITLE
fix: runtime dependency missing as explicit dependency

### DIFF
--- a/.changeset/ninety-geese-do.md
+++ b/.changeset/ninety-geese-do.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/config': patch
+---
+
+fix: runtime dependency missing as explicit dependency

--- a/packages/signature/package.json
+++ b/packages/signature/package.json
@@ -38,11 +38,11 @@
     "build": "pnpm run build:js && pnpm run build:types"
   },
   "dependencies": {
+    "@verdaccio/config": "workspace:8.0.0-next-8.9",
     "jsonwebtoken": "9.0.2",
     "debug": "4.4.0"
   },
   "devDependencies": {
-    "@verdaccio/config": "workspace:8.0.0-next-8.9",
     "@verdaccio/types": "workspace:13.0.0-next-8.3"
   },
   "funding": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1610,6 +1610,9 @@ importers:
 
   packages/signature:
     dependencies:
+      '@verdaccio/config':
+        specifier: workspace:8.0.0-next-8.9
+        version: link:../config
       debug:
         specifier: 4.4.0
         version: 4.4.0(supports-color@5.5.0)
@@ -1617,9 +1620,6 @@ importers:
         specifier: 9.0.2
         version: 9.0.2
     devDependencies:
-      '@verdaccio/config':
-        specifier: workspace:8.0.0-next-8.9
-        version: link:../config
       '@verdaccio/types':
         specifier: workspace:13.0.0-next-8.3
         version: link:../core/types


### PR DESCRIPTION
Currently, when `@verdaccio/signature` is loaded, in particular the `signature.js` file, th
 `@verdaccio/config` module is being loaded but it's not an explicit dependency. 

It's just a dev dependency. This is problematic with e.g. pnpm as package manager which
intentionally tries to prevent such "leaking"/"escaping" of dependencies.