### PR TITLE
chore: package.json maintenance

### DIFF
--- a/.changeset/pink-jeans-lick.md
+++ b/.changeset/pink-jeans-lick.md
@@ -1,0 +1,42 @@
+---
+'generator-verdaccio-plugin': patch
+'@verdaccio/logger-prettify': patch
+'@verdaccio/logger-commons': patch
+'@verdaccio/local-storage': patch
+'@verdaccio/local-publish': patch
+'@verdaccio/local-scripts': patch
+'@verdaccio/file-locking': patch
+'verdaccio-htpasswd': patch
+'@verdaccio/ui-theme': patch
+'verdaccio-memory': patch
+'@verdaccio/search-indexer': patch
+'@verdaccio/server': patch
+'@verdaccio/server-fastify': patch
+'@verdaccio/logger': patch
+'@verdaccio/test-helper': patch
+'@verdaccio/ui-components': patch
+'@verdaccio/tarball': patch
+'@verdaccio/eslint-config': patch
+'@verdaccio/types': patch
+'@verdaccio/middleware': patch
+'@verdaccio/cli-standalone': patch
+'@verdaccio/core': patch
+'@verdaccio/ui-i18n': patch
+'@verdaccio/signature': patch
+'verdaccio': patch
+'@verdaccio/url': patch
+'@verdaccio/node-api': patch
+'@verdaccio/loaders': patch
+'@verdaccio/config': patch
+'@verdaccio/search': patch
+'@verdaccio/hooks': patch
+'@verdaccio/proxy': patch
+'@verdaccio/store': patch
+'@verdaccio/utils': patch
+'@verdaccio/auth': patch
+'@verdaccio/api': patch
+'@verdaccio/cli': patch
+'@verdaccio/web': patch
+---
+
+chore: package.json maintenance

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/api",
   "version": "8.1.0-next-8.12",
-  "description": "loaders logic",
+  "description": "Verdaccio Registry API",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/api"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "homepage": "https://verdaccio.org",
   "keywords": [

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/auth",
   "version": "8.0.0-next-8.12",
-  "description": "logger",
+  "description": "Verdaccio Authentication",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/auth"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "homepage": "https://verdaccio.org",
   "keywords": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,7 +11,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "homepage": "https://verdaccio.org",
   "keywords": [
@@ -28,7 +32,7 @@
   "engines": {
     "node": ">=18"
   },
-  "description": "verdaccio CLI",
+  "description": "Verdaccio CLI",
   "license": "MIT",
   "main": "./build/index.js",
   "types": "build/index.d.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/config",
   "version": "8.0.0-next-8.12",
-  "description": "logger",
+  "description": "Verdaccio Configuration",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/config"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/core",
   "version": "8.0.0-next-8.12",
-  "description": "core utilities",
+  "description": "Verdaccio Core Components",
   "keywords": [
     "private",
     "package",

--- a/packages/core/file-locking/package.json
+++ b/packages/core/file-locking/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/file-locking",
   "version": "13.0.0-next-8.2",
-  "description": "library that handle file locking",
+  "description": "Verdaccio File Locking Library",
   "keywords": [
     "private",
     "package",

--- a/packages/core/i18n/package.json
+++ b/packages/core/i18n/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/ui-i18n",
   "version": "8.0.0-next-8.11",
-  "description": "ui i18n",
+  "description": "Verdaccio UI Internationalization (i18n)",
   "keywords": [
     "private",
     "package",
@@ -24,7 +24,7 @@
   "repository": {
     "type": "https",
     "url": "https://github.com/verdaccio/verdaccio",
-    "directory": "packages/core/url-resolver"
+    "directory": "packages/core/i18n"
   },
   "bugs": {
     "url": "https://github.com/verdaccio/verdaccio/issues"

--- a/packages/core/tarball/package.json
+++ b/packages/core/tarball/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/tarball",
   "version": "13.0.0-next-8.12",
-  "description": "tarball utilities resolver",
+  "description": "Verdaccio Tarball Utilities",
   "keywords": [
     "private",
     "package",

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/types",
   "version": "13.0.0-next-8.3",
-  "description": "verdaccio types definitions",
+  "description": "Verdaccio Type Definitions",
   "keywords": [
     "private",
     "package",

--- a/packages/core/url/package.json
+++ b/packages/core/url/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/url",
   "version": "13.0.0-next-8.12",
-  "description": "url utilities resolver",
+  "description": "Verdaccio URL Utilities",
   "keywords": [
     "private",
     "package",
@@ -24,7 +24,7 @@
   "repository": {
     "type": "https",
     "url": "https://github.com/verdaccio/verdaccio",
-    "directory": "packages/core/url-resolver"
+    "directory": "packages/core/url"
   },
   "bugs": {
     "url": "https://github.com/verdaccio/verdaccio/issues"

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/hooks",
   "version": "8.0.0-next-8.12",
-  "description": "loaders logic",
+  "description": "Verdaccio Hooks",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/hooks"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/loaders",
   "version": "8.0.0-next-8.4",
-  "description": "loaders logic",
+  "description": "Verdaccio Loader Logic",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/loaders"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "dependencies": {
     "debug": "4.4.0",

--- a/packages/logger/logger-commons/package.json
+++ b/packages/logger/logger-commons/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/logger-commons",
   "version": "8.0.0-next-8.12",
-  "description": "logger",
+  "description": "Verdaccio Logger Commons",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/logger/logger-commons"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/logger/logger-prettify/package.json
+++ b/packages/logger/logger-prettify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/logger-prettify",
   "version": "8.0.0-next-8.1",
-  "description": "logger",
+  "description": "Verdaccio Logger Prettify",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/logger/logger-prettify"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/logger/logger/package.json
+++ b/packages/logger/logger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/logger",
   "version": "8.0.0-next-8.12",
-  "description": "logger",
+  "description": "Verdaccio Logger",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/logger/logger"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/middleware",
   "version": "8.0.0-next-8.12",
-  "description": "express middleware utils",
+  "description": "Verdaccio Express Middleware",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/middleware"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/node-api",
   "version": "8.0.0-next-8.12",
-  "description": "node API",
+  "description": "Verdaccio Node API",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/node-api"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "homepage": "https://verdaccio.org",
   "keywords": [

--- a/packages/plugins/active-directory/package.json
+++ b/packages/plugins/active-directory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/active-directory",
   "version": "11.0.0-6-next.8",
-  "description": "Active Directory authentication plugin for Verdaccio",
+  "description": "Active Directory Authentication Plugin for Verdaccio",
   "keywords": [
     "private",
     "package",

--- a/packages/plugins/htpasswd/package.json
+++ b/packages/plugins/htpasswd/package.json
@@ -1,7 +1,7 @@
 {
   "name": "verdaccio-htpasswd",
   "version": "13.0.0-next-8.12",
-  "description": "htpasswd auth plugin for Verdaccio",
+  "description": "Htpasswd Authentication Plugin for Verdaccio",
   "keywords": [
     "private",
     "package",
@@ -19,7 +19,7 @@
   "repository": {
     "type": "https",
     "url": "https://github.com/verdaccio/verdaccio",
-    "directory": "packages/core/htpasswd"
+    "directory": "packages/plugins/htpasswd"
   },
   "bugs": {
     "url": "https://github.com/verdaccio/verdaccio/issues"

--- a/packages/plugins/local-storage/package.json
+++ b/packages/plugins/local-storage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/local-storage",
   "version": "13.0.0-next-8.12",
-  "description": "Local storage implementation",
+  "description": "Verdaccio Local Storage Plugin",
   "keywords": [
     "private",
     "package",
@@ -19,7 +19,7 @@
   "repository": {
     "type": "https",
     "url": "https://github.com/verdaccio/verdaccio",
-    "directory": "packages/core/local-storage"
+    "directory": "packages/plugins/local-storage"
   },
   "bugs": {
     "url": "https://github.com/verdaccio/verdaccio/issues"

--- a/packages/plugins/memory/package.json
+++ b/packages/plugins/memory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "verdaccio-memory",
   "version": "13.0.0-next-8.12",
-  "description": "Storage implementation in memory",
+  "description": "Verdaccio Memory Storage Plugin",
   "keywords": [
     "private",
     "package",

--- a/packages/plugins/ui-theme/package.json
+++ b/packages/plugins/ui-theme/package.json
@@ -1,14 +1,18 @@
 {
   "name": "@verdaccio/ui-theme",
   "version": "8.0.0-next-8.12",
-  "description": "Verdaccio User Interface",
+  "description": "Verdaccio User Interface (Theme)",
   "author": {
     "name": "Verdaccio Contributors",
     "email": "verdaccio.npm@gmail.com"
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/plugins/ui-theme"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "homepage": "https://verdaccio.org",
   "main": "index.js",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/proxy",
   "version": "8.0.0-next-8.12",
-  "description": "verdaccio proxy fetcher",
+  "description": "Verdaccio Proxy Fetcher",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/proxy"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/search-indexer/package.json
+++ b/packages/search-indexer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/search-indexer",
   "version": "8.0.0-next-8.2",
-  "description": "verdaccio search indexer",
+  "description": "Verdaccio Search Indexer",
   "main": "./build/dist.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/search-indexer"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/search",
   "version": "8.0.0-next-8.12",
-  "description": "verdaccio search proxy",
+  "description": "Verdaccio Search Proxy",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/search"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/server/express/package.json
+++ b/packages/server/express/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/server",
   "version": "8.0.0-next-8.12",
-  "description": "server logic",
+  "description": "Verdaccio Express Server",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/server/express"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/server/fastify/package.json
+++ b/packages/server/fastify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/server-fastify",
   "version": "8.0.0-next-8.12",
-  "description": "fastify server api implementation",
+  "description": "Verdaccio Fastify Server",
   "keywords": [
     "private",
     "package",
@@ -24,7 +24,7 @@
   "repository": {
     "type": "https",
     "url": "https://github.com/verdaccio/verdaccio",
-    "directory": "packages/core/streams"
+    "directory": "packages/server/fastify"
   },
   "bugs": {
     "url": "https://github.com/verdaccio/verdaccio/issues"

--- a/packages/signature/package.json
+++ b/packages/signature/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/signature",
   "version": "8.0.0-next-8.4",
-  "description": "verdaccio signature utils",
+  "description": "Verdaccio Signature Utilities",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/signature"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/cli-standalone",
   "version": "8.0.0-next-8.0",
-  "description": "standalone verdaccio registry with no dependencies",
+  "description": "Standalone Verdaccio Registry without Dependencies",
   "main": "dist/bundle.js",
   "bin": {
     "verdaccio": "./dist/bundle.js"
@@ -27,7 +27,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/standalone"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "homepage": "https://verdaccio.org",
   "license": "MIT",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/store",
   "version": "8.0.0-next-8.12",
-  "description": "loaders logic",
+  "description": "Verdaccio Storage",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/store"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/tools/eslint/package.json
+++ b/packages/tools/eslint/package.json
@@ -2,7 +2,7 @@
   "name": "@verdaccio/eslint-config",
   "version": "4.0.0-next-8.0",
   "private": "true",
-  "description": "verdaccio eslint config",
+  "description": "Verdaccio ESLint Configuration",
   "main": "src/index.js",
   "scripts": {
     "lint": "eslint . --ext .js"
@@ -27,8 +27,16 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/tools/eslint"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "homepage": "https://verdaccio.org",
-  "license": "MIT"
+  "license": "MIT",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/verdaccio"
+  }
 }

--- a/packages/tools/generator-verdaccio-plugin/package.json
+++ b/packages/tools/generator-verdaccio-plugin/package.json
@@ -1,8 +1,8 @@
 {
   "name": "generator-verdaccio-plugin",
   "version": "6.0.0-next-8.12",
-  "description": "plugin generator for verdaccio",
-  "homepage": "https://github.com/verdaccio",
+  "description": "Plugin Generator for Verdaccio",
+  "homepage": "https://verdaccio.org",
   "author": {
     "name": "Juan Picado <@jotadeveloper>",
     "email": "juanpicado19@gmail.com",
@@ -32,11 +32,15 @@
     "yeoman-test": "6.3.0"
   },
   "engines": {
-    "node": ">18.0.0"
+    "node": ">=18"
   },
   "repository": {
-    "type": "git",
-    "url": "git://github.com/verdaccio/generator-verdaccio-plugin"
+    "type": "https",
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/tools/generator-verdaccio-plugin"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "scripts": {
     "type-check": "tsc --noEmit -p tsconfig.build.json",
@@ -46,5 +50,9 @@
     "test:new": "vitest run --pool=forks",
     "lint": "eslint  --max-warnings 0 \"**/*.{js,ts}\""
   },
-  "license": "MIT"
+  "license": "MIT",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/verdaccio"
+  }
 }

--- a/packages/tools/helpers/package.json
+++ b/packages/tools/helpers/package.json
@@ -2,7 +2,7 @@
   "name": "@verdaccio/test-helper",
   "version": "4.0.0-next-8.3",
   "private": true,
-  "description": "test helpers",
+  "description": "Verdaccio Test Helpers",
   "author": "Juan Picado <juanpicado19@gmail.com>",
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/tools/local-publish/package.json
+++ b/packages/tools/local-publish/package.json
@@ -2,7 +2,7 @@
   "name": "@verdaccio/local-publish",
   "version": "0.0.2",
   "private": true,
-  "description": "trigger server for local development",
+  "description": "Trigger Server for Local Development",
   "author": "Juan Picado <juanpicado19@gmail.com>",
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/tools/local-scripts/package.json
+++ b/packages/tools/local-scripts/package.json
@@ -5,7 +5,7 @@
     "local-crowdin-api": "./index.js"
   },
   "private": "true",
-  "description": "update translations percentage for website data",
+  "description": "Update Translations Percentage for Website Data",
   "main": "./build/index.js",
   "scripts": {
     "build": "babel src/ --out-dir build/ --copy-files --extensions \".ts,.tsx\" --source-maps",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/ui-components",
   "version": "4.0.0-next-8.6",
-  "description": "theme ui component",
+  "description": "Verdaccio UI Components",
   "author": "Juan Picado <juanpicado19@gmail.com>",
   "license": "MIT",
   "homepage": "https://verdaccio.org",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@verdaccio/utils",
   "version": "8.1.0-next-8.12",
-  "description": "verdaccio utilities",
+  "description": "Verdaccio Utilities",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "author": {
@@ -10,7 +10,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/utils"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "license": "MIT",
   "homepage": "https://verdaccio.org",
@@ -26,7 +30,7 @@
     "verdaccio"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=18"
   },
   "dependencies": {
     "@verdaccio/core": "workspace:8.0.0-next-8.12",

--- a/packages/verdaccio/package.json
+++ b/packages/verdaccio/package.json
@@ -33,7 +33,11 @@
   },
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/verdaccio"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "homepage": "https://verdaccio.org",
   "dependencies": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@verdaccio/web",
   "version": "8.1.0-next-8.12",
-  "description": "web ui middleware",
+  "description": "Verdaccio Web Middleware",
   "main": "./build/index.js",
   "types": "build/index.d.ts",
   "repository": {
     "type": "https",
-    "url": "https://github.com/verdaccio/verdaccio"
+    "url": "https://github.com/verdaccio/verdaccio",
+    "directory": "packages/web"
+  },
+  "bugs": {
+    "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "keywords": [
     "private",


### PR DESCRIPTION
I updated the following fields: `description`, `repository.directory`,  `bugs`, `funding`, and `homepage` and fixed a couple `node` min versions to match the rest. This helps AI tools to get a better understanding of the monorepo.