### PR TITLE
chore: debug messages in loader

### DIFF
--- a/.changeset/red-dolls-repair.md
+++ b/.changeset/red-dolls-repair.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/loaders': patch
+---
+
+chore: debug messages in loader

--- a/packages/loaders/src/plugin-async-loader.ts
+++ b/packages/loaders/src/plugin-async-loader.ts
@@ -55,7 +55,7 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
   const { config } = pluginOptions;
   let plugins: PluginType<T>[] = [];
   for (let pluginId of pluginsIds) {
-    debug('looking for plugin %o', pluginId);
+    debug('>>> looking for plugin %o', pluginId);
     if (typeof config.plugins === 'string') {
       let pluginsPath = config.plugins;
       debug('plugin path %s', pluginsPath);
@@ -90,6 +90,7 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
             );
             continue;
           }
+          debug('>>> plugin is running and passed sanity check');
           plugins.push(plugin);
           logger.info(
             { prefix, pluginId, pluginCategory },
@@ -119,6 +120,7 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
           logger.error({ content: pluginName }, "@{content} doesn't look like a valid plugin");
           continue;
         }
+        debug('>>> plugin is running and passed sanity check');
         plugins.push(plugin);
         logger.info(
           { prefix, pluginId, pluginCategory },
@@ -134,7 +136,7 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
       }
     }
   }
-  debug('%s plugins found: %s', pluginCategory, plugins.length);
+  debug('%o plugins found: %o', pluginCategory, plugins.length);
   return plugins;
 }
 

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -28,7 +28,15 @@ export function tryLoad<T>(path: string, onError: any): PluginType<T> | null {
     return require(path) as PluginType<T>;
   } catch (err: any) {
     if (err.code === MODULE_NOT_FOUND) {
-      debug('plugin %s not found', path);
+      debug('"require" failed for plugin %s', path);
+      // If loading fails, because a dependency is missing,
+      // we want to log the error message and require stack
+      // to see where the missing dependency is.
+      const message = err.message.replace(/\\\\/g, '\\').split('\n');
+      if (!message[0].includes(path)) {
+        debug('%o', message[0]); // error message
+        debug('%o', message.slice(1)); // stack trace
+      }
       return null;
     }
     onError({ err: err.msg }, 'error loading plugin @{err}');


### PR DESCRIPTION
- Make it easier to spot plugin loads in debug log
- Add call stack to identify issues with failing plugin loads (require)