### PR TITLE
chore(api): avoid double registration of JSON bodyParser

### DIFF
--- a/.changeset/early-trainers-grin.md
+++ b/.changeset/early-trainers-grin.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/api': patch
+---
+
+chore(api): avoid double registration of JSON bodyParser


### PR DESCRIPTION
Closes #2451 

If a middleware plugin registers a JSON parser, the current api package would register another one. Such double registration would lead to worse performance or possible other side effects. 

The change avoids the second registration of a parser. It also allows the middleware plugin to use define the settings of the parser.
