### PR TITLE
docs(uplinks): updated the documentation for an example of AWS CodeArtifact in uplinks

### DIFF
--- a/.changeset/modern-llamas-know.md
+++ b/.changeset/modern-llamas-know.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/website': patch
+---
+
+- Updated the docs to show how we can make AWS CodeArtifact work with Verdaccio
+- Added the example uplinks configuration

--- a/website/docs/uplinks.md
+++ b/website/docs/uplinks.md
@@ -92,3 +92,20 @@ uplinks:
 - Multiple uplinks might slow down the lookup of your packages. For each request an npm client makes, verdaccio makes 1 call to each configured uplink.
 - The (timeout, maxage and fail_timeout) format follow the [NGINX measurement units](http://nginx.org/en/docs/syntax.html)
 - When using the [Helm Chart](https://github.com/verdaccio/charts), you can use `secretEnvVars` to inject sensitive environment variables, which can be used to configure private uplink auth.
+- While trying to configure AWS CodeArtifact to be used as an uplink, it is necessary to define the `accept: */*` in headers.
+- An example of uplink configuration for AWS CodeArtifact is given below
+
+  ```yaml
+  uplinks:
+    aws-codeArtifact:
+      url: https://private-registry.domain.com/registry
+      cache: false # Adjust this as per your needs
+      auth:
+        type: bearer
+        token_env: CODEARTIFACT_AUTH_TOKEN # this is a shell variable and it should exists in terminal session where verdaccio is running
+        strict_ssl: false # in some cases, it may need to disabled. Adjust as per your needs
+        headers:
+          'Accept': '*/*' # this line is very important. without this it may not work
+          'Accept-Encoding': 'gzip, deflate, br'
+          'Cache-Control': 'no-cache' # Adjust as per your needs
+  ```

--- a/website/docs/uplinks.md
+++ b/website/docs/uplinks.md
@@ -92,20 +92,20 @@ uplinks:
 - Multiple uplinks might slow down the lookup of your packages. For each request an npm client makes, verdaccio makes 1 call to each configured uplink.
 - The (timeout, maxage and fail_timeout) format follow the [NGINX measurement units](http://nginx.org/en/docs/syntax.html)
 - When using the [Helm Chart](https://github.com/verdaccio/charts), you can use `secretEnvVars` to inject sensitive environment variables, which can be used to configure private uplink auth.
-- While trying to configure AWS CodeArtifact to be used as an uplink, it is necessary to define the `accept: */*` in headers.
-- An example of uplink configuration for AWS CodeArtifact is given below
+- While trying to configure [AWS CodeArtifact](https://aws.amazon.com/codeartifact/) to be used as an uplink, it is necessary to define the `accept: */*` in headers.
+- An example of uplink configuration for [AWS CodeArtifact](https://aws.amazon.com/codeartifact/) is given below
 
   ```yaml
   uplinks:
     aws-codeArtifact:
       url: https://private-registry.domain.com/registry
-      cache: false # Adjust this as per your needs
+      cache: false
       auth:
         type: bearer
-        token_env: CODEARTIFACT_AUTH_TOKEN # this is a shell variable and it should exists in terminal session where verdaccio is running
-        strict_ssl: false # in some cases, it may need to disabled. Adjust as per your needs
-        headers:
-          'Accept': '*/*' # this line is very important. without this it may not work
-          'Accept-Encoding': 'gzip, deflate, br'
-          'Cache-Control': 'no-cache' # Adjust as per your needs
+        token_env: CODEARTIFACT_AUTH_TOKEN
+      strict_ssl: false
+      headers:
+        'Accept': '*/*'
+        'Accept-Encoding': 'gzip, deflate, br'
+        'Cache-Control': 'no-cache'
   ```

--- a/website/versioned_docs/version-6.x/uplinks.md
+++ b/website/versioned_docs/version-6.x/uplinks.md
@@ -89,3 +89,20 @@ uplinks:
 - Multiple uplinks might slow down the lookup of your packages. For each request an npm client makes, verdaccio makes 1 call to each configured uplink.
 - The (timeout, maxage and fail_timeout) format follow the [NGINX measurement units](http://nginx.org/en/docs/syntax.html)
 - When using the [Helm Chart](https://github.com/verdaccio/charts), you can use `secretEnvVars` to inject sensitive environment variables, which can be used to configure private uplink auth.
+- While trying to configure AWS CodeArtifact to be used as an uplink, it is necessary to define the `accept: */*` in headers.
+- An example of uplink configuration for AWS CodeArtifact is given below
+
+  ```yaml
+  uplinks:
+    aws-codeArtifact:
+      url: https://private-registry.domain.com/registry
+      cache: false # Adjust this as per your needs
+      auth:
+        type: bearer
+        token_env: CODEARTIFACT_AUTH_TOKEN # this is a shell variable and it should exists in terminal session where verdaccio is running
+        strict_ssl: false # in some cases, it may need to disabled. Adjust as per your needs
+        headers:
+          'Accept': '*/*' # this line is very important. without this it may not work
+          'Accept-Encoding': 'gzip, deflate, br'
+          'Cache-Control': 'no-cache' # Adjust as per your needs
+  ```

--- a/website/versioned_docs/version-6.x/uplinks.md
+++ b/website/versioned_docs/version-6.x/uplinks.md
@@ -89,20 +89,20 @@ uplinks:
 - Multiple uplinks might slow down the lookup of your packages. For each request an npm client makes, verdaccio makes 1 call to each configured uplink.
 - The (timeout, maxage and fail_timeout) format follow the [NGINX measurement units](http://nginx.org/en/docs/syntax.html)
 - When using the [Helm Chart](https://github.com/verdaccio/charts), you can use `secretEnvVars` to inject sensitive environment variables, which can be used to configure private uplink auth.
-- While trying to configure AWS CodeArtifact to be used as an uplink, it is necessary to define the `accept: */*` in headers.
-- An example of uplink configuration for AWS CodeArtifact is given below
+- While trying to configure [AWS CodeArtifact](https://aws.amazon.com/codeartifact/) to be used as an uplink, it is necessary to define the `accept: */*` in headers.
+- An example of uplink configuration for [AWS CodeArtifact](https://aws.amazon.com/codeartifact/) is given below
 
   ```yaml
   uplinks:
     aws-codeArtifact:
       url: https://private-registry.domain.com/registry
-      cache: false # Adjust this as per your needs
+      cache: false
       auth:
         type: bearer
-        token_env: CODEARTIFACT_AUTH_TOKEN # this is a shell variable and it should exists in terminal session where verdaccio is running
-        strict_ssl: false # in some cases, it may need to disabled. Adjust as per your needs
-        headers:
-          'Accept': '*/*' # this line is very important. without this it may not work
-          'Accept-Encoding': 'gzip, deflate, br'
-          'Cache-Control': 'no-cache' # Adjust as per your needs
+        token_env: CODEARTIFACT_AUTH_TOKEN
+      strict_ssl: false
+      headers:
+        'Accept': '*/*'
+        'Accept-Encoding': 'gzip, deflate, br'
+        'Cache-Control': 'no-cache'
   ```


### PR DESCRIPTION
This PR updates the documentation about making AWS CodeArtifact work with Verdaccio and an example configuration

PR create by @saurabh-gohil 