### PR TITLE
fix: warnings when building website

### DIFF
--- a/website/blog/2018-09-06-verdaccio-and-deterministic-lock-files.md
+++ b/website/blog/2018-09-06-verdaccio-and-deterministic-lock-files.md
@@ -1,6 +1,5 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: Verdaccio and deterministic lock files
 ---
 
@@ -30,7 +29,7 @@ The snippet above is just a small part of this huge file which nobody dares to d
 
 #### Simple example with Verdaccio as localhost {#simple-example-with-verdaccio-as-localhost}
 
-Let’s imagine you are using **Verdaccio** and **yarn** for local purposes and your registry configuration points to.
+Let's imagine you are using **Verdaccio** and **yarn** for local purposes and your registry configuration points to.
 
 ```
 yarn config set registry http://localhost:4873/
@@ -48,13 +47,13 @@ math-random@^1.0.1:
  resolved "[http://localhost:4873/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac](http://localhost:4873/math-random/-/math-random-1.0.1.tgz#8b3aac588b8a66e4975e3cdea67f7bb329601fac)"
 ```
 
-Let’s imagine you that might want to change your domain where your registry is hosted and the resolved field still points to the previous location and your package manager won’t be able to resolve the project dependencies anymore.
+Let's imagine you that might want to change your domain where your registry is hosted and the resolved field still points to the previous location and your package manager won't be able to resolve the project dependencies anymore.
 
 **A usual solution is to delete the whole lock file and generate a new one** , but, this is not practical for large teams since will drive you to conflicts between branch hard to solve.
 
-So, _How can I use a private registry avoiding the_ _resolved field issue?_. All clients handle this issue in a different way, let’s see how they do it.
+So, _How can I use a private registry avoiding the_ _resolved field issue?_. All clients handle this issue in a different way, let's see how they do it.
 
-### How does the resolved field is being used by …? {#how-does-the-resolved-field-is-being-used-by-}
+### How does the resolved field is being used by ...? {#how-does-the-resolved-field-is-being-used-by-}
 
 ![](https://cdn-images-1.medium.com/max/1024/1*kafHawK1RCt-LDsdGz6iUA.png)
 
@@ -67,7 +66,7 @@ import { Tweet } from "react-twitter-widgets"
   align: 'center'
 }} />
 
-Nowadays you can use the npm cli with lock file safely with Verdaccio independently the URL where tarball was served. But, I’d recommend to share a local .npmrc file with the registry set by default locally or notify your team about it.
+Nowadays you can use the npm cli with lock file safely with Verdaccio independently the URL where tarball was served. But, I'd recommend to share a local .npmrc file with the registry set by default locally or notify your team about it.
 
 ![](https://cdn-images-1.medium.com/max/1024/1*0pWUcgRyhax5KVJKsnbgkA.png)
 
@@ -113,9 +112,9 @@ specifiers:
 
 The example above is just a small snippet of how this long file looks like and you might observe that there is a field called [registry](https://github.com/pnpm/spec/blob/master/shrinkwrap/3.8.md#registry) added at the bottom of the lock file which [was introduced to reduce the file size of the lock file](https://github.com/pnpm/pnpm/issues/1072), in some scenarios pnpm decides to set [the domain is part of the tarball field](https://github.com/josephschmitt/pnpm-406-npmE).
 
-**pnpm** will try to fetch dependencies using the registry defined within the lockfile as yarn **does**. However, as a workaround, if the domain changes you must update the registry field manually, it’s not hard to do but, is better than nothing.
+**pnpm** will try to fetch dependencies using the registry defined within the lockfile as yarn **does**. However, as a workaround, if the domain changes you must update the registry field manually, it's not hard to do but, is better than nothing.
 
-pnpm has already opened a ticket to drive this issue, I’ll let below the link to it.
+pnpm has already opened a ticket to drive this issue, I'll let below the link to it.
 
 [Remove the "registry" field from "shrinkwrap.yaml" · Issue #1353 · pnpm/pnpm](https://github.com/pnpm/pnpm/issues/1353)
 
@@ -130,7 +129,7 @@ registry=[https://registry.npmjs.org](https://registry.npmjs.org/)
 
 > It does exist any support for at the time of this writing.
 
-In my opinion, this is just a workaround, which depends on the number or scopes you handle to decide whether or not worth it. Furthermore, the package manager will bypass those packages that do not match with the scope and won’t be resolved by your private registry.
+In my opinion, this is just a workaround, which depends on the number or scopes you handle to decide whether or not worth it. Furthermore, the package manager will bypass those packages that do not match with the scope and won't be resolved by your private registry.
 
 ### Conclusion {#conclusion}
 

--- a/website/blog/2018-10-21-verdaccio-4-alpha-release.md
+++ b/website/blog/2018-10-21-verdaccio-4-alpha-release.md
@@ -1,6 +1,5 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: Verdaccio 4 alpha release
 ---
 

--- a/website/blog/2018-11-19-setting-up-verdaccio-on-digitalocean.md
+++ b/website/blog/2018-11-19-setting-up-verdaccio-on-digitalocean.md
@@ -1,12 +1,11 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: Setting up Verdaccio on DigitalOcean
 ---
 
 This one of the multiple articles I will write about running Verdaccio on multiple platforms.
 
-This time for simplicity I’ve chosen [DigitalOcean](https://www.digitalocean.com/) that provides affordable base prices and if you want to run your own registry, it’s a good option.
+This time for simplicity I've chosen [DigitalOcean](https://www.digitalocean.com/) that provides affordable base prices and if you want to run your own registry, it's a good option.
 
 <!--truncate-->
 
@@ -18,7 +17,7 @@ Create a droplet is fairly easy, it just matters to choose an image and click on
 
 ![](https://cdn-images-1.medium.com/max/1024/1*V1GIMttiMPYuX8FLKuumRg.png)<figcaption>A view of the droplet panel</figcaption>
 
-While the droplet is created, which takes a matter of seconds the next step is to find a way to log in via SSH, you can find credentials in your email. _Keep on mind the droplet provides root access and the next steps I won’t use sudo_.
+While the droplet is created, which takes a matter of seconds the next step is to find a way to log in via SSH, you can find credentials in your email. _Keep on mind the droplet provides root access and the next steps I won't use sudo_.
 
 ### Installing Requirements {#installing-requirements}
 
@@ -28,7 +27,7 @@ As first step we have to install [Verdaccio](https://verdaccio.org/) with the fo
 npm install --global verdaccio
 ```
 
-> We will use npm for simplicity, but I’d recommend using other tools as [pnpm](https://pnpm.js.org/) or [yarn](https://yarnpkg.com/en/).
+> We will use npm for simplicity, but I'd recommend using other tools as [pnpm](https://pnpm.js.org/) or [yarn](https://yarnpkg.com/en/).
 
 We will handle the **verdaccio** process using the _pm2_ tool that provides handy tools for restarting and monitoring.
 
@@ -38,7 +37,7 @@ npm install -g pm2
 
 #### Nginx Configuration {#nginx-configuration}
 
-To handle the request we will set up _ngnix_ which is really easy to install. I won’t include in this article all steps to setup the web but you can [follow this article](https://www.digitalocean.com/community/tutorials/how-to-install-nginx-on-ubuntu-16-04).
+To handle the request we will set up _ngnix_ which is really easy to install. I won't include in this article all steps to setup the web but you can [follow this article](https://www.digitalocean.com/community/tutorials/how-to-install-nginx-on-ubuntu-16-04).
 
 Once _nginx_ is running in the port 80, we have to modify lightly the configuration file as follow
 

--- a/website/blog/2019-02-08-the-crazy-story-of-verdaccio.md
+++ b/website/blog/2019-02-08-the-crazy-story-of-verdaccio.md
@@ -1,12 +1,11 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: The crazy story of Verdaccio
 ---
 
-It’s not the first time that I’ve heard the following expression “Thanks for creating Verdaccio”, which actually flatters me, but is really hard to explain in a couple of words that **I haven’t created Verdaccio**. Perhaps I might be responsible for what is Verdaccio today, but that is a different story. Today I’d like to share the whole story behind this project and how I ended up working on it.
+It's not the first time that I've heard the following expression "Thanks for creating Verdaccio", which actually flatters me, but is really hard to explain in a couple of words that **I haven't created Verdaccio**. Perhaps I might be responsible for what is Verdaccio today, but that is a different story. Today I'd like to share the whole story behind this project and how I ended up working on it.
 
-### Sinopia “The Origin” {#sinopia-the-origin}
+### Sinopia "The Origin" {#sinopia-the-origin}
 
 A few years ago in 2013, the main registry _(npmjs)_ was running for a while and at the same time, [Alex Kocharin](https://github.com/rlidwka) decided to create Sinopia.
 
@@ -31,16 +30,16 @@ It was clear the project was growing, but something happened in **October 2015**
 
 Early 2016 [the Sinopia community started to wonder](https://github.com/rlidwka/sinopia/issues/376) why so that such good idea with good support just stopped for no reason.
 
-A few months later forks did not take long to appear. The most prominent forks were the following _(I’m aware there were much more than these)_:
+A few months later forks did not take long to appear. The most prominent forks were the following _(I'm aware there were much more than these)_:
 
 ![](https://cdn-images-1.medium.com/max/700/1*AlByG_WIbkxp6W9OH0JYzQ.png)
 
 - [**Sinopia2**](https://github.com/fl4re/sinopia): Maybe the most affordable and updated fork which seems to be intended with the idea to merge some [PR were in the queue](https://github.com/rlidwka/sinopia/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+dead#issuecomment-197239368). Still, today seems on having some development but no further new features.
 - [**shimmerjs/sinopia**](https://github.com/shimmerjs/sinopia): A try from IBM team contributors to provide sinopia with CouchDB support. They did a couple of releases but no much development since the fork _(this idea was a PR at Verdaccio for a long time but never was merged)_.
 - [**npm-register**](https://github.com/jdxcode/npm-register): A inspired sinopia fork but created from scratch focused as to be hosted on PaaS services.
-- **verdaccio** : And here is where all started, the 0 km started on 5 April 2016 which the “baptism” by [**cuzzinz**](https://github.com/cuzzinz) suggesting the name that he read on Wikipedia.
+- **verdaccio** : And here is where all started, the 0 km started on 5 April 2016 which the "baptism" by [**cuzzinz**](https://github.com/cuzzinz) suggesting the name that he read on Wikipedia.
 
-> Since it will be a fork, follow the subject the original project used but a new “color.” …. verdaccio
+> Since it will be a fork, follow the subject the original project used but a new "color." .... verdaccio
 
 ### Verdaccio as fork {#verdaccio-as-fork}
 
@@ -56,7 +55,7 @@ Originally the project was just another fork but soon started to receive the upd
 
 During the _fall of 2016_ and beginning of 2017, we noticed more adoption and bug reports, but in February 2017 **the original authors gave me the ownership of Verdaccio** just before v2.1.1 release and they have stepped away of development and currently are just watcher. Nowadays I still feel super happy and grateful for the opportunity to drive this project.
 
-> As a side note, in that time, my experience with Node.js was not far away from beginner level even if I had good JS background (I’m a front-end developer until today in my private work experience), I’ve never had the chance to work with Node.js in any workplace, funny huh 😅?. What I learnt about real Node.js development is 100% due Verdaccio and reading open source code.
+> As a side note, in that time, my experience with Node.js was not far away from beginner level even if I had good JS background (I'm a front-end developer until today in my private work experience), I've never had the chance to work with Node.js in any workplace, funny huh 😅?. What I learnt about real Node.js development is 100% due Verdaccio and reading open source code.
 
 During early **2017** the project had only ~600 stars and I started to coordinate new contributions and a progressive migration to a modern codebase. I have to highlight the new ideas [Meeeeow](https://github.com/Meeeeow) that brought to the project as semantic commits, the new UI based on React and other interesting things.
 
@@ -70,7 +69,7 @@ When you fork a project GitHub **reduces the visibility on Google and Github sea
 
 By that time, Docker was new for me until I saw the first time the Dockerfile and was getting so many tickets related with such topic that forced me to learn really quick to be able to merge contributions which were Chinese for me, what did I do?. **Go to Docker meetups and read books. Problem solved.** Thankfully the community has a lot of knowledge to share in this area thus I had the opportunity to learn from amazing contributions. **Nowadays Docker is the most popular way to use Verdaccio** even over the _npm_ installation.
 
-### 2018 “the year” {#2018-the-year}
+### 2018 "the year" {#2018-the-year}
 
 ![](https://cdn-images-1.medium.com/max/804/1*77nCfVH9qaQbP1dBkAXBMg.png)<figcaption>Verdaccio overpass sinopia on stars December 2018</figcaption>
 
@@ -86,13 +85,13 @@ After some crazy months working really hard, we manage at May to [release Verdac
 
 Also, we have boarded [Sergio Herrera Guzmán](https://medium.com/u/5609d55238ab) and [Priscila Oliveira](https://medium.com/u/c1899129305b) that have demonstrated a lot of interest about Verdaccio contributing with awesome features as the new release pipeline and the new UI which will be released in 2019. **The project currently has ~150 contributors and we are welcoming the new ones with open arms**.
 
-I’ve seen [written articles about Verdaccio in multiple languages](https://github.com/verdaccio/verdaccio/wiki#articles), [conference speakers recommending](https://youtu.be/q4XmAy6_ucw) the usage of Verdaccio, generous [donations](https://opencollective.com/verdaccio) and our [chat](http://chat.verdaccio.org/) at Discord more active than ever.
+I've seen [written articles about Verdaccio in multiple languages](https://github.com/verdaccio/verdaccio/wiki#articles), [conference speakers recommending](https://youtu.be/q4XmAy6_ucw) the usage of Verdaccio, generous [donations](https://opencollective.com/verdaccio) and our [chat](http://chat.verdaccio.org/) at Discord more active than ever.
 
 To finish the story and ending 2018 we have created what we defined as the core team, a small group of developers trying to work together in [the development of Verdaccio 4](https://dev.to/verdaccio/verdaccio-4-alpha-release-1d7p-temp-slug-4609102).
 
 ### Current Status {#current-status}
 
-If you wonder how the “governance” works at Verdaccio, we do it in the following way. **We have 4 owners** (the founders, [Juan Picado](https://medium.com/u/a6a7b0f6a9e4), [Ayush](https://medium.com/u/ffdb15785e37)) which we open communication when something important should take place and we ship an internal report every 6 months at GitHub teams threads. We have decided this structure in order to avoid what happened with Sinopia do not happen again. The development decisions are taking at the core team level based on democracy and common sense.
+If you wonder how the "governance" works at Verdaccio, we do it in the following way. **We have 4 owners** (the founders, [Juan Picado](https://medium.com/u/a6a7b0f6a9e4), [Ayush](https://medium.com/u/ffdb15785e37)) which we open communication when something important should take place and we ship an internal report every 6 months at GitHub teams threads. We have decided this structure in order to avoid what happened with Sinopia do not happen again. The development decisions are taking at the core team level based on democracy and common sense.
 
 The development communication happens over Discord and **we started to encourage code reviews and open discussions about everything**. For now, it works, but we are trying to evolve the process and improve it.
 
@@ -100,18 +99,18 @@ Currently, we are working on improving the documentation and create a clean ecos
 
 ### Wrapping Up {#wrapping-up}
 
-As you have read, Verdaccio is not a one author project. **It’s a collaboration of many developers that decided don’t let this project die**. I always like to think the following if you allow me [to quote a simile famous words of Abraham Lincoln](https://en.wikipedia.org/wiki/Gettysburg_Address)
+As you have read, Verdaccio is not a one author project. **It's a collaboration of many developers that decided don't let this project die**. I always like to think the following if you allow me [to quote a simile famous words of Abraham Lincoln](https://en.wikipedia.org/wiki/Gettysburg_Address)
 
 > Verdaccio is a project of the community, by the community and for the community.
 
-I’m driving this project today, but does not means I’ll do it forever. I like to share responsibilities with others because **nobody is working on Verdaccio full time** as it happens with other open source projects.
+I'm driving this project today, but does not means I'll do it forever. I like to share responsibilities with others because **nobody is working on Verdaccio full time** as it happens with other open source projects.
 
 **We want this project alive, updated and as reliable, open source and free option for everybody**. Following the principles of sinopia stablished as simplicity, zero configuration and with the possibility to extend it.
 
-Even if some initial developers are not contributing anymore _(all we have a life)_, I’m really grateful for the time they have invested and hoped they back in some point.
+Even if some initial developers are not contributing anymore _(all we have a life)_, I'm really grateful for the time they have invested and hoped they back in some point.
 
 ### Disclaimer {#disclaimer}
 
-I’m telling this story based on my own research and all the information collected along the latest 2 years, comments, private chats, and social networks.
+I'm telling this story based on my own research and all the information collected along the latest 2 years, comments, private chats, and social networks.
 
 ---

--- a/website/blog/2019-02-24-migrating-verdaccio.md
+++ b/website/blog/2019-02-24-migrating-verdaccio.md
@@ -1,6 +1,5 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: Verdaccio Migration Guides
 ---
 
@@ -77,40 +76,6 @@ If you are using the Docker image as base with the purpose of installing plugins
 
 In _Verdaccio 3_ was really easy to install plugins, for instance:
 
-```docker
-FROM verdaccio/verdaccio:3
-
-RUN npm i && npm install verdaccio-ldap
 ```
 
-Rather in Verdaccio 4, the image has changed considerably and now you need to deal with the right folder permissions.
-
-You can find more info about this in [this ticket](https://github.com/verdaccio/verdaccio/issues/1324).
-
-To install plugins, you need to use the right users for it, which is `root`.
-
-> ⚠️ This approach works, but perhaps is no the best one, feel free to suggest modifications.
-
-```docker
-FROM verdaccio/verdaccio:4
-
-## switch to root user
-USER root
-
-ENV NODE_ENV=production
-
-## perhaps all of this is not fully required
-RUN apk --no-cache add openssl ca-certificates wget && \
-    apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python && \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
-    apk add glibc-2.25-r0.apk
-
-
-RUN npm i && npm install verdaccio-[YOUR-PLUGIN-HERE]
-
-# switch back to the verdaccio user
-USER verdaccio
 ```
-
-Once you have installed the plugin, it needs to restore the user, either the default one `verdaccio` or the one defined under the environment variable `VERDACCIO_USER_NAME`.

--- a/website/blog/2019-02-24-migrating-verdaccio.md
+++ b/website/blog/2019-02-24-migrating-verdaccio.md
@@ -76,6 +76,40 @@ If you are using the Docker image as base with the purpose of installing plugins
 
 In _Verdaccio 3_ was really easy to install plugins, for instance:
 
+```docker
+FROM verdaccio/verdaccio:3
+
+RUN npm i && npm install verdaccio-ldap
 ```
 
+Rather in Verdaccio 4, the image has changed considerably and now you need to deal with the right folder permissions.
+
+You can find more info about this in [this ticket](https://github.com/verdaccio/verdaccio/issues/1324).
+
+To install plugins, you need to use the right users for it, which is `root`.
+
+> ⚠️ This approach works, but perhaps is no the best one, feel free to suggest modifications.
+
+```docker
+FROM verdaccio/verdaccio:4
+
+## switch to root user
+USER root
+
+ENV NODE_ENV=production
+
+## perhaps all of this is not fully required
+RUN apk --no-cache add openssl ca-certificates wget && \
+    apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python && \
+    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
+    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk && \
+    apk add glibc-2.25-r0.apk
+
+
+RUN npm i && npm install verdaccio-[YOUR-PLUGIN-HERE]
+
+# switch back to the verdaccio user
+USER verdaccio
 ```
+
+Once you have installed the plugin, it needs to restore the user, either the default one `verdaccio` or the one defined under the environment variable `VERDACCIO_USER_NAME`.

--- a/website/blog/2019-04-19-diving-into-jwt-support-for-verdaccio-4.md
+++ b/website/blog/2019-04-19-diving-into-jwt-support-for-verdaccio-4.md
@@ -1,5 +1,5 @@
 ---
-author: Juan Picado
+author: juan_picado
 authorFBID: 1122901551
 title: Diving into JWT support for Verdaccio 4
 ---
@@ -14,7 +14,7 @@ npm install -g verdaccio@next
 
 This article will explain what are the advantages of using JWT instead of the traditional or _legacy_ token signature used by Verdaccio. But before that, we need to be int he same page about ** JWT.**
 
-I’d recommend reading the following article before continue the reading.
+I'd recommend reading the following article before continue the reading.
 
 [5 Easy Steps to Understanding JSON Web Tokens (JWT)](https://medium.com/vandium-software/5-easy-steps-to-understanding-json-web-tokens-jwt-1164c0adfcec)
 

--- a/website/blog/2019-05-13-the-new-docker-image-verdaccio-4.md
+++ b/website/blog/2019-05-13-the-new-docker-image-verdaccio-4.md
@@ -1,6 +1,5 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: The new Docker image for Verdaccio 4
 ---
 
@@ -8,7 +7,7 @@ Docker has been a key part of success for Verdaccio. At the time of this writing
 
 This article will describe what has changed, all the improvements and benefits you will enjoy from migrating to the latest version.
 
-## What’s new? {#whats-new}
+## What's new? {#whats-new}
 
 ### Keep it small {#keep-it-small}
 
@@ -32,7 +31,7 @@ To avoid mistakes we have renamed all environment variables to be prefixed with 
 
 The previous image runs the container with the verdaccio user and group by default, being the UID created randomly within the image. Some users were experiencing issues since some environments require the usage of custom user IDs for security reasons. To support this, we have introduced the environment variable `VERDACCIO_USER_ID`.
 
-Furthermore, other optimizations can be possible, as for instance, define a different username using `VERDACCIO_USER_NAME` and such user won’t have permissions to log in by default.
+Furthermore, other optimizations can be possible, as for instance, define a different username using `VERDACCIO_USER_NAME` and such user won't have permissions to log in by default.
 
 ### Security {#security}
 

--- a/website/blog/2019-05-19-15-verdaccio-4-release.md
+++ b/website/blog/2019-05-19-15-verdaccio-4-release.md
@@ -1,7 +1,5 @@
 ---
-author: Ayush Sharma
-authorURL: https://twitter.com/ayusharma_
-authorFBID: 100001655957183
+author: ayush_sharma
 title: Verdaccio 4 released !!!
 ---
 
@@ -35,7 +33,7 @@ You can find detailed installation instructions [here](https://verdaccio.org/doc
 
 ## Why 'Freedom' ? {#why-freedom-}
 
-Verdaccio originated from [Sinopia](https://github.com/rlidwka/sinopia) almost three years ago and since then the [Verdaccio Team](https://verdaccio.org/en/team) maintaining and releasing major release every year. Since the fork, the project has evolved in many ways, making the project’s code base modern, easier to debug and more straightforward to contribute.
+Verdaccio originated from [Sinopia](https://github.com/rlidwka/sinopia) almost three years ago and since then the [Verdaccio Team](https://verdaccio.org/en/team) maintaining and releasing major release every year. Since the fork, the project has evolved in many ways, making the project's code base modern, easier to debug and more straightforward to contribute.
 
 The name Freedom holds true meaning for Verdaccio@4.x release. Verdaccio is a strong community of many contributors and developers from across the world, providing an ideal platform for everyone to give control of their code. Also, Verdaccio@4.x is free from tech debt of legacy code and stands on design patterns of the modern era which consist [React](https://reactjs.org/), [Typescript](https://www.typescriptlang.org/), [JWT](https://jwt.io/), [Docker](https://www.docker.com/) & [Kubernetes](https://kubernetes.io/). We can call it Freedom in true sense.
 

--- a/website/blog/2019-07-08-verdaccio-410-release.md
+++ b/website/blog/2019-07-08-verdaccio-410-release.md
@@ -1,6 +1,5 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: Release 4.1.0
 ---
 

--- a/website/blog/2019-07-30-verdaccio-420-release.md
+++ b/website/blog/2019-07-30-verdaccio-420-release.md
@@ -1,6 +1,5 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: Release 4.2.0
 ---
 

--- a/website/blog/2019-09-07-managing-multiples-projects-with-lerna-and-yarn-workspaces.md
+++ b/website/blog/2019-09-07-managing-multiples-projects-with-lerna-and-yarn-workspaces.md
@@ -1,6 +1,6 @@
 ---
 title: Managing multiples projects with Lerna and Yarn Workspaces
-author: Sergio Herrera
+author: sergio_herrera
 authorURL: https://github.com/sergiohgz
 authorImageURL: https://avatars3.githubusercontent.com/u/14012309
 authorTwitter: sergiohgz

--- a/website/blog/2019-09-30-verdaccio-430-release.md
+++ b/website/blog/2019-09-30-verdaccio-430-release.md
@@ -1,5 +1,5 @@
 ---
-author: Juan Picado
+author: juan_picado
 authorFBID: 1122901551
 title: Release 4.3.0
 ---

--- a/website/blog/2019-10-05-verdaccio-4-with-ldap-and-docker.md
+++ b/website/blog/2019-10-05-verdaccio-4-with-ldap-and-docker.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade from v3.x to verdaccio 4.x with LDAP and Docker
-author: Dimitri Kopriwa
+author: dimitri_kopriwa
 authorURL: https://twitter.com/DimitriKopriwa
 authorImageURL: https://avatars1.githubusercontent.com/u/1866564?s=460&v=4
 authorTwitter: DimitriKopriwa

--- a/website/blog/2021-04-14-verdaccio-5-migration-guide.md
+++ b/website/blog/2021-04-14-verdaccio-5-migration-guide.md
@@ -1,10 +1,11 @@
 ---
-author: Juan Picado
-authorFBID: 1122901551
+author: juan_picado
 title: Verdaccio 5 migration guidelines
 ---
 
 **Verdaccio 5** will introduce a few breaking changes, either way the migration should be light for the most of the users, here the big details.
+
+<!--truncate-->
 
 # Node.js requirements
 

--- a/website/blog/authors.yml
+++ b/website/blog/authors.yml
@@ -1,0 +1,42 @@
+juan_picado:
+  name: Juan Picado
+  title: Core Maintainer
+  url: https://github.com/juanpicado
+  image_url: https://github.com/juanpicado.png
+  socials:
+    bluesky: jotadeveloper.bsky.social
+    github: juanpicado
+
+ayush_sharma:
+  name: Ayush Sharma
+  title: Core Maintainer
+  url: https://github.com/ayusharma
+  image_url: https://github.com/ayusharma.png
+  socials:
+    x: ayusharma_
+    github: ayusharma
+
+sergio_herrera:
+  name: Sergio Herrera Guzmán
+  title: Contributor
+  url: https://github.com/sergiohgz
+  image_url: https://github.com/sergiohgz.png
+  socials:
+    github: sergiohgz
+
+priscila_oliveira:
+  name: Priscila Oliveira
+  title: Contributor
+  url: https://github.com/priscilawebdev
+  image_url: https://github.com/priscilawebdev.png
+  socials:
+    github: priscilawebdev
+
+dimitri_kopriwa:
+  name: Dimitri Kopriwa
+  title: Contributor
+  url: https://twitter.com/DimitriKopriwa
+  image_url: https://github.com/DimitriKopriwa.png
+  socials:
+    x: DimitriKopriwa
+    github: DimitriKopriwa

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -356,6 +356,7 @@ module.exports = {
           },
           blogSidebarCount: 'ALL',
           blogSidebarTitle: 'All our posts',
+          authorsMapPath: 'authors.yml',
           editUrl: ({ locale, blogDirPath, blogPath }) => {
             if (locale !== 'en') {
               return `https://crowdin.com/project/verdaccio/${locale}`;


### PR DESCRIPTION
- Create `authors.yml`
- Add truncation markers
- Replace non-ascii quotes

```
[WARNING] Some blog authors used in "2021-04-14-verdaccio-5-migration-guide.md" are not defined in "authors.yml":
- {"name":"Juan Picado","key":null,"page":null}

Note that we recommend to declare authors once in a "authors.yml" file and reference them by key in blog posts front matter to avoid author info duplication.
But if you want to allow inline blog authors, you can disable this message by setting onInlineAuthors: 'ignore' in your blog plugin options.
More info at https://docusaurus.io/docs/blog

[WARNING] Docusaurus found blog posts without truncation markers:
- "blog/2021-04-14-verdaccio-5-migration-guide.md"
```