### PR TITLE
chore: add locakstack example s3 aws plugin

### DIFF
--- a/docker-examples/v6/README.md
+++ b/docker-examples/v6/README.md
@@ -11,7 +11,7 @@
 - [Docker + Nginx + Verdaccio](proxy/reverse_proxy/nginx/README.md)
 - [Docker + Apache + Verdaccio](proxy/apache-verdaccio/README.md)
 - [Docker + HTTPS Portal + Verdaccio](proxy/https-portal-example/README.md)
-- [Docker + Localstack S3 + Verdaccio](proxy/amazon-s3-docker-example/README.md)
+- [Docker + Localstack S3 + Verdaccio](amazon-s3-docker-example/README.md)
 
 > Looking forward more examples with proxies.
 

--- a/docker-examples/v6/README.md
+++ b/docker-examples/v6/README.md
@@ -11,6 +11,7 @@
 - [Docker + Nginx + Verdaccio](proxy/reverse_proxy/nginx/README.md)
 - [Docker + Apache + Verdaccio](proxy/apache-verdaccio/README.md)
 - [Docker + HTTPS Portal + Verdaccio](proxy/https-portal-example/README.md)
+- [Docker + Localstack S3 + Verdaccio](proxy/amazon-s3-docker-example/README.md)
 
 > Looking forward more examples with proxies.
 

--- a/docker-examples/v6/amazon-s3-docker-example/README.md
+++ b/docker-examples/v6/amazon-s3-docker-example/README.md
@@ -1,0 +1,17 @@
+# Amazon S3 Bucket (Localstack) and Verdaccio 6.x
+
+This setup runs Verdaccio alongside Localstack, providing a simple test/mocking environment for
+developing cloud applications. In this case, we are simulating AWS S3 functionality.
+
+## Usage
+
+> You might need to create bucket manually here
+> aws --endpoint-url=http://localhost:4572 s3 mb s3://localstack.s3.plugin.test
+
+```
+docker-compose up --force-recreate --build --always-recreate-deps
+```
+
+## Articles
+
+- [Set up S3 bucket using Docker / Compose](https://discuss.localstack.cloud/t/set-up-s3-bucket-using-docker-compose/646.html)

--- a/docker-examples/v6/amazon-s3-docker-example/docker-compose.yaml
+++ b/docker-examples/v6/amazon-s3-docker-example/docker-compose.yaml
@@ -1,0 +1,29 @@
+version: '3.8'
+
+services:
+  localstack-s3:
+    container_name: '${LOCALSTACK_DOCKER_NAME-localstack-main}'
+    image: localstack/localstack:s3-latest
+    ports:
+      - '127.0.0.1:4566:4566'
+    volumes:
+      - './init-s3.py:/etc/localstack/init/ready.d/init-s3.py'
+  verdaccio:
+    container_name: verdaccio-s3-plugin
+    build: s3Plugin/
+    environment:
+      - DEBUG=verdaccio:*
+      - AWS_ACCESS_KEY_ID=foobar
+      - AWS_SECRET_ACCESS_KEY=foobar
+      - AWS_DEFAULT_REGION=eu-west-2
+      - AWS_S3_ENDPOINT=http://localstack-s3:4566
+      - AWS_S3_PATH_STYLE=true
+    ports:
+      - '4874:4873'
+    depends_on:
+      - localstack-s3
+    networks:
+      - default
+networks:
+  default:
+    name: verdaccio-network

--- a/docker-examples/v6/amazon-s3-docker-example/init-s3.py
+++ b/docker-examples/v6/amazon-s3-docker-example/init-s3.py
@@ -1,0 +1,10 @@
+import boto3
+
+s3_client = boto3.client(
+    "s3",
+    endpoint_url=f"http://localhost:4566",
+    aws_access_key_id="test",
+    aws_secret_access_key="test"
+)
+
+s3_client.create_bucket(Bucket="localstack.s3.plugin.test")

--- a/docker-examples/v6/amazon-s3-docker-example/localStack-resources/Dockerfile
+++ b/docker-examples/v6/amazon-s3-docker-example/localStack-resources/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.7-alpine
+
+ENV AWS_ACCESS_KEY_ID='[something]'
+ENV AWS_SECRET_ACCESS_KEY='[something]'
+ENV AWS_S3_ENDPOINT='http://localstack-s3:4572'
+
+RUN pip install awscli
+COPY entry.sh /entry.sh
+RUN chmod +x /entry.sh
+ENTRYPOINT ["/entry.sh"]

--- a/docker-examples/v6/amazon-s3-docker-example/localStack-resources/entry.sh
+++ b/docker-examples/v6/amazon-s3-docker-example/localStack-resources/entry.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+aws --endpoint-url http://localstack-s3:4572 s3 mb s3://localstack.s3.plugin.test --region eu-west-2

--- a/docker-examples/v6/amazon-s3-docker-example/s3Plugin/Dockerfile
+++ b/docker-examples/v6/amazon-s3-docker-example/s3Plugin/Dockerfile
@@ -1,0 +1,9 @@
+FROM verdaccio/verdaccio:6.x-next
+LABEL Juan Picado <jotadeveloper@gmail.com>
+# Copy the configuration file into the container
+ADD config.yaml /verdaccio/conf/config.yaml
+USER root
+# This is the best way to install a plugin in Verdaccio
+RUN npm install --global verdaccio-aws-s3-storage
+USER $VERDACCIO_USER_UID
+

--- a/docker-examples/v6/amazon-s3-docker-example/s3Plugin/config.yaml
+++ b/docker-examples/v6/amazon-s3-docker-example/s3Plugin/config.yaml
@@ -1,0 +1,27 @@
+storage: /verdaccio/storage
+
+store:
+  aws-s3-storage:
+    bucket: localstack.s3.plugin.test
+    keyPrefix: docker-test-prefix
+    region: eu-west-2
+    endpoint: http://localstack-s3:4566
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+packages:
+  '@*/*':
+    access: $all
+    publish: $all
+    proxy: npmjs
+  '**':
+    access: $all
+    publish: $all
+    proxy: npmjs
+
+log: { type: stdout, format: pretty, level: trace }
+
+listen:
+  - 0.0.0.0:4873


### PR DESCRIPTION
This pull request introduces a new example setup for running Verdaccio with Localstack to simulate AWS S3 functionality. The setup includes necessary configurations, scripts, and documentation to help users get started.

New example setup for Verdaccio with Localstack:

* [`docker-examples/v6/README.md`](diffhunk://#diff-f9153f26374f90d54aa5d853e4f470049848d88d77edb30523ec032972d8c434R14): Added a link to the new Docker + Localstack S3 + Verdaccio example.
* [`docker-examples/v6/amazon-s3-docker-example/README.md`](diffhunk://#diff-5fca6753527e8a06bf96d1a3b7b3d8c6262e35f8de447b9384d33fba91b9eec6R1-R17): Added documentation for setting up Verdaccio with Localstack S3, including usage instructions and reference articles.

Configuration and setup files:

* [`docker-examples/v6/amazon-s3-docker-example/docker-compose.yaml`](diffhunk://#diff-640233a7016199f0b1f6da83ff16dcdc562515696c001eb09ca06c946b90bbceR1-R29): Added a Docker Compose configuration to set up Localstack S3 and Verdaccio services.
* [`docker-examples/v6/amazon-s3-docker-example/init-s3.py`](diffhunk://#diff-d50cff68b652a8b302bcba6e14c3792d2636aa6069caeab1f0c5f4e447fb76bbR1-R10): Added a Python script to initialize the S3 bucket in Localstack.
* [`docker-examples/v6/amazon-s3-docker-example/s3Plugin/config.yaml`](diffhunk://#diff-1c3df31dddcb63730480e55939ffeec7ac002cbe82c7aefa29a6e682c3d28137R1-R27): Added a configuration file for Verdaccio to use the AWS S3 storage plugin.