### PR TITLE
fix(config): server settings

### DIFF
--- a/.changeset/swift-mangos-grab.md
+++ b/.changeset/swift-mangos-grab.md
@@ -1,0 +1,12 @@
+---
+'@verdaccio/server': patch
+'@verdaccio/core': patch
+'@verdaccio/loaders': patch
+'@verdaccio/config': patch
+'@verdaccio/store': patch
+'@verdaccio/auth': patch
+'@verdaccio/api': patch
+'@verdaccio/web': patch
+---
+
+fix(config): server settings

--- a/packages/api/src/user.ts
+++ b/packages/api/src/user.ts
@@ -119,10 +119,8 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
       } else {
         debug('adduser: %o', name);
         if (
-          validationUtils.validatePassword(
-            password,
-            config?.serverSettings?.passwordValidationRegex
-          ) === false
+          validationUtils.validatePassword(password, config?.server?.passwordValidationRegex) ===
+          false
         ) {
           debug('adduser: invalid password');
           // eslint-disable-next-line new-cap

--- a/packages/api/src/v1/profile.ts
+++ b/packages/api/src/v1/profile.ts
@@ -74,7 +74,7 @@ export default function (route: Router, auth: Auth, config: Config): void {
         if (
           validationUtils.validatePassword(
             password.new,
-            config?.serverSettings?.passwordValidationRegex
+            config?.server?.passwordValidationRegex
           ) === false
         ) {
           /* eslint new-cap:off */

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -6,6 +6,7 @@ import { createAnonymousRemoteUser, createRemoteUser } from '@verdaccio/config';
 import {
   API_ERROR,
   PLUGIN_CATEGORY,
+  PLUGIN_PREFIX,
   SUPPORT_ERRORS,
   TOKEN_BASIC,
   TOKEN_BEARER,
@@ -126,7 +127,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
         );
       },
       this.options.legacyMergeConfigs,
-      this.config?.serverSettings?.pluginPrefix,
+      this.config?.server?.pluginPrefix ?? PLUGIN_PREFIX,
       PLUGIN_CATEGORY.AUTHENTICATION
     );
   }

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -20,7 +20,7 @@ import { generateRandomHexString, getMatchedPackagesSpec } from '@verdaccio/util
 import { getUserAgent } from './agent';
 import { normalisePackageAccess } from './package-access';
 import { defaultSecurity } from './security';
-import serverSettings from './serverSettings';
+import defaultServerSettings from './serverSettings';
 import { generateRandomSecretKey } from './token';
 import { sanityCheckUplinksProps, uplinkSanityCheck } from './uplinks';
 
@@ -63,7 +63,7 @@ class Config implements AppConfig {
 
   public plugins: string | void | null;
   public security: Security;
-  public serverSettings: ServerSettingsConf;
+  public server: ServerSettingsConf;
   private configOverrideOptions: { forceMigrateToSecureLegacySignature: boolean };
   // @ts-ignore
   public secret: string;
@@ -102,7 +102,7 @@ class Config implements AppConfig {
       }),
       config.security
     );
-    this.serverSettings = serverSettings;
+    this.server = { ...defaultServerSettings, ...config.server };
     this.flags = {
       searchRemote: config.flags?.searchRemote ?? true,
       changePassword: config.flags?.changePassword ?? false,

--- a/packages/core/core/src/constants.ts
+++ b/packages/core/core/src/constants.ts
@@ -128,6 +128,9 @@ export enum HtpasswdHashAlgorithm {
   bcrypt = 'bcrypt',
 }
 
+export const PLUGIN_PREFIX = 'verdaccio';
+export const PLUGIN_UI_PREFIX = 'verdaccio-theme';
+
 export const PLUGIN_CATEGORY = {
   AUTHENTICATION: 'authentication',
   MIDDLEWARE: 'middleware',

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -26,6 +26,8 @@ export {
   USERS,
   MAINTAINERS,
   PLUGIN_CATEGORY,
+  PLUGIN_PREFIX,
+  PLUGIN_UI_PREFIX,
   HtpasswdHashAlgorithm,
 } from './constants';
 export {

--- a/packages/loaders/src/plugin-async-loader.ts
+++ b/packages/loaders/src/plugin-async-loader.ts
@@ -3,15 +3,13 @@ import fs from 'fs';
 import _ from 'lodash';
 import { dirname, isAbsolute, join, resolve } from 'path';
 
-import { pluginUtils } from '@verdaccio/core';
+import { PLUGIN_PREFIX, pluginUtils } from '@verdaccio/core';
 
 import { PluginType, isES6, isValid, tryLoad } from './utils';
 
 const debug = buildDebug('verdaccio:plugin:loader:async');
 
 const { lstat } = fs.promises ? fs.promises : require('fs/promises');
-
-const PLUGIN_PREFIX = 'verdaccio';
 
 async function isDirectory(pathFolder: string) {
   const stat = await lstat(pathFolder);

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -8,7 +8,13 @@ import AuditMiddleware from 'verdaccio-audit';
 import apiEndpoint from '@verdaccio/api';
 import { Auth } from '@verdaccio/auth';
 import { Config as AppConfig } from '@verdaccio/config';
-import { API_ERROR, PLUGIN_CATEGORY, errorUtils, pluginUtils } from '@verdaccio/core';
+import {
+  API_ERROR,
+  PLUGIN_CATEGORY,
+  PLUGIN_PREFIX,
+  errorUtils,
+  pluginUtils,
+} from '@verdaccio/core';
 import { asyncLoadPlugin } from '@verdaccio/loaders';
 import { logger } from '@verdaccio/logger';
 import {
@@ -41,7 +47,7 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<Ex
     app.set('trust proxy', config.server.trustProxy);
   }
   app.use(cors());
-  app.use(rateLimit(config.serverSettings.rateLimit));
+  app.use(rateLimit(config.server?.rateLimit));
 
   const errorReportingMiddlewareWrap = errorReportingMiddleware(logger);
 
@@ -74,7 +80,7 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<Ex
       return typeof plugin.register_middlewares !== 'undefined';
     },
     false,
-    config?.serverSettings?.pluginPrefix,
+    config.server?.pluginPrefix ?? PLUGIN_PREFIX,
     PLUGIN_CATEGORY.MIDDLEWARE
   );
 

--- a/packages/store/src/local-storage.ts
+++ b/packages/store/src/local-storage.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import buildDebug from 'debug';
 import _ from 'lodash';
 
-import { PLUGIN_CATEGORY, errorUtils, pluginUtils } from '@verdaccio/core';
+import { PLUGIN_CATEGORY, PLUGIN_PREFIX, errorUtils, pluginUtils } from '@verdaccio/core';
 import { asyncLoadPlugin } from '@verdaccio/loaders';
 import LocalDatabase from '@verdaccio/local-storage';
 import { Config, Logger } from '@verdaccio/types';
@@ -81,7 +81,7 @@ class LocalStorage {
         return typeof plugin.getPackageStorage !== 'undefined';
       },
       false,
-      this.config?.serverSettings?.pluginPrefix,
+      this.config.server?.pluginPrefix ?? PLUGIN_PREFIX,
       PLUGIN_CATEGORY.STORAGE
     );
 

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -16,6 +16,7 @@ import {
   HTTP_STATUS,
   MAINTAINERS,
   PLUGIN_CATEGORY,
+  PLUGIN_PREFIX,
   SUPPORT_ERRORS,
   USERS,
   errorUtils,
@@ -687,7 +688,7 @@ class Storage {
           return typeof plugin.filter_metadata !== 'undefined';
         },
         false,
-        this.config?.serverSettings?.pluginPrefix,
+        this.config.server?.pluginPrefix ?? PLUGIN_PREFIX,
         PLUGIN_CATEGORY.FILTER
       );
       debug('filters available %o', this.filters.length);

--- a/packages/web/src/api/user.ts
+++ b/packages/web/src/api/user.ts
@@ -69,7 +69,7 @@ function addUserAuthApi(auth: Auth, config: Config): Router {
         if (
           validationUtils.validatePassword(
             password.new,
-            config?.serverSettings?.passwordValidationRegex
+            config?.server?.passwordValidationRegex
           ) === false
         ) {
           return next(errorUtils.getCode(HTTP_STATUS.BAD_REQUEST, APP_ERROR.PASSWORD_VALIDATION));

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,2 +1,2 @@
-export { default, PLUGIN_UI_PREFIX, DEFAULT_PLUGIN_UI_THEME } from './middleware';
+export { default, DEFAULT_PLUGIN_UI_THEME } from './middleware';
 export * from './web-utils';

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,14 +1,13 @@
 import express from 'express';
 import _ from 'lodash';
 
-import { PLUGIN_CATEGORY } from '@verdaccio/core';
+import { PLUGIN_CATEGORY, PLUGIN_UI_PREFIX } from '@verdaccio/core';
 import { asyncLoadPlugin } from '@verdaccio/loaders';
 import { logger } from '@verdaccio/logger';
 import { webMiddleware } from '@verdaccio/middleware';
 
 import webEndpointsApi from './api';
 
-export const PLUGIN_UI_PREFIX = 'verdaccio-theme';
 export const DEFAULT_PLUGIN_UI_THEME = '@verdaccio/ui-theme';
 
 export async function loadTheme(config: any) {
@@ -27,7 +26,7 @@ export async function loadTheme(config: any) {
         return plugin.staticPath && plugin.manifest && plugin.manifestFiles;
       },
       false,
-      config?.serverSettings?.pluginPrefix ?? PLUGIN_UI_PREFIX,
+      config.server?.pluginPrefix ?? PLUGIN_UI_PREFIX,
       PLUGIN_CATEGORY.THEME
     );
     if (plugin.length > 1) {


### PR DESCRIPTION
There was some confusion between `serverSettings` and `server`. After the constructor it looked like this, for example:

```
serverSettings: { rateLimit: { windowMs: 1000, max: 10000 }, keepAliveTimeout: 60 },
server: { pluginPrefix: 'customprefix' },
```

It now uses `config.server` consistently like in yaml.