### PR TITLE
fix(api): cidr whitelist for tokens

### DIFF
--- a/.changeset/swift-zebras-cheer.md
+++ b/.changeset/swift-zebras-cheer.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/api': patch
+---
+
+fix(api): cidr whitelist for tokens

--- a/packages/api/src/v1/token.ts
+++ b/packages/api/src/v1/token.ts
@@ -1,3 +1,4 @@
+import buildDebug from 'debug';
 import { Response, Router } from 'express';
 import _ from 'lodash';
 
@@ -13,13 +14,17 @@ import { mask, stringToMD5 } from '@verdaccio/utils';
 
 import { $NextFunctionVer, $RequestExtend } from '../../types/custom';
 
+const debug = buildDebug('verdaccio:api:token');
+
 export type NormalizeToken = Token & {
+  cidr_whitelist: string[];
   created: string;
 };
 
 function normalizeToken(token: Token): NormalizeToken {
   return {
     ...token,
+    cidr_whitelist: token.cidr || [],
     created: new Date(token.created).toISOString(),
   };
 }
@@ -41,6 +46,7 @@ export default function (
       if (_.isNil(name) === false) {
         try {
           const tokens = await storage.readTokens({ user: name });
+          debug('tokens: %o', tokens);
           const totalTokens = tokens.length;
           logger.debug({ totalTokens }, 'token list retrieved: @{totalTokens}');
 

--- a/packages/api/src/v1/token.ts
+++ b/packages/api/src/v1/token.ts
@@ -1,4 +1,3 @@
-import buildDebug from 'debug';
 import { Response, Router } from 'express';
 import _ from 'lodash';
 
@@ -14,13 +13,12 @@ import { mask, stringToMD5 } from '@verdaccio/utils';
 
 import { $NextFunctionVer, $RequestExtend } from '../../types/custom';
 
-const debug = buildDebug('verdaccio:api:token');
-
 export type NormalizeToken = Token & {
   cidr_whitelist: string[];
   created: string;
 };
 
+// npm expects "cidr_whitelist" for token list
 function normalizeToken(token: Token): NormalizeToken {
   return {
     ...token,
@@ -46,7 +44,6 @@ export default function (
       if (_.isNil(name) === false) {
         try {
           const tokens = await storage.readTokens({ user: name });
-          debug('tokens: %o', tokens);
           const totalTokens = tokens.length;
           logger.debug({ totalTokens }, 'token list retrieved: @{totalTokens}');
 


### PR DESCRIPTION
npm expects `cidr_whitelist` for token list (not `cidr`).

https://github.com/npm/cli/blob/04f53ce13201b460123067d7153f1681342548e1/lib/commands/token.js#L151C18-L153

