### PR TITLE
fix: add legacy getMatchedPackagesSpec to config

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -64,12 +64,6 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<ex
     hookDebug(app, config.configPath);
   }
 
-  // register middleware plugins
-  const plugin_params = {
-    config: config,
-    logger: logger,
-  };
-
   const plugins: pluginUtils.ExpressMiddleware<IConfig, {}, Auth>[] = await asyncLoadPlugin(
     config.middlewares,
     {
@@ -79,6 +73,7 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<ex
     function (plugin) {
       return typeof plugin.register_middlewares !== 'undefined';
     },
+    true,
     config?.serverSettings?.pluginPrefix ?? 'verdaccio',
     PLUGIN_CATEGORY.MIDDLEWARE
   );
@@ -116,6 +111,7 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<ex
 export default (async function (configHash: any) {
   setup(configHash.logs);
   const config: IConfig = new AppConfig(_.cloneDeep(configHash));
+
   const storage = new Storage(config);
   // waits until init calls have been initialized
   await storage.init(config, []);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,7 +5,7 @@ class Config extends ConfigCore {
   public constructor(config: any) {
     config.configPath = config.self_path;
     super(config, { forceMigrateToSecureLegacySignature: false });
-    // Temporary solution for plugins that depepends of legacy configuration files
+    // Temporary solution for plugins that depends on legacy configuration files
     // @ts-ignore
     this.getMatchedPackagesSpec = getMatchedPackagesSpec;
   }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,11 +1,13 @@
-import _ from 'lodash';
-
 import { Config as ConfigCore } from '@verdaccio/config';
+import { getMatchedPackagesSpec } from '@verdaccio/utils';
 
 class Config extends ConfigCore {
   public constructor(config: any) {
     config.configPath = config.self_path;
     super(config, { forceMigrateToSecureLegacySignature: false });
+    // Temporary solution for plugins that depepends of legacy configuration files
+    // @ts-ignore
+    this.getMatchedPackagesSpec = getMatchedPackagesSpec;
   }
 }
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -81,6 +81,7 @@ class Storage {
         (plugin: pluginUtils.ManifestFilter<Config>) => {
           return typeof plugin.filter_metadata !== 'undefined';
         },
+        true,
         this.config?.serverSettings?.pluginPrefix,
         PLUGIN_CATEGORY.FILTER
       );


### PR DESCRIPTION
This pull request includes several changes to the `src/api/index.ts`, `src/lib/config.ts`, and `src/lib/storage.ts` files to improve plugin handling and configuration management. The most important changes are as follows:

### Improvements to plugin handling:

* [`src/api/index.ts`](diffhunk://#diff-764761d79ed791ea154187526b088322dba3bebe94f9d38ab22120554aba77c7L67-L72): Removed unnecessary middleware plugin registration parameters and added a boolean flag to the `asyncLoadPlugin` function call for middleware plugins. [[1]](diffhunk://#diff-764761d79ed791ea154187526b088322dba3bebe94f9d38ab22120554aba77c7L67-L72) [[2]](diffhunk://#diff-764761d79ed791ea154187526b088322dba3bebe94f9d38ab22120554aba77c7R76)
* [`src/lib/storage.ts`](diffhunk://#diff-69a5c2bf4322fa6dd3eb08beb1de557902ba44c75a00910bb25e2e46b6f35dc3R84): Added a boolean flag to the `asyncLoadPlugin` function call for manifest filters.

### Configuration management:

* [`src/lib/config.ts`](diffhunk://#diff-0b4f5977a52cef50ed20e7cdf9761795df9ee1cb3b5e5ea45edeb9394e8a47ffL1-R10): Removed unused import of `lodash` and added a temporary solution for plugins that depend on legacy configuration files by importing `getMatchedPackagesSpec` from `@verdaccio/utils`.

fix: https://github.com/verdaccio/verdaccio/issues/5160