### PR TITLE
fix(web): anonymous user handling

### DIFF
--- a/.changeset/dirty-moles-smash.md
+++ b/.changeset/dirty-moles-smash.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/web': patch
+---
+
+fix(web): "??" operator warning

--- a/.changeset/dirty-moles-smash.md
+++ b/.changeset/dirty-moles-smash.md
@@ -1,5 +1,0 @@
----
-'@verdaccio/web': patch
----
-
-fix(web): "??" operator warning

--- a/.changeset/proud-houses-switch.md
+++ b/.changeset/proud-houses-switch.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/web': patch
+---
+
+fix(web): anonymous user handling

--- a/packages/web/src/api/package.ts
+++ b/packages/web/src/api/package.ts
@@ -22,7 +22,7 @@ const getOrder = (order = 'asc') => {
 const debug = buildDebug('verdaccio:web:api:package');
 
 function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router {
-  const isLoginEnabled = config?.web?.login === true ?? true;
+  const isLoginEnabled = config?.web?.login === true;
   const pkgRouter = Router(); /* eslint new-cap: 0 */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const anonymousRemoteUser: RemoteUser = {

--- a/packages/web/src/api/package.ts
+++ b/packages/web/src/api/package.ts
@@ -3,6 +3,7 @@ import { Router } from 'express';
 import _ from 'lodash';
 
 import { Auth } from '@verdaccio/auth';
+import { createAnonymousRemoteUser } from '@verdaccio/config';
 import { logger } from '@verdaccio/logger';
 import { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '@verdaccio/middleware';
 import { WebUrls } from '@verdaccio/middleware';
@@ -24,21 +25,15 @@ const debug = buildDebug('verdaccio:web:api:package');
 function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router {
   const isLoginEnabled = config?.web?.login === true;
   const pkgRouter = Router(); /* eslint new-cap: 0 */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const anonymousRemoteUser: RemoteUser = {
-    name: undefined,
-    real_groups: [],
-    groups: [],
-  };
+  const anonymousRemoteUser: RemoteUser = createAnonymousRemoteUser();
 
   debug('initialized package web api');
   const checkAllow = (name: string, remoteUser: RemoteUser): Promise<boolean> =>
     new Promise((resolve, reject): void => {
-      debug('is login disabled %o', isLoginEnabled);
-      // FIXME: this logic does not work, review
-      // const remoteUserAccess = !isLoginEnabled ? anonymousRemoteUser : remoteUser;
+      debug('is login enabled: %o', isLoginEnabled);
+      const remoteUserAccess = !isLoginEnabled ? anonymousRemoteUser : remoteUser;
       try {
-        auth.allow_access({ packageName: name }, remoteUser, (err, allowed): void => {
+        auth.allow_access({ packageName: name }, remoteUserAccess, (err, allowed): void => {
           if (err) {
             resolve(false);
           }

--- a/packages/web/test/api.packages.test.ts
+++ b/packages/web/test/api.packages.test.ts
@@ -33,4 +33,58 @@ describe('test web server', () => {
       .expect(HTTP_STATUS.OK);
     expect(response.body).toEqual([]);
   });
+
+  test('should allow anonymous user to access package api when login is disabled', async () => {
+    mockManifest.mockReturnValue(() => ({
+      staticPath: path.join(__dirname, 'static'),
+      manifestFiles: {
+        js: ['runtime.js', 'vendors.js', 'main.js'],
+      },
+      manifest: require('./partials/manifest/manifest.json'),
+    }));
+
+    const response = await supertest(await initializeServer('login-disabled.yaml'))
+      .get('/-/verdaccio/data/packages')
+      .set('Accept', HEADERS.JSON_CHARSET)
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.OK);
+
+    expect(response.body).toEqual([]);
+  });
+
+  test('should allow authenticated user to access package api', async () => {
+    mockManifest.mockReturnValue(() => ({
+      staticPath: path.join(__dirname, 'static'),
+      manifestFiles: {
+        js: ['runtime.js', 'vendors.js', 'main.js'],
+      },
+      manifest: require('./partials/manifest/manifest.json'),
+    }));
+
+    const api = supertest(await initializeServer('default-test.yaml'));
+
+    // First login to get the token
+    const loginRes = await api
+      .post('/-/verdaccio/sec/login')
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .send(
+        JSON.stringify({
+          username: 'test',
+          password: 'test',
+        })
+      )
+      .expect(HTTP_STATUS.OK);
+
+    expect(loginRes.body.token).toBeDefined();
+
+    // Then access the packages API with the token
+    const response = await api
+      .get('/-/verdaccio/data/packages')
+      .set('Accept', HEADERS.JSON_CHARSET)
+      .set(HEADER_TYPE.AUTHORIZATION, `Bearer ${loginRes.body.token}`)
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.OK);
+
+    expect(response.body).toEqual([]);
+  });
 });


### PR DESCRIPTION
Fix "??" operator warning and handling of anonymous user:

```bash
2025-03-01T16:38:50.5417412Z packages/web test: 4:38:50 PM [vite] warning: The "??" operator here will always return the left operand
2025-03-01T16:38:50.5422632Z packages/web test: 23 |  
2025-03-01T16:38:50.5423679Z packages/web test: 24 |  function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router {
2025-03-01T16:38:50.5424943Z packages/web test: 25 |    const isLoginEnabled = config?.web?.login === true ?? true;
...
// FIXME: this logic does not work, review
// const remoteUserAccess = !isLoginEnabled ? anonymousRemoteUser : remoteUser;
```

