### PR TITLE
chore: enable CI Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        node_version: [18, 20, 21, 22, 23]
+        node_version: [18, 20, 21, 22, 23, 24]
     name: ${{ matrix.os }} / Node ${{ matrix.node_version }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -45,7 +45,7 @@ jobs:
             npm9,
             npm10
           ]
-        node: [22]
+        node: [22, 24]
     name: ${{ matrix.pkg }}/ ubuntu-latest / ${{ matrix.node }}
     runs-on: ubuntu-latest
     steps:
@@ -72,7 +72,7 @@ jobs:
             pnpm9,
             pnpm10,
           ]
-        node: [22]
+        node: [2, 24]
     name: ${{ matrix.pkg }}/ ubuntu-latest / ${{ matrix.node }}
     runs-on: ubuntu-latest
     steps:
@@ -99,7 +99,7 @@ jobs:
             yarn3,
             yarn4
           ]
-        node: [22]
+        node: [22, 24]
     name: ${{ matrix.pkg }}/ ubuntu-latest / ${{ matrix.node }}
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:22-alpine AS builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:24-alpine AS builder
 
 ENV NODE_ENV=development \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org
@@ -21,7 +21,7 @@ RUN npm -g i corepack && \
 # NODE_ENV=production pnpm install --frozen-lockfile --ignore-scripts
 # RUN pnpm install --prod --ignore-scripts
 
-FROM node:22-alpine
+FROM node:24-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \


### PR DESCRIPTION
- Enable CI Node.js 24 
- Docker build on v24
- E2E CI on 24 (mostly because npm 11 is enabled by default)

Node.js 22 remains default for other branches, until October 2025

https://nodejs.org/en/about/previous-releases