### PR TITLE
fix: link to API page

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -183,6 +183,12 @@ module.exports = {
           position: 'left',
           label: 'Docs',
         },
+        {
+          type: 'doc',
+          docId: 'node-api',
+          position: 'left',
+          label: 'API',
+        },
         { to: '/blog', label: 'Blog', position: 'left' },
         {
           type: 'docsVersionDropdown',

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -183,12 +183,6 @@ module.exports = {
           position: 'left',
           label: 'Docs',
         },
-        {
-          type: 'doc',
-          docId: 'api/node-api/index',
-          position: 'left',
-          label: 'API',
-        },
         { to: '/blog', label: 'Blog', position: 'left' },
         {
           type: 'docsVersionDropdown',


### PR DESCRIPTION
Remove a link to the documentation page `api/node-api/index` that does not exist.

![image](https://github.com/user-attachments/assets/18e35a25-5b0b-4ce9-81e8-33ae8a9f248d)
