### PR TITLE
chore(signature): remove duplicate code

### DIFF
--- a/.changeset/poor-queens-shop.md
+++ b/.changeset/poor-queens-shop.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/signature': patch
+'@verdaccio/config': patch
+---
+
+chore(signature): remove duplicate code

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -2,7 +2,7 @@ import buildDebug from 'debug';
 import _ from 'lodash';
 import { HTPasswd } from 'verdaccio-htpasswd';
 
-import { createAnonymousRemoteUser, createRemoteUser } from '@verdaccio/config';
+import { TOKEN_VALID_LENGTH, createAnonymousRemoteUser, createRemoteUser } from '@verdaccio/config';
 import {
   API_ERROR,
   PLUGIN_CATEGORY,
@@ -21,7 +21,6 @@ import {
   aesEncryptDeprecated,
   parseBasicPayload,
   signPayload,
-  utils as signatureUtils,
 } from '@verdaccio/signature';
 import {
   AllowAccess,
@@ -595,7 +594,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
    * Encrypt a string.
    */
   public aesEncrypt(value: string): string | void {
-    if (this.secret.length === signatureUtils.TOKEN_VALID_LENGTH) {
+    if (this.secret.length === TOKEN_VALID_LENGTH) {
       debug('signing with enhanced aes legacy');
       const token = aesEncrypt(value, this.secret);
       return token;

--- a/packages/config/src/token.ts
+++ b/packages/config/src/token.ts
@@ -1,11 +1,9 @@
 import { randomBytes } from 'crypto';
 
-// TODO: code duplicated at @verdaccio/signature
 export const TOKEN_VALID_LENGTH = 32;
 
 /**
  * Secret key must have 32 characters.
- * // TODO: code duplicated at @verdaccio/signature
  */
 export function generateRandomSecretKey(): string {
   return randomBytes(TOKEN_VALID_LENGTH).toString('base64').substring(0, TOKEN_VALID_LENGTH);

--- a/packages/signature/package.json
+++ b/packages/signature/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@verdaccio/config": "workspace:8.0.0-next-8.15",
+    "@verdaccio/core": "workspace:8.0.0-next-8.15",
     "jsonwebtoken": "9.0.2",
     "debug": "4.4.0"
   },

--- a/packages/signature/src/legacy-signature/index.ts
+++ b/packages/signature/src/legacy-signature/index.ts
@@ -1,10 +1,9 @@
 import { createCipher, createDecipher } from 'crypto';
 import buildDebug from 'debug';
 
-import { generateRandomHexString } from '../utils';
+import { cryptoUtils } from '@verdaccio/core';
 
 export const defaultAlgorithm = 'aes192';
-export const defaultTarballHashAlgorithm = 'sha1';
 
 const debug = buildDebug('verdaccio:auth:token:legacy:deprecated');
 
@@ -54,5 +53,5 @@ export const TOKEN_VALID_LENGTH_DEPRECATED = 64;
  * Generate a secret key of 64 characters.
  */
 export function generateRandomSecretKeyDeprecated(): string {
-  return generateRandomHexString(6);
+  return cryptoUtils.generateRandomHexString(6);
 }

--- a/packages/signature/src/utils.ts
+++ b/packages/signature/src/utils.ts
@@ -1,40 +1,14 @@
-import { Hash, createHash, pseudoRandomBytes, randomBytes } from 'crypto';
+import { TOKEN_VALID_LENGTH, generateRandomSecretKey } from '@verdaccio/config';
+import { cryptoUtils } from '@verdaccio/core';
 
-export const defaultTarballHashAlgorithm = 'sha1';
+// @deprecated use @verdaccio/core.cryptoUtils instead
+export const defaultTarballHashAlgorithm = cryptoUtils.defaultTarballHashAlgorithm;
+// @deprecated use @verdaccio/core.cryptoUtils instead
+export const stringToMD5 = cryptoUtils.stringToMD5;
+// @deprecated use @verdaccio/core.cryptoUtils instead
+export const createTarballHash = cryptoUtils.createTarballHash;
+// @deprecated use @verdaccio/core.cryptoUtils instead
+export const generateRandomHexString = cryptoUtils.generateRandomHexString;
 
-/**
- *
- * @returns
- */
-export function createTarballHash(algorithm = defaultTarballHashAlgorithm): Hash {
-  return createHash(algorithm);
-}
-
-/**
- * Express doesn't do ETAGS with requests <= 1024b
- * we use md5 here, it works well on 1k+ bytes, but with fewer data
- * could improve performance using crc32 after benchmarks.
- * @param {Object} data
- * @return {String}
- */
-export function stringToMD5(data: Buffer | string): string {
-  return createHash('md5').update(data).digest('hex');
-}
-
-/**
- *
- * @param length
- * @returns
- */
-export function generateRandomHexString(length = 8): string {
-  return pseudoRandomBytes(length).toString('hex');
-}
-
-export const TOKEN_VALID_LENGTH = 32;
-
-/**
- * Generate a secret of 32 characters.
- */
-export function generateRandomSecretKey(): string {
-  return randomBytes(TOKEN_VALID_LENGTH).toString('base64').substring(0, TOKEN_VALID_LENGTH);
-}
+// @deprecated use @verdaccio/config instead
+export { TOKEN_VALID_LENGTH, generateRandomSecretKey };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1630,6 +1630,9 @@ importers:
       '@verdaccio/config':
         specifier: workspace:8.0.0-next-8.15
         version: link:../config
+      '@verdaccio/core':
+        specifier: workspace:8.0.0-next-8.15
+        version: link:../core/core
       debug:
         specifier: 4.4.0
         version: 4.4.0(supports-color@5.5.0)


### PR DESCRIPTION
We could delete `signature/src/utils.ts` (and `signature/test/utils.spec.ts`) but I'm not sure if that's used somewhere else.