### PR TITLE
fix(express): error loading middleware plugins

### DIFF
--- a/.changeset/pink-pants-try.md
+++ b/.changeset/pink-pants-try.md
@@ -1,5 +1,6 @@
 ---
 '@verdaccio/server': patch
+'@verdaccio/loaders': patch
 ---
 
 fix(express): error loading middleware plugins

--- a/.changeset/pink-pants-try.md
+++ b/.changeset/pink-pants-try.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/server': patch
+---
+
+fix(express): error loading middleware plugins

--- a/packages/loaders/src/plugin-async-loader.ts
+++ b/packages/loaders/src/plugin-async-loader.ts
@@ -11,6 +11,8 @@ const debug = buildDebug('verdaccio:plugin:loader:async');
 
 const { lstat } = fs.promises ? fs.promises : require('fs/promises');
 
+const PLUGIN_PREFIX = 'verdaccio';
+
 async function isDirectory(pathFolder: string) {
   const stat = await lstat(pathFolder);
   return stat.isDirectory();
@@ -53,7 +55,7 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
   pluginOptions: pluginUtils.PluginOptions,
   sanityCheck: (plugin: PluginType<T>) => boolean,
   legacyMergeConfigs: boolean = false,
-  prefix: string = 'verdaccio',
+  prefix: string = PLUGIN_PREFIX,
   pluginCategory: string = ''
 ): Promise<PluginType<T>[]> {
   const logger = pluginOptions?.logger;

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -22,7 +22,7 @@ import {
 import { Storage } from '@verdaccio/store';
 import { ConfigYaml } from '@verdaccio/types';
 import { Config as IConfig } from '@verdaccio/types';
-import webMiddleware, { PLUGIN_UI_PREFIX } from '@verdaccio/web';
+import webMiddleware from '@verdaccio/web';
 
 import { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '../types/custom';
 import hookDebug from './debug';
@@ -74,7 +74,7 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<Ex
       return typeof plugin.register_middlewares !== 'undefined';
     },
     false,
-    config?.serverSettings?.pluginPrefix ?? PLUGIN_UI_PREFIX,
+    config?.serverSettings?.pluginPrefix,
     PLUGIN_CATEGORY.MIDDLEWARE
   );
 


### PR DESCRIPTION
Regression #5170

Fixes error loading middleware plugin:

`error - package not found, try to install verdaccio-theme-audit using a package manager`

PS: It loads the correct plugin on second attempt.

![image](https://github.com/user-attachments/assets/92c8c7f9-1859-405c-bfa5-bd37270de591)
