### PR TITLE
fix: internal error for unpublished tarball

### DIFF
--- a/.changeset/forty-hounds-matter.md
+++ b/.changeset/forty-hounds-matter.md
@@ -1,0 +1,7 @@
+---
+'verdaccio': patch
+'@verdaccio/store': patch
+'@verdaccio/utils': patch
+---
+
+fix: internal error for unpublished tarball

--- a/packages/store/src/lib/versions-utils.ts
+++ b/packages/store/src/lib/versions-utils.ts
@@ -41,19 +41,15 @@ export function getVersion(versions: Versions, version: string): Version | undef
  * @return {Array} sorted Array
  */
 export function sortVersionsAndFilterInvalid(listVersions: string[] /* logger */): string[] {
-  return (
-    listVersions
-      .filter(function (version): boolean {
-        if (!semver.parse(version, true)) {
-          return false;
-        }
-        return true;
-      })
-      // FIXME: it seems the @types/semver do not handle a legitimate method named 'compareLoose'
-      // @ts-ignore
-      .sort(semver.compareLoose)
-      .map(String)
-  );
+  return listVersions
+    .filter(function (version): boolean {
+      if (!semver.parse(version, true)) {
+        return false;
+      }
+      return true;
+    })
+    .sort(semver.compareLoose)
+    .map(String);
 }
 
 /**

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -366,7 +366,7 @@ class Storage {
       const [updatedManifest] = await this.syncUplinksMetadata(name, cachedManifest, {
         uplinksLook: true,
       });
-      const distFile = (updatedManifest as Manifest)._distfiles[filename];
+      const distFile = (updatedManifest as Manifest)?._distfiles?.[filename];
 
       if (updatedManifest === null || !distFile) {
         debug('remote tarball not found');

--- a/packages/utils/src/utils.ts
+++ b/packages/utils/src/utils.ts
@@ -235,8 +235,6 @@ export function normalizeContributors(contributors: Author[]): Author[] {
   if (_.isNil(contributors)) {
     return [];
   } else if (contributors && _.isArray(contributors) === false) {
-    // FIXME: this branch is clearly no an array, still tsc complains
-    // @ts-ignore
     return [contributors];
   } else if (_.isString(contributors)) {
     return [

--- a/packages/verdaccio/test/basic.spec.ts
+++ b/packages/verdaccio/test/basic.spec.ts
@@ -50,10 +50,9 @@ describe('basic test endpoints', () => {
       (await server.getPackage('unpublish-new-package')).status(HTTP_STATUS.OK);
       (await server.removePackage('unpublish-new-package', '_rev')).status(HTTP_STATUS.CREATED);
       (await server.getPackage('unpublish-new-package')).status(HTTP_STATUS.NOT_FOUND);
-      // FIXME: throws 500 instead 404
-      // (await server.getTarball('unpublish-new-package', 'unpublish-new-package-1.0.0.tgz')).status(
-      //   HTTP_STATUS.NOT_FOUND
-      // );
+      (await server.getTarball('unpublish-new-package', 'unpublish-new-package-1.0.0.tgz')).status(
+        HTTP_STATUS.NOT_FOUND
+      );
     });
   });
 });


### PR DESCRIPTION
Trying to download a tarball that did not exist locally nor in any uplink was resulting in an `internal error (500)`. This was caused by accessing `_distfiles` when there was manifest returned (undefined). It now returns correctly `not found (404)`.

I also removed a couple ts-ignore that are not necessary anymore. 

-3x FIXME 😃 