### PR TITLE
fix(server): web-enabled test

### DIFF
--- a/.changeset/breezy-toys-judge.md
+++ b/.changeset/breezy-toys-judge.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/server': patch
+---
+
+fix(server): web-enabled test

--- a/packages/server/express/test/config/web-enabled.yaml
+++ b/packages/server/express/test/config/web-enabled.yaml
@@ -7,6 +7,7 @@ auth:
 # Use enabled instead of enable which is deprecated
 web:
   enabled: true
+  title: verdaccio
 
 publish:
   allow_offline: false


### PR DESCRIPTION
Repair the failing express test (in #5196).

The test was added in https://github.com/verdaccio/verdaccio/pull/5166 and passed. 🤷 