### PR TITLE
chore: add package parameter to storage plugin interface

### DIFF
--- a/.changeset/violet-bobcats-allow.md
+++ b/.changeset/violet-bobcats-allow.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/core': patch
+'@verdaccio/store': patch
+---
+
+chore: add package parameter to storage plugin interface

--- a/packages/core/core/src/plugin-utils.ts
+++ b/packages/core/core/src/plugin-utils.ts
@@ -51,7 +51,7 @@ export class Plugin<PluginConfig> {
 export interface StorageHandler {
   logger: Logger;
   deletePackage(fileName: string): Promise<void>;
-  removePackage(): Promise<void>;
+  removePackage(packageName: string): Promise<void>;
   //  next packages migration (this list is meant to replace the callback parent functions)
   updatePackage(
     packageName: string,
@@ -65,7 +65,7 @@ export interface StorageHandler {
   // verify if tarball exist in the storage
   hasTarball(fileName: string): Promise<boolean>;
   // verify if package exist in the storage
-  hasPackage(): Promise<boolean>;
+  hasPackage(packageName: string): Promise<boolean>;
 }
 
 /**

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -813,7 +813,7 @@ class Storage {
       await storage.deletePackage(STORAGE.PACKAGE_FILE_NAME);
       // remove folder
       debug('remove package folder');
-      await storage.removePackage();
+      await storage.removePackage(pkgName);
       this.logger.info({ pkgName }, 'package @{pkgName} removed');
     } catch (err: any) {
       this.logger.error({ err }, 'removed package has failed: @{err.message}');
@@ -1123,7 +1123,7 @@ class Storage {
     if (typeof storage === 'undefined') {
       throw errorUtils.getNotFound();
     }
-    const hasPackage = await storage.hasPackage();
+    const hasPackage = await storage.hasPackage(pkgName);
     debug('has package %o for %o', pkgName, hasPackage);
     return hasPackage;
   }


### PR DESCRIPTION
Avoid side effects between storage plugin `constructor` and `removePackage`/`hasPackage` calls.