### PR TITLE
chore(ui): flags import and minor updates

### DIFF
--- a/.changeset/nice-garlics-tie.md
+++ b/.changeset/nice-garlics-tie.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/ui-theme': patch
+'@verdaccio/ui-components': patch
+---
+
+chore(ui): flags import and minor updates

--- a/packages/plugins/ui-theme/src/App/App.tsx
+++ b/packages/plugins/ui-theme/src/App/App.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable react/jsx-max-depth */
 import styled from '@emotion/styled';
 import Box from '@mui/material/Box';
-import FlagsIcon from 'country-flag-icons/react/3x2';
+import * as FlagsIcon from 'country-flag-icons/react/3x2';
 import React, { StrictMode, Suspense, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';

--- a/packages/plugins/ui-theme/src/components/Contributors/Contributors.tsx
+++ b/packages/plugins/ui-theme/src/components/Contributors/Contributors.tsx
@@ -11,7 +11,7 @@ const Contributors: React.FC = () => {
   return (
     <>
       <Link href={`https://verdaccio.org/contributors`} rel="noreferrer" target="_blank">
-        <AvatarGroup max={18} spacing={15} total={400}>
+        <AvatarGroup max={11} spacing={15} total={400}>
           {contributors?.map(({ username, id }) => {
             return (
               <div key={username}>

--- a/packages/plugins/ui-theme/src/components/about.md
+++ b/packages/plugins/ui-theme/src/components/about.md
@@ -3,18 +3,18 @@ you can [learn more about the project in our blog](https://verdaccio.org/blog/20
 
 #### Useful links
 
-- [Installation](https://verdaccio.org/docs/en/installation)
+- [Installation](https://verdaccio.org/docs/installation)
 - [Translate](https://translate.verdaccio.org/)
-- [Best practices](https://verdaccio.org/docs/best)
-- [Security policy](https://github.com/verdaccio/verdaccio/security/policy)
-- [Sponsor via open collective](https://opencollective.com/verdaccio)
+- [Best Practices](https://verdaccio.org/docs/best)
+- [Security Policy](https://github.com/verdaccio/verdaccio/security/policy)
+- [Sponsor via Open Collective](https://opencollective.com/verdaccio)
 - [Sponsor via GitHub](https://github.com/sponsors/verdaccio)
 
 #### How to connect
 
 - [Discussions](https://github.com/verdaccio/verdaccio/discussions)
-- [YouTube channel](https://www.youtube.com/channel/UC5i20v6o7lSjXzAHOvatt0w)
-- [Discord chat](https://discord.gg/hv42jfs)
+- [YouTube Channel](https://www.youtube.com/channel/UC5i20v6o7lSjXzAHOvatt0w)
+- [Discord Chat](https://discord.gg/hv42jfs)
 
 https://www.verdaccio.org
 

--- a/packages/plugins/ui-theme/src/components/license.md
+++ b/packages/plugins/ui-theme/src/components/license.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Verdaccio contributors
+Copyright (c) 2025 Verdaccio contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/plugins/ui-theme/src/i18n/enabledLanguages.ts
+++ b/packages/plugins/ui-theme/src/i18n/enabledLanguages.ts
@@ -1,4 +1,4 @@
-import Flags from 'country-flag-icons/react/3x2';
+import * as Flags from 'country-flag-icons/react/3x2';
 
 export const DEFAULT_LANGUAGE = 'en-US';
 

--- a/packages/ui-components/src/sections/Header/RegistryInfoContent/RegistryInfoContent.tsx
+++ b/packages/ui-components/src/sections/Header/RegistryInfoContent/RegistryInfoContent.tsx
@@ -169,7 +169,7 @@ const RegistryInfoContent: FC<Props> = ({ scope, registryUrl }) => {
             expandIcon={<ExpandMoreIcon />}
             id="panel3a-header"
           >
-            {'pnpm'}
+            <Typography className={classes.heading}>{'pnpm'}</Typography>
           </AccordionSummary>
           <AccordionDetails>
             <CommandContainer data-testid={'tab-content'}>


### PR DESCRIPTION
- Fix "module has no default export" error for `country-flag-icons`
- Avoid too many avatars in "Contributors" dialog 
- Update links in "About" dialog
- Update license year to match LICENSE file
- Change `pnpm` in "RegistryInfo" dialog to bold