### PR TITLE
feat: add legacyMergeConfigs as option

### DIFF
--- a/.changeset/large-turkeys-change.md
+++ b/.changeset/large-turkeys-change.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/auth': patch
+---
+
+feat: add legacyMergeConfigs as option

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -59,12 +59,14 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
   public secret: string;
   public logger: Logger;
   public plugins: pluginUtils.Auth<Config>[];
+  public options: { legacyMergeConfigs: boolean };
 
-  public constructor(config: Config, logger: Logger) {
+  public constructor(config: Config, logger: Logger, options = { legacyMergeConfigs: false }) {
     this.config = config;
     this.secret = config.secret;
     this.logger = logger;
     this.plugins = [];
+    this.options = options;
     if (!this.secret) {
       throw new TypeError('secret it is required value on initialize the auth class');
     }
@@ -123,7 +125,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
           typeof allow_publish !== 'undefined'
         );
       },
-      false,
+      this.options.legacyMergeConfigs,
       this.config?.serverSettings?.pluginPrefix,
       PLUGIN_CATEGORY.AUTHENTICATION
     );


### PR DESCRIPTION
This pull request introduces a new feature to the `@verdaccio/auth` package, adding support for the `legacyMergeConfigs` option. This change involves updating the `Auth` class to include and utilize the new option.

Key changes include:

### Code Updates:
* `packages/auth/src/auth.ts`: 
  * Added a new `options` property to the `Auth` class to store the `legacyMergeConfigs` option.
  * Updated the `Auth` class constructor to accept the `options` parameter, with a default value setting `legacyMergeConfigs` to `false`.
  * Modified the use of the `legacyMergeConfigs` option in the `Auth` class logic to apply the new configuration setting.

ref: https://github.com/verdaccio/verdaccio/issues/5160#issuecomment-2765312581