### PR TITLE
fix(middleware): properly derive the html cache key

### DIFF
--- a/.changeset/thick-dolphins-rule.md
+++ b/.changeset/thick-dolphins-rule.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/middleware': patch
+---
+
+fix(middleware): properly derive the html cache key

--- a/packages/middleware/src/middlewares/web/utils/renderHTML.ts
+++ b/packages/middleware/src/middlewares/web/utils/renderHTML.ts
@@ -133,17 +133,7 @@ export default function renderHTML(
 
   let webPage;
 
-  let cacheKey =
-    'template:' +
-    stringToMD5(
-      JSON.stringify({
-        // render options derived from requestOptions
-        base,
-        favicon,
-        logo,
-        logoDark,
-      })
-    );
+  let cacheKey = `template:${stringToMD5(JSON.stringify(options))}`;
 
   try {
     webPage = cache.get(cacheKey);

--- a/packages/middleware/src/middlewares/web/utils/renderHTML.ts
+++ b/packages/middleware/src/middlewares/web/utils/renderHTML.ts
@@ -9,7 +9,6 @@ import { HEADERS } from '@verdaccio/core';
 import { ConfigYaml, TemplateUIOptions } from '@verdaccio/types';
 import type { RequestOptions } from '@verdaccio/url';
 import { getPublicUrl, isURLhasValidProtocol } from '@verdaccio/url';
-import { stringToMD5 } from '@verdaccio/utils';
 
 import type { Manifest } from './manifest';
 import renderTemplate from './template';
@@ -133,7 +132,7 @@ export default function renderHTML(
 
   let webPage;
 
-  let cacheKey = `template:${stringToMD5(JSON.stringify(options))}`;
+  let cacheKey = `template:${JSON.stringify(options)}`;
 
   try {
     webPage = cache.get(cacheKey);

--- a/packages/middleware/src/middlewares/web/utils/renderHTML.ts
+++ b/packages/middleware/src/middlewares/web/utils/renderHTML.ts
@@ -9,6 +9,7 @@ import { HEADERS } from '@verdaccio/core';
 import { ConfigYaml, TemplateUIOptions } from '@verdaccio/types';
 import type { RequestOptions } from '@verdaccio/url';
 import { getPublicUrl, isURLhasValidProtocol } from '@verdaccio/url';
+import { stringToMD5 } from '@verdaccio/utils';
 
 import type { Manifest } from './manifest';
 import renderTemplate from './template';
@@ -132,8 +133,20 @@ export default function renderHTML(
 
   let webPage;
 
+  let cacheKey =
+    'template:' +
+    stringToMD5(
+      JSON.stringify({
+        // render options derived from requestOptions
+        base,
+        favicon,
+        logo,
+        logoDark,
+      })
+    );
+
   try {
-    webPage = cache.get('template');
+    webPage = cache.get(cacheKey);
     if (!webPage) {
       webPage = renderTemplate(
         {
@@ -147,7 +160,7 @@ export default function renderHTML(
       );
 
       if (needHtmlCache) {
-        cache.set('template', webPage);
+        cache.set(cacheKey, webPage);
         debug('set template cache');
       }
     } else {


### PR DESCRIPTION
Include template rendering options that change depending on the request header in the cache key

Fixes #5195