### PR TITLE
fix(ui-components): typings for vitest/jest-dom

### DIFF
--- a/.changeset/quick-avocados-type.md
+++ b/.changeset/quick-avocados-type.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+fix(ui-components): typings for vitest/jest-dom

--- a/packages/ui-components/tsconfig.build.json
+++ b/packages/ui-components/tsconfig.build.json
@@ -10,10 +10,10 @@
     "rootDir": ".",
     "outDir": "./build",
     "skipLibCheck": true,
-    "jsx": "react"
+    "jsx": "react",
+    "types": ["node", "@testing-library/jest-dom"]
   },
   "include": ["src/**/*", "./src/types/index.d.ts"],
-  "types": ["node", "@testing-library/jest-dom"],
   "typedocOptions": {
     "categoryOrder": ["Model", "Component", "Provider", "*"],
     "defaultCategory": "Component",

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -10,9 +10,10 @@
     "outDir": "./build",
     "preserveSymlinks": true,
     "jsx": "react",
-    "allowJs": true
+    "allowJs": true,
+    "types": ["node", "jest", "@testing-library/jest-dom"]
   },
-  "types": ["node", "jest", "@testing-library/jest-dom"],
+  "include": ["src/**/*", "vitest/**/*"],
   "references": [
     {
       "path": "../core/types"

--- a/packages/ui-components/vitest.config.mjs
+++ b/packages/ui-components/vitest.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest/setup.ts', './vitest/setup-env.ts'],
-    exclude: ['node_modules', './build/'],
+    exclude: ['**/node_modules/**', '**/build/**'],
     snapshotFormat: {
       escapeString: true,
       printBasicPrototype: true,
@@ -22,7 +22,7 @@ export default defineConfig({
       '\\.(jpg)$': './vitest/unit/empty.ts',
       '\\.(md)$': './vitest/unit/empty-string.ts',
     },
-    testTimeout: 15000,
+    testTimeout: 20000,
   },
   plugins: [
     react({

--- a/packages/ui-components/vitest/server-handlers.ts
+++ b/packages/ui-components/vitest/server-handlers.ts
@@ -3,10 +3,17 @@ import { HttpResponse, http } from 'msw';
 import path from 'path';
 
 export const handlers = [
+  // Home
   http.get('http://localhost:9000/-/verdaccio/data/packages', () => {
     return HttpResponse.json(Array(400).fill(require('./api/home-packages.json')));
   }),
 
+  // Search
+  http.get('http://localhost:9000/-/verdaccio/data/search/*', () => {
+    return HttpResponse.json(require('./api/search-verdaccio.json'));
+  }),
+
+  // Storybook
   http.get('http://localhost:9000/-/verdaccio/data/sidebar/storybook', ({ params }) => {
     const { v } = params;
     if (v) {
@@ -15,18 +22,19 @@ export const handlers = [
       return HttpResponse.json(require('./api/storybook-sidebar.json'));
     }
   }),
-
-  http.get('http://localhost:9000/-/verdaccio/data/search/*', () => {
-    return HttpResponse.json(require('./api/search-verdaccio.json'));
-  }),
-
   http.get('http://localhost:9000/-/verdaccio/data/package/readme/storybook', () => {
     return HttpResponse.text(require('./api/storybook-readme')());
   }),
 
+  // JQuery (with complete Readme)
   http.get('http://localhost:9000/-/verdaccio/data/sidebar/jquery', () => {
     return HttpResponse.json(require('./api/jquery-sidebar.json'));
   }),
+  http.get('http://localhost:9000/-/verdaccio/data/package/readme/jquery', () => {
+    return HttpResponse.text(require('./api/jquery-readme')());
+  }),
+
+  // Sidebar Errors
   http.get('http://localhost:9000/-/verdaccio/data/sidebar/JSONStream', () => {
     return new HttpResponse('unauthorized', { status: 401 });
   }),
@@ -36,21 +44,24 @@ export const handlers = [
   http.get('http://localhost:9000/-/verdaccio/data/sidebar/kleur', () => {
     return new HttpResponse('not found', { status: 404 });
   }),
+
+  // Glob
   http.get('http://localhost:9000/-/verdaccio/data/sidebar/glob', () => {
     return HttpResponse.json(require('./api/glob-sidebar.json'));
   }),
   http.get('http://localhost:9000/-/verdaccio/data/package/readme/glob', () => {
     return HttpResponse.text('foo glob');
   }),
+
+  // Got
   http.get('http://localhost:9000/-/verdaccio/data/sidebar/got', () => {
     return HttpResponse.json(require('./api/got-sidebar.json'));
   }),
   http.get('http://localhost:9000/-/verdaccio/data/package/readme/got', () => {
     return HttpResponse.text('foo got');
   }),
-  http.get('http://localhost:9000/-/verdaccio/data/package/readme/jquery', () => {
-    return HttpResponse.text(require('./api/jquery-readme')());
-  }),
+
+  // Tarball Download
   http.get('http://localhost:9000/verdaccio/-/verdaccio-1.0.0.tgz', () => {
     const fileName = path.resolve(__dirname, './api/verdaccio-1.0.0.tgz');
     const fileContent = fs.readFileSync(fileName);
@@ -60,6 +71,7 @@ export const handlers = [
     });
   }),
 
+  // Login
   http.post<{ username: string; password: string }, { token: string; username: string }>(
     'http://localhost:9000/-/verdaccio/sec/login',
     async ({ request }) => {

--- a/packages/ui-components/vitest/setup-env.ts
+++ b/packages/ui-components/vitest/setup-env.ts
@@ -1,3 +1,4 @@
+// / <reference path="./testing-library.d.ts" />
 import '@testing-library/jest-dom';
 import 'whatwg-fetch';
 

--- a/packages/ui-components/vitest/setup.ts
+++ b/packages/ui-components/vitest/setup.ts
@@ -1,3 +1,5 @@
+// / <reference path="./testing-library.d.ts" />
+
 /**
  * Setup configuration for Jest
  * This file includes global settings for the JEST environment.

--- a/packages/ui-components/vitest/testing-library.d.ts
+++ b/packages/ui-components/vitest/testing-library.d.ts
@@ -1,0 +1,29 @@
+import '@testing-library/jest-dom';
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeInTheDocument(): R;
+      toHaveTextContent(text: string | RegExp): R;
+      toBeVisible(): R;
+      toBeDisabled(): R;
+      toBeEnabled(): R;
+      toHaveAttribute(attr: string, value?: string): R;
+      toHaveClass(className: string): R;
+      toHaveFocus(): R;
+      toBeChecked(): R;
+      toBeEmpty(): R;
+      toBeEmptyDOMElement(): R;
+      toBeInvalid(): R;
+      toBeRequired(): R;
+      toBeValid(): R;
+      toContainElement(element: HTMLElement | null): R;
+      toContainHTML(htmlText: string): R;
+      toHaveStyle(css: string | object): R;
+      toHaveValue(value?: string | string[] | number): R;
+    }
+  }
+}
+
+// Make the file a module
+export {};


### PR DESCRIPTION
Error in VSC occur because TypeScript doesn't recognize the custom matchers provided by `@testing-library/jest-dom`, such as `toBeInTheDocument()`. 

TypeScript doesn't automatically recognize these custom matchers because the type definitions aren't being properly extended.

- Create declaration file `testing-library.d.ts` that extends Jest's matcher interface with all the custom matchers from `@testing-library/jest-dom`.
- Added references to this declaration file in Vitest setup files.

Updated `tsconfig.json`:
- Move the "types" array inside compilerOptions (it was incorrectly placed at the root level)
- Add an "include" section to ensure TypeScript processes your Vitest directory
- Exclude "build" sub-folders (it was running tests in build/.../*.js files)

PS: `server-handler.ts` is just re-order + some comments