### PR TITLE
fix(ui): search chips when `showUplinks: false` 

### DIFF
--- a/.changeset/nine-onions-talk.md
+++ b/.changeset/nine-onions-talk.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+fix(ui): search chips in offline mode

--- a/.changeset/nine-onions-talk.md
+++ b/.changeset/nine-onions-talk.md
@@ -2,4 +2,4 @@
 '@verdaccio/ui-components': patch
 ---
 
-fix(ui): search chips when `showUplinks: false` 
+fix(ui): search chips when showUplinks is false

--- a/.changeset/nine-onions-talk.md
+++ b/.changeset/nine-onions-talk.md
@@ -2,4 +2,4 @@
 '@verdaccio/ui-components': patch
 ---
 
-fix(ui): search chips in offline mode
+fix(ui): search chips when `showUplinks: false` 

--- a/packages/ui-components/src/components/Search/SearchItem.tsx
+++ b/packages/ui-components/src/components/Search/SearchItem.tsx
@@ -9,6 +9,7 @@ import Stack from '@mui/material/Stack';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { useConfig } from '../../';
 import { cleanDescription } from './utils';
 
 type SearchItemProps = {
@@ -74,6 +75,7 @@ const SearchItem: React.FC<SearchItemProps> = ({
   ...props
 }) => {
   const { t } = useTranslation();
+  const { configOptions } = useConfig();
   const handleDelete = () => {
     // no action assigned by default
   };
@@ -87,37 +89,39 @@ const SearchItem: React.FC<SearchItemProps> = ({
         </NameGroup>
         {version && <Version>{version}</Version>}
       </Wrapper>
-      <Wrapper>
-        <Stack direction="row" spacing={1}>
-          {isPrivate && (
-            <Chip
-              color="primary"
-              deleteIcon={<HttpsIcon />}
-              label={t('search.isPrivate')}
-              onDelete={handleDelete}
-              size="small"
-            />
-          )}
-          {isRemote && !isPrivate && (
-            <Chip
-              deleteIcon={<SyncAlt />}
-              label={t('search.isRemote')}
-              onDelete={handleDelete}
-              size="small"
-              variant="outlined"
-            />
-          )}
-          {isCached && (
-            <Chip
-              deleteIcon={<Cached />}
-              label={t('search.isCached')}
-              onDelete={handleDelete}
-              size="small"
-              variant="outlined"
-            />
-          )}
-        </Stack>
-      </Wrapper>
+      {configOptions?.showUplinks && (
+        <Wrapper>
+          <Stack direction="row" spacing={1}>
+            {isPrivate && (
+              <Chip
+                color="primary"
+                deleteIcon={<HttpsIcon />}
+                label={t('search.isPrivate')}
+                onDelete={handleDelete}
+                size="small"
+              />
+            )}
+            {isRemote && !isPrivate && (
+              <Chip
+                deleteIcon={<SyncAlt />}
+                label={t('search.isRemote')}
+                onDelete={handleDelete}
+                size="small"
+                variant="outlined"
+              />
+            )}
+            {isCached && (
+              <Chip
+                deleteIcon={<Cached />}
+                label={t('search.isCached')}
+                onDelete={handleDelete}
+                size="small"
+                variant="outlined"
+              />
+            )}
+          </Stack>
+        </Wrapper>
+      )}
     </li>
   );
 };


### PR DESCRIPTION
If uplinks are disabled for the web UI (`web.showUplinks: false`, ref [#4687](https://github.com/verdaccio/verdaccio/pull/4687)), then the "Private", "Remote", and "Cached" chips in search are not useful and therefore hidden.