### PR TITLE
docs: add a new link to the Docker custom image list

### DIFF
--- a/website/docs/docker.md
+++ b/website/docs/docker.md
@@ -238,3 +238,4 @@ There is a separate repository that hosts multiple configurations to compose Doc
 - [coldrye-debian-verdaccio](https://github.com/coldrye-docker/coldrye-debian-verdaccio) docker image providing verdaccio from coldrye-debian-nodejs.
 - [verdaccio-github-oauth-ui](https://github.com/n4bb12/verdaccio-github-oauth-ui/blob/master/Dockerfile)
 - [verdaccio-auth-gitlab](https://github.com/johanneslosch/verdaccio-auth-gitlab)
+- [docker-verdaccio-quickly-deploy](https://github.com/DAmarkday/docker-verdaccio-quickly-deploy)

--- a/website/versioned_docs/version-6.x/docker.md
+++ b/website/versioned_docs/version-6.x/docker.md
@@ -277,3 +277,4 @@ There is a separate repository that hosts multiple configurations to compose Doc
 - [verdaccio-server](https://github.com/andru255/verdaccio-server)
 - [coldrye-debian-verdaccio](https://github.com/coldrye-docker/coldrye-debian-verdaccio) docker image providing verdaccio from coldrye-debian-nodejs.
 - [verdaccio-github-oauth-ui](https://github.com/n4bb12/verdaccio-github-oauth-ui/blob/master/Dockerfile)
+- [docker-verdaccio-quickly-deploy](https://github.com/DAmarkday/docker-verdaccio-quickly-deploy)


### PR DESCRIPTION
I added a new v6 version of the Docker + Verdaccio repository address for updating docker.md, 
hoping it will be helpful.