### PR TITLE
chore(utils): replace `@verdaccio/utils` dependency with core

### DIFF
--- a/.changeset/brave-ears-drive.md
+++ b/.changeset/brave-ears-drive.md
@@ -1,0 +1,18 @@
+---
+'@verdaccio/local-storage': patch
+'@verdaccio/server': patch
+'@verdaccio/server-fastify': patch
+'@verdaccio/test-helper': patch
+'@verdaccio/ui-components': patch
+'@verdaccio/tarball': patch
+'@verdaccio/types': patch
+'@verdaccio/middleware': patch
+'verdaccio': patch
+'@verdaccio/config': patch
+'@verdaccio/proxy': patch
+'@verdaccio/store': patch
+'@verdaccio/auth': patch
+'@verdaccio/api': patch
+---
+
+chore(utils): replace @verdaccio/utils dependency with core

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -48,7 +48,6 @@
     "@verdaccio/logger": "workspace:8.0.0-next-8.15",
     "@verdaccio/middleware": "workspace:8.0.0-next-8.15",
     "@verdaccio/store": "workspace:8.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "abortcontroller-polyfill": "1.7.8",
     "body-parser": "1.20.3",
     "cookies": "0.9.1",

--- a/packages/api/src/user.ts
+++ b/packages/api/src/user.ts
@@ -9,13 +9,14 @@ import {
   API_MESSAGE,
   HEADERS,
   HTTP_STATUS,
+  authUtils,
+  cryptoUtils,
   errorUtils,
   validationUtils,
 } from '@verdaccio/core';
 import { USER_API_ENDPOINTS, rateLimit } from '@verdaccio/middleware';
 import { Logger } from '@verdaccio/types';
 import { Config, RemoteUser } from '@verdaccio/types';
-import { getAuthenticatedMessage, mask } from '@verdaccio/utils';
 
 import { $NextFunctionVer, $RequestExtend } from '../types/custom';
 
@@ -39,7 +40,7 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
       }
 
       const username = req.params.org_couchdb_user.split(':')[1];
-      const message = getAuthenticatedMessage(req.remote_user.name);
+      const message = authUtils.getAuthenticatedMessage(req.remote_user.name);
       debug('user authenticated message %o', message);
       res.status(HTTP_STATUS.OK);
       next({
@@ -107,7 +108,7 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
             res.status(HTTP_STATUS.CREATED);
             res.set(HEADERS.CACHE_CONTROL, 'no-cache, no-store');
 
-            const message = getAuthenticatedMessage(req.remote_user.name);
+            const message = authUtils.getAuthenticatedMessage(req.remote_user.name);
             debug('login: created user message %o', message);
 
             return next({
@@ -146,7 +147,7 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
               ? await getApiToken(auth, config, user as RemoteUser, password)
               : undefined;
           if (token) {
-            debug('adduser: new token %o', mask(token as string, 4));
+            debug('adduser: new token %o', cryptoUtils.mask(token as string, 4));
           }
           if (!token) {
             return next(errorUtils.getUnauthorized());

--- a/packages/api/src/v1/token.ts
+++ b/packages/api/src/v1/token.ts
@@ -1,15 +1,11 @@
 import { Response, Router } from 'express';
 import _ from 'lodash';
 
-import { getApiToken } from '@verdaccio/auth';
-import { Auth } from '@verdaccio/auth';
-import { HEADERS, HTTP_STATUS, SUPPORT_ERRORS, errorUtils } from '@verdaccio/core';
-import { rateLimit } from '@verdaccio/middleware';
-import { TOKEN_API_ENDPOINTS } from '@verdaccio/middleware';
+import { Auth, getApiToken } from '@verdaccio/auth';
+import { HEADERS, HTTP_STATUS, SUPPORT_ERRORS, cryptoUtils, errorUtils } from '@verdaccio/core';
+import { TOKEN_API_ENDPOINTS, rateLimit } from '@verdaccio/middleware';
 import { Storage } from '@verdaccio/store';
-import { Config, RemoteUser, Token } from '@verdaccio/types';
-import { Logger } from '@verdaccio/types';
-import { mask, stringToMD5 } from '@verdaccio/utils';
+import { Config, Logger, RemoteUser, Token } from '@verdaccio/types';
 
 import { $NextFunctionVer, $RequestExtend } from '../../types/custom';
 
@@ -94,9 +90,9 @@ export default function (
             throw errorUtils.getInternalError();
           }
 
-          const key = stringToMD5(token);
+          const key = cryptoUtils.stringToMD5(token);
           // TODO: use a utility here
-          const maskedToken = mask(token, 5);
+          const maskedToken = cryptoUtils.mask(token, 5);
           const created = new Date().getTime();
 
           /**

--- a/packages/api/test/integration/_helper.ts
+++ b/packages/api/test/integration/_helper.ts
@@ -5,7 +5,14 @@ import supertest from 'supertest';
 import { expect } from 'vitest';
 
 import { parseConfigFile } from '@verdaccio/config';
-import { HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
+import {
+  HEADERS,
+  HEADER_TYPE,
+  HTTP_STATUS,
+  TOKEN_BEARER,
+  authUtils,
+  cryptoUtils,
+} from '@verdaccio/core';
 import { setup } from '@verdaccio/logger';
 import { Storage } from '@verdaccio/store';
 import {
@@ -13,17 +20,18 @@ import {
   initializeServer as initializeServerHelper,
 } from '@verdaccio/test-helper';
 import { Author, GenericBody, PackageUsers } from '@verdaccio/types';
-import { buildToken, generateRandomHexString } from '@verdaccio/utils';
 
 import apiMiddleware from '../../src';
 
 setup({});
 
+export const buildToken = authUtils.buildToken;
+
 export const getConf = (conf) => {
   const configPath = path.join(__dirname, 'config', conf);
   const config = parseConfigFile(configPath);
   // custom config to avoid conflict with other tests
-  config.auth.htpasswd.file = `${config.auth.htpasswd.file}-${generateRandomHexString()}`;
+  config.auth.htpasswd.file = `${config.auth.htpasswd.file}-${cryptoUtils.generateRandomHexString()}`;
   return config;
 };
 

--- a/packages/api/test/integration/profile.spec.ts
+++ b/packages/api/test/integration/profile.spec.ts
@@ -2,9 +2,8 @@ import supertest from 'supertest';
 import { describe, test } from 'vitest';
 
 import { HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
-import { buildToken } from '@verdaccio/utils';
 
-import { createUser, initializeServer } from './_helper';
+import { buildToken, createUser, initializeServer } from './_helper';
 
 describe('profile ', () => {
   describe('get profile ', () => {

--- a/packages/api/test/integration/token.spec.ts
+++ b/packages/api/test/integration/token.spec.ts
@@ -10,9 +10,14 @@ import {
   SUPPORT_ERRORS,
   TOKEN_BEARER,
 } from '@verdaccio/core';
-import { buildToken } from '@verdaccio/utils';
 
-import { deleteTokenCLI, generateTokenCLI, getNewToken, initializeServer } from './_helper';
+import {
+  buildToken,
+  deleteTokenCLI,
+  generateTokenCLI,
+  getNewToken,
+  initializeServer,
+} from './_helper';
 
 describe('token', () => {
   describe('basics', () => {

--- a/packages/api/test/integration/user.spec.ts
+++ b/packages/api/test/integration/user.spec.ts
@@ -2,9 +2,8 @@ import supertest from 'supertest';
 import { describe, expect, test, vi } from 'vitest';
 
 import { API_ERROR, HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
-import { buildToken } from '@verdaccio/utils';
 
-import { createUser, getPackage, initializeServer } from './_helper';
+import { buildToken, createUser, getPackage, initializeServer } from './_helper';
 
 const FORBIDDEN_VUE = 'authorization required to access package vue';
 

--- a/packages/api/test/integration/whoami.spec.ts
+++ b/packages/api/test/integration/whoami.spec.ts
@@ -2,9 +2,8 @@ import supertest from 'supertest';
 import { describe, expect, test } from 'vitest';
 
 import { HEADERS, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
-import { buildToken } from '@verdaccio/utils';
 
-import { createUser, initializeServer } from './_helper';
+import { buildToken, createUser, initializeServer } from './_helper';
 
 describe('whoami', () => {
   test('should return the logged username', async () => {

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -46,7 +46,6 @@
     "@verdaccio/core": "workspace:8.0.0-next-8.15",
     "@verdaccio/loaders": "workspace:8.0.0-next-8.6",
     "@verdaccio/signature": "workspace:8.0.0-next-8.7",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "debug": "4.4.0",
     "lodash": "4.17.21",
     "verdaccio-htpasswd": "workspace:13.0.0-next-8.15"

--- a/packages/auth/test/auth-utils-middleware.spec.ts
+++ b/packages/auth/test/auth-utils-middleware.spec.ts
@@ -9,15 +9,16 @@ import {
   parseConfigFile,
 } from '@verdaccio/config';
 import { getDefaultConfig } from '@verdaccio/config';
-import { TOKEN_BEARER } from '@verdaccio/core';
+import { TOKEN_BEARER, authUtils } from '@verdaccio/core';
 import { logger, setup } from '@verdaccio/logger';
 import { signPayload } from '@verdaccio/signature';
 import { Config, RemoteUser, Security } from '@verdaccio/types';
-import { buildToken, buildUserBuffer } from '@verdaccio/utils';
 
 import { Auth, getApiToken, getMiddlewareCredentials, verifyJWTPayload } from '../src';
 
 setup({});
+
+const buildToken = authUtils.buildToken;
 
 const parseConfigurationFile = (conf) => {
   const { name, ext } = path.parse(conf);
@@ -37,6 +38,7 @@ describe('Auth utilities', () => {
     const conf = parseConfigFile(parseConfigurationSecurityFile(configFileName));
     // @ts-ignore
     const secConf = _.merge(getDefaultConfig(), conf);
+    // @ts-expect-error
     secConf.secret = secret;
     const config: Config = new AppConfig(secConf);
 
@@ -101,7 +103,7 @@ describe('Auth utilities', () => {
         const user = 'test';
         const pass = 'test';
         // basic authentication need send user as base64
-        const token = buildUserBuffer(user, pass).toString('base64');
+        const token = authUtils.buildUserBuffer(user, pass).toString('base64');
         const config: Config = getConfig('security-legacy', secret);
         const security: Security = config.security;
         const credentials = getMiddlewareCredentials(security, secret, `Basic ${token}`);

--- a/packages/auth/test/auth-utils.spec.ts
+++ b/packages/auth/test/auth-utils.spec.ts
@@ -7,14 +7,19 @@ import {
   ROLES,
   createAnonymousRemoteUser,
   createRemoteUser,
+  getDefaultConfig,
   parseConfigFile,
 } from '@verdaccio/config';
-import { getDefaultConfig } from '@verdaccio/config';
-import { API_ERROR, CHARACTER_ENCODING, VerdaccioError, errorUtils } from '@verdaccio/core';
+import {
+  API_ERROR,
+  CHARACTER_ENCODING,
+  VerdaccioError,
+  authUtils,
+  errorUtils,
+} from '@verdaccio/core';
 import { logger, setup } from '@verdaccio/logger';
 import { aesDecrypt, verifyPayload } from '@verdaccio/signature';
 import { Config, RemoteUser } from '@verdaccio/types';
-import { getAuthenticatedMessage } from '@verdaccio/utils';
 
 import {
   ActionsAllowed,
@@ -356,7 +361,7 @@ describe('Auth utilities', () => {
 
   describe('getAuthenticatedMessage test', () => {
     test('should sign token with jwt enabled', () => {
-      expect(getAuthenticatedMessage('test')).toBe("you are authenticated as 'test'");
+      expect(authUtils.getAuthenticatedMessage('test')).toBe("you are authenticated as 'test'");
     });
   });
 });

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@verdaccio/core": "workspace:8.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "debug": "4.4.0",
     "js-yaml": "4.1.0",
     "lodash": "4.17.21",

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -2,7 +2,7 @@ import assert from 'assert';
 import buildDebug from 'debug';
 import _ from 'lodash';
 
-import { APP_ERROR, validationUtils, warningUtils } from '@verdaccio/core';
+import { APP_ERROR, authUtils, cryptoUtils, validationUtils, warningUtils } from '@verdaccio/core';
 import { Codes } from '@verdaccio/core/build/warning-utils';
 import {
   Config as AppConfig,
@@ -15,7 +15,6 @@ import {
   Security,
   ServerSettingsConf,
 } from '@verdaccio/types';
-import { generateRandomHexString, getMatchedPackagesSpec } from '@verdaccio/utils';
 
 import { getUserAgent } from './agent';
 import { normalisePackageAccess } from './package-access';
@@ -148,7 +147,7 @@ class Config implements AppConfig {
     // unique identifier of self server (or a cluster), used to avoid loops
     // @ts-ignore
     if (!this.server_id) {
-      this.server_id = generateRandomHexString(6);
+      this.server_id = cryptoUtils.generateRandomHexString(6);
     }
   }
 
@@ -162,10 +161,13 @@ class Config implements AppConfig {
 
   /**
    * Check for package spec
+   * @param pkgName - package name
+   * @returns package access
+   * @deprecated use core.authUtils instead
    */
   public getMatchedPackagesSpec(pkgName: string): PackageAccess | void {
     // TODO: remove this method and replace by library utils
-    return getMatchedPackagesSpec(pkgName, this.packages);
+    return authUtils.getMatchedPackagesSpec(pkgName, this.packages);
   }
 
   /**

--- a/packages/config/src/uplinks.ts
+++ b/packages/config/src/uplinks.ts
@@ -1,8 +1,8 @@
 import assert from 'assert';
 import _ from 'lodash';
 
+import { authUtils } from '@verdaccio/core';
 import { PackageList, UpLinksConfList } from '@verdaccio/types';
-import { getMatchedPackagesSpec } from '@verdaccio/utils';
 
 export const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
 export const DEFAULT_UPLINK = 'npmjs';
@@ -49,7 +49,7 @@ export function sanityCheckUplinksProps(configUpLinks: UpLinksConfList): UpLinks
 }
 
 export function getProxiesForPackage(pkg: string, packages: PackageList): string[] {
-  const matchedPkg = getMatchedPackagesSpec(pkg, packages);
+  const matchedPkg = authUtils.getMatchedPackagesSpec(pkg, packages);
   return matchedPkg?.proxy || [];
 }
 

--- a/packages/core/tarball/package.json
+++ b/packages/core/tarball/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@verdaccio/core": "workspace:8.0.0-next-8.15",
     "@verdaccio/url": "workspace:13.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "debug": "4.4.0",
     "gunzip-maybe": "^1.4.2",
     "lodash": "4.17.21",

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -287,6 +287,7 @@ export interface Config extends Omit<ConfigYaml, 'packages' | 'security' | 'conf
   security: Security;
   // @deprecated (pending adding the replacement)
   checkSecretKey(token: string | void): string;
+  // @deprecated use core.authUtils instead
   getMatchedPackagesSpec(storage: string): PackageAccess | void;
   // TODO: verify how to handle this in the future
   [key: string]: any;

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -45,7 +45,6 @@
     "@verdaccio/config": "workspace:8.0.0-next-8.15",
     "@verdaccio/core": "workspace:8.0.0-next-8.15",
     "@verdaccio/url": "workspace:13.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "debug": "4.4.0",
     "express": "4.21.2",
     "express-rate-limit": "5.5.1",

--- a/packages/middleware/src/middlewares/final.ts
+++ b/packages/middleware/src/middlewares/final.ts
@@ -1,9 +1,8 @@
 import buildDebug from 'debug';
 import _ from 'lodash';
 
-import { HEADERS, HTTP_STATUS, TOKEN_BASIC, TOKEN_BEARER } from '@verdaccio/core';
+import { HEADERS, HTTP_STATUS, TOKEN_BASIC, TOKEN_BEARER, cryptoUtils } from '@verdaccio/core';
 import { Manifest } from '@verdaccio/types';
-import { stringToMD5 } from '@verdaccio/utils';
 
 import { $NextFunctionVer, $RequestExtend, $ResponseExtend, MiddlewareError } from '../types';
 
@@ -44,7 +43,7 @@ export function final(
         !res.statusCode ||
         (res.statusCode >= HTTP_STATUS.OK && res.statusCode < HTTP_STATUS.MULTIPLE_CHOICES)
       ) {
-        const etag = stringToMD5(body as string);
+        const etag = cryptoUtils.stringToMD5(body as string);
         debug('set etag header %s', etag);
         res.header(HEADERS.ETAG, '"' + etag + '"');
       }

--- a/packages/plugins/local-storage/package.json
+++ b/packages/plugins/local-storage/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@verdaccio/core": "workspace:8.0.0-next-8.15",
     "@verdaccio/file-locking": "workspace:13.0.0-next-8.3",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "core-js": "3.40.0",
     "debug": "4.4.0",
     "globby": "11.1.0",

--- a/packages/plugins/local-storage/src/local-database.ts
+++ b/packages/plugins/local-storage/src/local-database.ts
@@ -6,9 +6,8 @@ import FileAsync from 'lowdb/adapters/FileAsync';
 import FileMemory from 'lowdb/adapters/Memory';
 import path from 'path';
 
-import { errorUtils, fileUtils, pluginUtils, searchUtils } from '@verdaccio/core';
+import { authUtils, errorUtils, fileUtils, pluginUtils, searchUtils } from '@verdaccio/core';
 import { Config, Logger, Token, TokenFilter } from '@verdaccio/types';
-import { getMatchedPackagesSpec } from '@verdaccio/utils';
 
 import { searchOnStorage } from './dir-utils';
 import { mkdirPromise, writeFilePromise } from './fs';
@@ -196,7 +195,7 @@ class LocalDatabase extends pluginUtils.Plugin<{}> implements Storage {
   }
 
   public getPackageStorage(packageName: string): pluginUtils.StorageHandler {
-    const packageAccess = getMatchedPackagesSpec(packageName, this.config.packages);
+    const packageAccess = authUtils.getMatchedPackagesSpec(packageName, this.config.packages);
 
     const packagePath: string = this._getLocalStoragePath(
       packageAccess ? packageAccess.storage : undefined

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -44,7 +44,6 @@
   "dependencies": {
     "@verdaccio/config": "workspace:8.0.0-next-8.15",
     "@verdaccio/core": "workspace:8.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "JSONStream": "1.3.5",
     "debug": "4.4.0",
     "got-cjs": "12.5.4",

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -18,12 +18,12 @@ import {
   HTTP_STATUS,
   TOKEN_BASIC,
   TOKEN_BEARER,
+  authUtils,
   constants,
   errorUtils,
   searchUtils,
 } from '@verdaccio/core';
 import { AgentOptionsConf, Config, Logger, Manifest, UpLinkConf } from '@verdaccio/types';
-import { buildToken } from '@verdaccio/utils';
 
 import CustomAgents from './agent';
 import { parseInterval } from './proxy-utils';
@@ -264,7 +264,7 @@ class ProxyStorage implements IProxy {
       this._throwErrorAuth(`Auth type '${_type}' not allowed`);
     }
 
-    headers[HEADERS.AUTHORIZATION] = buildToken(type, token);
+    headers[HEADERS.AUTHORIZATION] = authUtils.buildToken(type, token);
   }
 
   /**

--- a/packages/proxy/test/headers.auth.spec.ts
+++ b/packages/proxy/test/headers.auth.spec.ts
@@ -1,9 +1,8 @@
 import { describe, expect, test, vi } from 'vitest';
 
 import { DEFAULT_REGISTRY } from '@verdaccio/config';
-import { HEADERS, TOKEN_BASIC, TOKEN_BEARER, constants } from '@verdaccio/core';
+import { HEADERS, TOKEN_BASIC, TOKEN_BEARER, authUtils, constants } from '@verdaccio/core';
 import { Logger } from '@verdaccio/types';
-import { buildToken } from '@verdaccio/utils';
 
 import { ProxyStorage } from '../src';
 
@@ -20,6 +19,8 @@ const logger = {
   error: mockError,
   warn: mockWarn,
 } as unknown as Logger;
+
+const buildToken = authUtils.buildToken;
 
 function createUplink(config) {
   const defaultConfig = {

--- a/packages/server/express/package.json
+++ b/packages/server/express/package.json
@@ -41,7 +41,6 @@
     "@verdaccio/logger": "workspace:8.0.0-next-8.15",
     "@verdaccio/middleware": "workspace:8.0.0-next-8.15",
     "@verdaccio/store": "workspace:8.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "@verdaccio/web": "workspace:8.1.0-next-8.15",
     "verdaccio-audit": "workspace:13.0.0-next-8.15",
     "compression": "1.8.0",

--- a/packages/server/express/test/_helper.ts
+++ b/packages/server/express/test/_helper.ts
@@ -2,9 +2,8 @@ import { Application } from 'express';
 import path from 'path';
 
 import { parseConfigFile } from '@verdaccio/config';
-import { fileUtils } from '@verdaccio/core';
+import { cryptoUtils, fileUtils } from '@verdaccio/core';
 import { setup } from '@verdaccio/logger';
-import { generateRandomHexString } from '@verdaccio/utils';
 
 import apiMiddleware from '../src';
 
@@ -17,7 +16,7 @@ export const getConf = async (conf) => {
   // custom config to avoid conflict with other tests
   config.auth.htpasswd.file = path.join(
     storage,
-    `${config.auth.htpasswd.file}-${generateRandomHexString()}`
+    `${config.auth.htpasswd.file}-${cryptoUtils.generateRandomHexString()}`
   );
   return config;
 };

--- a/packages/server/fastify/package.json
+++ b/packages/server/fastify/package.json
@@ -39,7 +39,6 @@
     "@verdaccio/logger": "workspace:8.0.0-next-8.15",
     "@verdaccio/store": "workspace:8.0.0-next-8.15",
     "@verdaccio/tarball": "workspace:13.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "core-js": "3.40.0",
     "debug": "4.4.0",
     "fastify": "4.25.2",

--- a/packages/server/fastify/src/endpoints/user.ts
+++ b/packages/server/fastify/src/endpoints/user.ts
@@ -7,10 +7,9 @@ import _ from 'lodash';
 
 import { getApiToken } from '@verdaccio/auth';
 import { createRemoteUser } from '@verdaccio/config';
-import { validationUtils } from '@verdaccio/core';
+import { authUtils, validationUtils } from '@verdaccio/core';
 import { logger } from '@verdaccio/logger';
 import { RemoteUser } from '@verdaccio/types';
-import { getAuthenticatedMessage } from '@verdaccio/utils';
 
 const debug = buildDebug('verdaccio:fastify:user');
 
@@ -22,7 +21,7 @@ async function userRoute(fastify: FastifyInstance) {
   fastify.get<{ Params: UserParamsInterface }>('/:org_couchdb_user', async (request, reply) => {
     // @ts-ignore
     // TODO: compare org_couchdb_user with remote user name
-    const message = getAuthenticatedMessage(request.userRemote.name);
+    const message = authUtils.getAuthenticatedMessage(request.userRemote.name);
     logger.info('user authenticated message %o', message);
     reply.code(fastify.statusCode.OK);
     return { ok: message };
@@ -87,7 +86,7 @@ async function userRoute(fastify: FastifyInstance) {
             return reply.send(fastify.errorUtils.getUnauthorized());
           } else {
             reply.code(fastify.statusCode.CREATED);
-            const message = getAuthenticatedMessage(remoteName);
+            const message = authUtils.getAuthenticatedMessage(remoteName);
             debug('login: created user message %o', message);
             reply.send({
               ok: message,

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -52,7 +52,6 @@
     "@verdaccio/search": "workspace:8.0.0-next-8.15",
     "@verdaccio/tarball": "workspace:13.0.0-next-8.15",
     "@verdaccio/url": "workspace:13.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "JSONStream": "1.3.5",
     "debug": "4.4.0",
     "lodash": "4.17.21",

--- a/packages/store/src/lib/storage-utils.ts
+++ b/packages/store/src/lib/storage-utils.ts
@@ -1,10 +1,19 @@
 import _ from 'lodash';
 import semver from 'semver';
 
-import { errorUtils, pkgUtils, searchUtils, validationUtils } from '@verdaccio/core';
-import { API_ERROR, DIST_TAGS, HTTP_STATUS, MAINTAINERS, USERS } from '@verdaccio/core';
-import { GenericBody, Manifest, ReadmeOptions, Version } from '@verdaccio/types';
-import { generateRandomHexString, isNil } from '@verdaccio/utils';
+import {
+  API_ERROR,
+  DIST_TAGS,
+  HTTP_STATUS,
+  MAINTAINERS,
+  USERS,
+  cryptoUtils,
+  errorUtils,
+  pkgUtils,
+  searchUtils,
+  validationUtils,
+} from '@verdaccio/core';
+import { Author, GenericBody, Manifest, ReadmeOptions, Version } from '@verdaccio/types';
 
 import { sortVersionsAndFilterInvalid } from './versions-utils';
 
@@ -46,7 +55,7 @@ export function normalizePackage(pkg: Manifest): Manifest {
   pkgProperties.forEach((key): void => {
     const pkgProp = pkg[key];
 
-    if (isNil(pkgProp) || validationUtils.isObject(pkgProp) === false) {
+    if (_.isNil(pkgProp) || validationUtils.isObject(pkgProp) === false) {
       pkg[key] = {};
     }
   });
@@ -66,7 +75,7 @@ export function normalizePackage(pkg: Manifest): Manifest {
 export function generateRevision(rev: string): string {
   const _rev = rev.split('-');
 
-  return (+_rev[0] || 0) + 1 + '-' + generateRandomHexString();
+  return (+_rev[0] || 0) + 1 + '-' + cryptoUtils.generateRandomHexString();
 }
 
 export function getLatestReadme(pkg: Manifest): string {
@@ -112,7 +121,7 @@ export function cleanUpReadme(
     }
   }
 
-  if (isNil(version) === false) {
+  if (_.isNil(version) === false) {
     version.readme = '';
   }
 
@@ -162,14 +171,14 @@ export function checkPackageRemote(
       }
 
       // checking package exist already
-      if (isNil(packageJsonLocal) === false) {
+      if (_.isNil(packageJsonLocal) === false) {
         return reject(errorUtils.getConflict(API_ERROR.PACKAGE_EXIST));
       }
 
       for (let errorItem = 0; errorItem < upLinksErrors.length; errorItem++) {
         // checking error
         // if uplink fails with a status other than 404, we report failure
-        if (isNil(upLinksErrors[errorItem][0]) === false) {
+        if (_.isNil(upLinksErrors[errorItem][0]) === false) {
           if (upLinksErrors[errorItem][0].status !== HTTP_STATUS.NOT_FOUND) {
             if (isAllowPublishOffline) {
               return resolve();
@@ -399,4 +408,20 @@ export function mapManifestToSearchPackageBody(
   }
 
   return result;
+}
+
+export function normalizeContributors(contributors: Author[]): Author[] {
+  if (_.isNil(contributors)) {
+    return [];
+  } else if (contributors && _.isArray(contributors) === false) {
+    return [contributors];
+  } else if (_.isString(contributors)) {
+    return [
+      {
+        name: contributors,
+      },
+    ];
+  }
+
+  return contributors;
 }

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -19,6 +19,7 @@ import {
   PLUGIN_PREFIX,
   SUPPORT_ERRORS,
   USERS,
+  cryptoUtils,
   errorUtils,
   pluginUtils,
   searchUtils,
@@ -59,7 +60,6 @@ import {
   UnPublishManifest,
   Version,
 } from '@verdaccio/types';
-import { createTarballHash, normalizeContributors } from '@verdaccio/utils';
 
 import {
   PublishOptions,
@@ -69,8 +69,7 @@ import {
   tagVersion,
   tagVersionNext,
 } from '.';
-import { isPublishablePackage } from './lib/star-utils';
-import { isExecutingStarCommand } from './lib/star-utils';
+import { isExecutingStarCommand, isPublishablePackage } from './lib/star-utils';
 import {
   STORAGE,
   cleanUpLinksRef,
@@ -80,6 +79,7 @@ import {
   mapManifestToSearchPackageBody,
   mergeUplinkTimeIntoLocalNext,
   mergeVersions,
+  normalizeContributors,
   normalizeDistTags,
   normalizePackage,
   updateUpLinkMetadata,
@@ -1321,7 +1321,7 @@ class Storage {
     debug(`add a tarball for %o`, pkgName);
     assert(validationUtils.validateName(filename));
 
-    const shaOneHash = createTarballHash();
+    const shaOneHash = cryptoUtils.createTarballHash();
     const transformHash = new Transform({
       transform(chunk: any, _encoding: string, callback: any): void {
         // measure the length for validation reasons

--- a/packages/tools/helpers/package.json
+++ b/packages/tools/helpers/package.json
@@ -15,7 +15,6 @@
     "@verdaccio/logger": "workspace:8.0.0-next-8.15",
     "@verdaccio/middleware": "workspace:8.0.0-next-8.15",
     "@verdaccio/types": "workspace:13.0.0-next-8.5",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "body-parser": "1.20.3",
     "debug": "4.4.0",
     "express": "4.21.2",

--- a/packages/tools/helpers/src/initializeServer.ts
+++ b/packages/tools/helpers/src/initializeServer.ts
@@ -5,10 +5,9 @@ import path from 'path';
 
 import { Auth } from '@verdaccio/auth';
 import { Config } from '@verdaccio/config';
-import { errorUtils } from '@verdaccio/core';
+import { cryptoUtils, errorUtils } from '@verdaccio/core';
 import { setup } from '@verdaccio/logger';
 import { errorReportingMiddleware, final, handleError } from '@verdaccio/middleware';
-import { generateRandomHexString } from '@verdaccio/utils';
 
 const debug = buildDebug('verdaccio:tools:helpers:server');
 
@@ -20,7 +19,7 @@ export async function initializeServer(
   const app = express();
   const logger = setup(configObject.log ?? {});
   const config = new Config(configObject);
-  config.storage = path.join(os.tmpdir(), '/storage', generateRandomHexString());
+  config.storage = path.join(os.tmpdir(), '/storage', cryptoUtils.generateRandomHexString());
   // httpass would get path.basename() for configPath thus we need to create a dummy folder
   // to avoid conflics
   config.configPath = config.storage;

--- a/packages/ui-components/vitest/api/home.json
+++ b/packages/ui-components/vitest/api/home.json
@@ -37,7 +37,6 @@
       "@verdaccio/tarball": "13.0.0-next-8.7",
       "@verdaccio/ui-theme": "8.0.0-next-8.7",
       "@verdaccio/url": "13.0.0-next-8.7",
-      "@verdaccio/utils": "7.0.1-next-8.1",
       "JSONStream": "1.3.5",
       "async": "3.2.6",
       "clipanion": "4.0.0-rc.4",

--- a/packages/verdaccio/package.json
+++ b/packages/verdaccio/package.json
@@ -46,7 +46,6 @@
     "@verdaccio/logger": "workspace:8.0.0-next-8.15",
     "@verdaccio/node-api": "workspace:8.0.0-next-8.15",
     "@verdaccio/ui-theme": "workspace:8.0.0-next-8.15",
-    "@verdaccio/utils": "workspace:8.1.0-next-8.15",
     "verdaccio-audit": "workspace:13.0.0-next-8.15",
     "verdaccio-htpasswd": "workspace:13.0.0-next-8.15"
   },

--- a/packages/verdaccio/src/server/registry.ts
+++ b/packages/verdaccio/src/server/registry.ts
@@ -4,17 +4,12 @@ import fs from 'fs';
 import path from 'path';
 
 import { fromJStoYAML } from '@verdaccio/config';
-import { HTTP_STATUS, TOKEN_BEARER, fileUtils } from '@verdaccio/core';
+import { HTTP_STATUS, TOKEN_BEARER, authUtils, fileUtils } from '@verdaccio/core';
 import { ConfigYaml } from '@verdaccio/types';
-import { buildToken } from '@verdaccio/utils';
 
 import { ServerQuery } from './request';
 
 const { writeFile } = fs.promises ? fs.promises : require('fs/promises');
-
-const buildAuthHeader = (token: string): string => {
-  return buildToken(TOKEN_BEARER, token);
-};
 
 const debug = buildDebug('verdaccio:registry');
 
@@ -150,7 +145,7 @@ export class Registry {
               user.status(HTTP_STATUS.CREATED).body_ok(new RegExp(this.credentials.user));
               // @ts-ignore
               this.token = user?.response?.body.token;
-              this.authstr = buildAuthHeader(this.token as string);
+              this.authstr = authUtils.buildToken(TOKEN_BEARER, this.token as string);
             }
 
             return resolve(this.childFork);

--- a/packages/verdaccio/test/disabled_test/__helper/api.ts
+++ b/packages/verdaccio/test/disabled_test/__helper/api.ts
@@ -1,12 +1,19 @@
 import _ from 'lodash';
 import request from 'supertest';
 
-import { HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
+import {
+  HEADERS,
+  HEADER_TYPE,
+  HTTP_STATUS,
+  TOKEN_BEARER,
+  authUtils,
+  cryptoUtils,
+} from '@verdaccio/core';
 import { Package } from '@verdaccio/types';
-import { buildToken } from '@verdaccio/utils';
-import { generateRandomHexString } from '@verdaccio/utils';
 
 import { getTaggedVersionFromPackage } from './expects';
+
+const buildToken = authUtils.buildToken;
 
 // API Helpers
 
@@ -46,7 +53,7 @@ export function putPackage(
 export function deletePackage(request: any, pkgName: string, token?: string): Promise<any[]> {
   return new Promise((resolve) => {
     let del = request
-      .put(`/${pkgName}/-rev/${generateRandomHexString(8)}`)
+      .put(`/${pkgName}/-rev/${cryptoUtils.generateRandomHexString(8)}`)
       .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON);
 
     if (_.isNil(token) === false) {
@@ -208,5 +215,5 @@ export async function verifyPackageVersionDoesExist(app, packageName, version, t
 }
 
 export function generateUnPublishURI(pkgName) {
-  return `/${pkgName}/-rev/${generateRandomHexString(8)}`;
+  return `/${pkgName}/-rev/${cryptoUtils.generateRandomHexString(8)}`;
 }

--- a/packages/verdaccio/test/disabled_test/sanity/nullstorage.ts
+++ b/packages/verdaccio/test/disabled_test/sanity/nullstorage.ts
@@ -1,5 +1,4 @@
-import { API_ERROR, DIST_TAGS, HTTP_STATUS } from '@verdaccio/core';
-import { createTarballHash } from '@verdaccio/utils';
+import { API_ERROR, DIST_TAGS, HTTP_STATUS, cryptoUtils } from '@verdaccio/core';
 
 import { DOMAIN_SERVERS, PORT_SERVER_1, TARBALL } from '../config.functional';
 import generatePkg from '../fixtures/package';
@@ -50,7 +49,7 @@ export default function (server, server2) {
 
         beforeAll(function () {
           let pkg = generatePkg(PKG_NAME);
-          pkg.dist.shasum = createTarballHash().update(getBinary()).digest('hex');
+          pkg.dist.shasum = cryptoUtils.createTarballHash().update(getBinary()).digest('hex');
           return server2
             .putVersion(PKG_NAME, PKG_VERSION, pkg)
             .status(HTTP_STATUS.CREATED)

--- a/packages/verdaccio/test/disabled_test/uplinks/cache.ts
+++ b/packages/verdaccio/test/disabled_test/uplinks/cache.ts
@@ -1,9 +1,7 @@
-import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 
-import { HTTP_STATUS } from '@verdaccio/core';
-import { createTarballHash } from '@verdaccio/utils';
+import { HTTP_STATUS, cryptoUtils } from '@verdaccio/core';
 
 import { TARBALL } from '../config.functional';
 import requirePackage from '../fixtures/package';
@@ -38,7 +36,7 @@ export default function (server, server2, server3) {
 
     beforeAll(function () {
       const pkg = requirePackage(PKG_GH131);
-      pkg.dist.shasum = crypto.createHash('sha1').update(getBinary()).digest('hex');
+      pkg.dist.shasum = cryptoUtils.createTarballHash().update(getBinary()).digest('hex');
 
       return server
         .putVersion(PKG_GH131, '0.0.1', pkg)
@@ -71,7 +69,7 @@ export default function (server, server2, server3) {
 
     beforeAll(function () {
       const pkg = requirePackage(PKG_GH1312);
-      pkg.dist.shasum = createTarballHash().update(getBinary()).digest('hex');
+      pkg.dist.shasum = cryptoUtils.createTarballHash().update(getBinary()).digest('hex');
 
       return server2
         .putVersion(PKG_GH1312, '0.0.1', pkg)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -560,9 +560,6 @@ importers:
       '@verdaccio/store':
         specifier: workspace:8.0.0-next-8.15
         version: link:../store
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../utils
       abortcontroller-polyfill:
         specifier: 1.7.8
         version: 1.7.8
@@ -615,9 +612,6 @@ importers:
       '@verdaccio/signature':
         specifier: workspace:8.0.0-next-8.7
         version: link:../signature
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../utils
       debug:
         specifier: 4.4.0
         version: 4.4.0(supports-color@5.5.0)
@@ -680,9 +674,6 @@ importers:
       '@verdaccio/core':
         specifier: workspace:8.0.0-next-8.15
         version: link:../core/core
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../utils
       debug:
         specifier: 4.4.0
         version: 4.4.0(supports-color@5.5.0)
@@ -757,9 +748,6 @@ importers:
       '@verdaccio/url':
         specifier: workspace:13.0.0-next-8.15
         version: link:../url
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../../utils
       debug:
         specifier: 4.4.0
         version: 4.4.0(supports-color@5.5.0)
@@ -944,9 +932,6 @@ importers:
       '@verdaccio/url':
         specifier: workspace:13.0.0-next-8.15
         version: link:../core/url
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../utils
       debug:
         specifier: 4.4.0
         version: 4.4.0(supports-color@5.5.0)
@@ -1117,9 +1102,6 @@ importers:
       '@verdaccio/file-locking':
         specifier: workspace:13.0.0-next-8.3
         version: link:../../core/file-locking
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../../utils
       core-js:
         specifier: 3.40.0
         version: 3.40.0
@@ -1434,9 +1416,6 @@ importers:
       '@verdaccio/core':
         specifier: workspace:8.0.0-next-8.15
         version: link:../core/core
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../utils
       JSONStream:
         specifier: 1.3.5
         version: 1.3.5
@@ -1544,9 +1523,6 @@ importers:
       '@verdaccio/store':
         specifier: workspace:8.0.0-next-8.15
         version: link:../../store
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../../utils
       '@verdaccio/web':
         specifier: workspace:8.1.0-next-8.15
         version: link:../../web
@@ -1599,9 +1575,6 @@ importers:
       '@verdaccio/tarball':
         specifier: workspace:13.0.0-next-8.15
         version: link:../../core/tarball
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../../utils
       core-js:
         specifier: 3.40.0
         version: 3.40.0
@@ -1697,9 +1670,6 @@ importers:
       '@verdaccio/url':
         specifier: workspace:13.0.0-next-8.15
         version: link:../core/url
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../utils
       JSONStream:
         specifier: 1.3.5
         version: 1.3.5
@@ -1860,9 +1830,6 @@ importers:
       '@verdaccio/types':
         specifier: workspace:13.0.0-next-8.5
         version: link:../../core/types
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../../utils
       body-parser:
         specifier: 1.20.3
         version: 1.20.3
@@ -2142,9 +2109,6 @@ importers:
       '@verdaccio/ui-theme':
         specifier: workspace:8.0.0-next-8.15
         version: link:../plugins/ui-theme
-      '@verdaccio/utils':
-        specifier: workspace:8.1.0-next-8.15
-        version: link:../utils
       verdaccio-audit:
         specifier: workspace:13.0.0-next-8.15
         version: link:../plugins/audit


### PR DESCRIPTION
This PR replaces the remaining dependencies on `@verdaccio/utils` with core utilities. 

Suggest deprecating `@verdaccio/utils`.