### PR TITLE
fix: docker smoke test (6.x)

### DIFF
--- a/.github/workflows/smoke-test-docker.yml
+++ b/.github/workflows/smoke-test-docker.yml
@@ -14,4 +14,4 @@ jobs:
     uses: verdaccio/verdaccio/.github/workflows/x-smok-test-docker.yml@master
     with:
       docker_tag: '6.x-next'
-
+      module_tag: '@latest'


### PR DESCRIPTION
Looks like this was never working in 6.x

https://github.com/verdaccio/verdaccio/actions/runs/14802762748

![image](https://github.com/user-attachments/assets/68d64e30-5641-4e4a-94a0-133d7b1477ec)
