### PR TITLE
feat(loader): support scoped plugins in plugin folder

### DIFF
--- a/.changeset/afraid-cars-sneeze.md
+++ b/.changeset/afraid-cars-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/loaders': minor
+---
+
+feat(loader): support scoped plugins in plugin folder

--- a/packages/loaders/test/partials/config/absolute-scoped-plugins.yaml
+++ b/packages/loaders/test/partials/config/absolute-scoped-plugins.yaml
@@ -1,0 +1,4 @@
+# require('@verdaccio-scope/verdaccio-plugin') in test-plugin-storage/@verdaccio-scope/verdaccio-plugin folder
+auth:
+  '@verdaccio-scope/verdaccio-plugin':
+    enabled: true

--- a/packages/loaders/test/partials/config/custom-prefix-auth.yaml
+++ b/packages/loaders/test/partials/config/custom-prefix-auth.yaml
@@ -1,3 +1,11 @@
+# require('customprefix-auth') as dependency
+#
+# "devDependencies": {
+#   "customprefix-auth": "workspace:2.0.0"
+# }
 auth:
-  '@verdaccio-scope/verdaccio-auth-foo':
+  auth:
     enabled: true
+
+server:
+  pluginPrefix: customprefix

--- a/packages/loaders/test/partials/config/npm-plugin-auth.yaml
+++ b/packages/loaders/test/partials/config/npm-plugin-auth.yaml
@@ -1,3 +1,8 @@
+# require('verdaccio-auth-memory') as dependency
+#
+# "devDependencies": {
+#   "verdaccio-auth-memory": "workspace:*"
+# }
 auth:
   auth-memory:
     enabled: true

--- a/packages/loaders/test/partials/config/npm-plugin-not-found.yaml
+++ b/packages/loaders/test/partials/config/npm-plugin-not-found.yaml
@@ -1,3 +1,4 @@
+# require('verdaccio-not-found') as dependency (but it's not installed)
 auth:
   not-found:
     enabled: true

--- a/packages/loaders/test/partials/config/npm-plugin-scope-auth.yaml
+++ b/packages/loaders/test/partials/config/npm-plugin-scope-auth.yaml
@@ -1,0 +1,8 @@
+# require('@verdaccio-scope/verdaccio-auth-foo') as dependency
+#
+# "devDependencies": {
+#   "@verdaccio-scope/verdaccio-auth-foo": "0.0.2"
+# }
+auth:
+  '@verdaccio-scope/verdaccio-auth-foo':
+    enabled: true

--- a/packages/loaders/test/partials/config/plugins-folder-fake.yaml
+++ b/packages/loaders/test/partials/config/plugins-folder-fake.yaml
@@ -1,4 +1,6 @@
+# require('something') in /root/does-not-exist folder (but the folder does not exist)
+plugins: /root/does-not-exist
+
 auth:
   something:
     enabled: true
-plugins: /roo/does-not-exist

--- a/packages/loaders/test/partials/config/relative-plugins.yaml
+++ b/packages/loaders/test/partials/config/relative-plugins.yaml
@@ -1,4 +1,6 @@
+# require('verdaccio-plugin') in test-plugin-storage/verdaccio-plugin folder
 plugins: '../test-plugin-storage'
+
 auth:
   plugin:
     enabled: true

--- a/packages/loaders/test/partials/config/relative-scoped-plugins.yaml
+++ b/packages/loaders/test/partials/config/relative-scoped-plugins.yaml
@@ -1,0 +1,6 @@
+# require('@verdaccio-scope/verdaccio-plugin') in test-plugin-storage/@verdaccio-scope/verdaccio-plugin folder
+plugins: '../test-plugin-storage'
+
+auth:
+  '@verdaccio-scope/verdaccio-plugin':
+    enabled: true

--- a/packages/loaders/test/partials/config/scope-auth.yaml
+++ b/packages/loaders/test/partials/config/scope-auth.yaml
@@ -1,3 +1,0 @@
-auth:
-  '@verdaccio-scope/verdaccio-auth-foo':
-    enabled: true

--- a/packages/loaders/test/partials/config/valid-plugin-store.yaml
+++ b/packages/loaders/test/partials/config/valid-plugin-store.yaml
@@ -1,3 +1,4 @@
+# require('verdaccio-plugin-store') in test-plugin-storage folder
 store:
   plugin-store:
     enabled: true

--- a/packages/loaders/test/partials/config/valid-plugin.yaml
+++ b/packages/loaders/test/partials/config/valid-plugin.yaml
@@ -1,3 +1,4 @@
+# require('verdaccio-plugin') in test-plugin-storage folder
 auth:
   plugin:
     enabled: true

--- a/packages/loaders/test/partials/test-plugin-storage/@verdaccio-scope/verdaccio-plugin/index.js
+++ b/packages/loaders/test/partials/test-plugin-storage/@verdaccio-scope/verdaccio-plugin/index.js
@@ -1,0 +1,7 @@
+function ValidScopedVerdaccioPlugin() {
+  return {
+    authenticate: function () {},
+  };
+}
+
+module.exports = ValidScopedVerdaccioPlugin;

--- a/packages/loaders/test/partials/test-plugin-storage/@verdaccio-scope/verdaccio-plugin/package.json
+++ b/packages/loaders/test/partials/test-plugin-storage/@verdaccio-scope/verdaccio-plugin/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@verdaccio-scope/verdaccio-plugin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Now you can add scoped plugins to your plugin folder. The scope is just another folder level:

```bash
./plugins
./plugins/verdaccio-plugin         # prefix plugin
./plugins/@scope/verdaccio-plugin  # scoped plugin
```

- Added tests for this option 
- Fixed the custom prefix case
- Added comments to the test configs explaining the require logic 
- Renamed `scope-auth.yml` to `npm-plugin-scope-auth.yml` 