### PR TITLE
chore: fix ui-component npmignore and readme

### DIFF
--- a/.changeset/tender-buckets-smoke.md
+++ b/.changeset/tender-buckets-smoke.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+chore: fix ui-component npmignore and readme

--- a/packages/ui-components/.npmignore
+++ b/packages/ui-components/.npmignore
@@ -1,6 +1,6 @@
-.storybook
-public/
-vitest
-__partials__
-__snapshots__
-*.map
+/*
+!/bin/**/*
+!/build/**/*
+!index.js
+!LICENSE
+!README.md

--- a/packages/ui-components/README.md
+++ b/packages/ui-components/README.md
@@ -3,7 +3,7 @@
 [![Verdaccio Home](https://img.shields.io/badge/Homepage-Verdaccio-405236?style=flat)](https://verdaccio.org)
 [![MIT License](https://img.shields.io/github/license/verdaccio/verdaccio?label=License&color=405236)](https://github.com/verdaccio/verdaccio/blob/master/LICENSE)
 [![Verdaccio Latest](https://img.shields.io/npm/v/verdaccio?label=Latest%20Version&color=405236)](https://github.com/verdaccio/verdaccio)
-[![This Package Latest](https://img.shields.io/npm/v/@verdaccio/ui-components?label=@verdaccio/ui-componentscolor=405236)](https://npmjs.com/package/@verdaccio/ui-components)
+[![This Package Latest](https://img.shields.io/npm/v/@verdaccio/ui-components?label=@verdaccio/ui-components&color=405236)](https://npmjs.com/package/@verdaccio/ui-components)
 
 [![Documentation](https://img.shields.io/badge/Help-Verdaccio?style=flat&logo=Verdaccio&label=Verdaccio&color=cd4000)](https://verdaccio.org/docs)
 [![Discord](https://img.shields.io/badge/Chat-Discord?style=flat&logo=Discord&label=Discord&color=cd4000)](https://discord.com/channels/388674437219745793)


### PR DESCRIPTION
- Fix badge in readme
- Switch to `.npmignore` used in other packages