### PR TITLE
chore(ui): fix ts errors due to excluded test folder

### DIFF
--- a/.changeset/silver-insects-train.md
+++ b/.changeset/silver-insects-train.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+chore(ui): fix ts error due to excluded test folder

--- a/packages/ui-components/tsconfig.json
+++ b/packages/ui-components/tsconfig.json
@@ -14,6 +14,15 @@
     "types": ["node", "jest", "@testing-library/jest-dom"]
   },
   "include": ["src/**/*"],
+  "exclude": [
+    "**/build",
+    "node_modules",
+    "**/node_modules",
+    "**/coverage",
+    "**/*.spec.ts",
+    "**/__tests__",
+    "**/*.test.ts"
+  ],
   "references": [
     {
       "path": "../core/types"


### PR DESCRIPTION
`tsconfig.base.json` excludes `test` folders. This change overwrites the setting for `ui-components` to fix these:

![image](https://github.com/user-attachments/assets/e15dcc7c-1de1-4ed3-87c0-398d77b7892c)

![image](https://github.com/user-attachments/assets/73a91ed7-9410-44d2-bcbc-6004f1673594)

