### PR TITLE
fix(ui): check token expiry on refresh/timer

### DIFF
--- a/.changeset/afraid-cheetahs-rule.md
+++ b/.changeset/afraid-cheetahs-rule.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+fix(ui): check token expiry on refresh/timer


### PR DESCRIPTION
This fixes a longtime issue: users stay logged into the web ui although their token has expired. 

What was missing:

- There was no effect or logic in any React component (including Header, App, or providers) that checked token validity on app load or periodically, and logged out the user if the token had expired.
- The only check was at initial Redux state setup, so if the token expired after that, the UI did not react.

What's new:

The web app checks the token on page refresh and again every hour (see `useEffect` in `Header` component). 

This timeout is independent of the validity of the JWT token. Let me know if it should be configurable (`config.web.timeout`?).

Closes https://github.com/verdaccio/verdaccio/issues/3748
Closes https://github.com/verdaccio/verdaccio/issues/4078 

Related https://github.com/verdaccio/verdaccio/issues/3163, https://github.com/verdaccio/verdaccio/issues/3980, https://github.com/verdaccio/verdaccio/pull/4007, https://github.com/orgs/verdaccio/discussions/3059

