### PR TITLE
chore: update docker publish action

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,50 +2,49 @@ name: Docker publish to docker.io
 
 on:
   push:
-    paths:
-      - .github/workflows/docker-publish.yml
-      - .github/workflows/docker-publish.yml
-      - 'packages/**'
-      - 'docker-bin/**'
-      - 'package.json'
-      - 'pnpm-*.yaml'
-      - 'Dockerfile'
-      - '.dockerignore'
     branches:
       - 'master'
     tags:
       - 'v*'
 
 permissions:
-  contents: read  #  to fetch code (actions/checkout)
+  contents: read
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     if: github.repository == 'verdaccio/verdaccio'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      - uses: docker/setup-buildx-action@v1
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
         with:
           driver-opts: network=host
-      - uses: docker/login-action@v1
-        name: Login Docker Hub
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Prepare docker image tags
+
+      - name: Prepare Docker image tags
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v5
         with:
           images: ${{ github.repository }}
-          tag-custom: nightly-master
-          tag-custom-only: ${{ github.ref == 'refs/heads/master' }}
-          tag-latest: false
-          tag-semver: |
-            {{version}}
-            {{major}}
-            {{major}}.{{minor}}
+          tags: |
+            type=raw,value=nightly-master
+            type=raw,value=latest,enable=false
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.created=${{ steps.docker_meta.outputs.created }}
+            org.opencontainers.image.version=${{ steps.docker_meta.outputs.version }}
+
       - name: Build & Push
         uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
- Update build and push pipeline to docker official actions
- Test on master first, moved later to 6.x branch
- Explicit to push an image on each commit to master
- Latest tag disabled
- No semver support on master branch
- ✅  Setup already tested in another repo

```
 type=raw,value=nightly-master
 type=raw,value=latest,enable=false
```