### PR TITLE
fix(i18n): avoid fallback for en-us

### DIFF
--- a/.changeset/twelve-games-wonder.md
+++ b/.changeset/twelve-games-wonder.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-i18n': patch
+---
+
+fix(i18n): avoid fallback for en-us

--- a/packages/core/i18n/src/index.ts
+++ b/packages/core/i18n/src/index.ts
@@ -1,1 +1,1 @@
-export { loadTranslationFile as default } from './loadTranslationFile';
+export { loadTranslationFile as default, DEFAULT_LANGUAGE } from './loadTranslationFile';

--- a/packages/core/i18n/src/loadTranslationFile.ts
+++ b/packages/core/i18n/src/loadTranslationFile.ts
@@ -1,9 +1,14 @@
+export const DEFAULT_LANGUAGE = 'en-US';
 /**
  * In development mode translations files might be not available,
  * crowdin translations are only available in CI.
  */
 export function loadTranslationFile(lng) {
   try {
+    // avoid fallback and console warning
+    if (lng === DEFAULT_LANGUAGE) {
+      return require(`./crowdin/ui.json`);
+    }
     return require(`./download_translations/${lng}/ui.json`);
   } catch {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
If language is English, load crowdin json directly.