### PR TITLE
fix: config web login default (6.x)

### DIFF
--- a/src/api/web/api/package.ts
+++ b/src/api/web/api/package.ts
@@ -44,7 +44,7 @@ function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router 
   const checkAllow = (name, remoteUser): Promise<boolean> =>
     new Promise((resolve, reject): void => {
       try {
-        const isLoginEnabled = config?.web?.login === true;
+        const isLoginEnabled = _.isNil(config?.web?.login) || config?.web?.login === true;
         const anonymousRemoteUser: RemoteUser = createAnonymousRemoteUser();
         const remoteUserAccess = !isLoginEnabled ? anonymousRemoteUser : remoteUser;
         auth.allow_access({ packageName: name }, remoteUserAccess, (err, allowed): void => {

--- a/test/unit/partials/config/yaml/api.web.spec.yaml
+++ b/test/unit/partials/config/yaml/api.web.spec.yaml
@@ -1,7 +1,6 @@
 storage: ./storage_default_storage
 web:
   title: Verdaccio
-  login: true
   rateLimit:
     windowMs: 5000000
     max: 100000


### PR DESCRIPTION
If `config.web.login` is not set, assume `true`.

Regression #5250 