### PR TITLE
fix: add `@verdaccio/core` as a dependency

### DIFF
--- a/.changeset/fuzzy-ears-yawn.md
+++ b/.changeset/fuzzy-ears-yawn.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/loaders': patch
+---
+
+add `@verdaccio/core` as a dependency

--- a/packages/loaders/package.json
+++ b/packages/loaders/package.json
@@ -17,17 +17,17 @@
     "url": "https://github.com/verdaccio/verdaccio/issues"
   },
   "dependencies": {
+    "@verdaccio/core": "workspace:8.0.0-next-8.17",
     "debug": "4.4.1",
     "lodash": "4.17.21"
   },
   "devDependencies": {
     "@verdaccio/logger": "workspace:8.0.0-next-8.17",
-    "@verdaccio/core": "workspace:8.0.0-next-8.17",
     "@verdaccio/config": "workspace:8.0.0-next-8.17",
     "@verdaccio/types": "workspace:13.0.0-next-8.6",
     "@verdaccio-scope/verdaccio-auth-foo": "0.0.2",
-    "verdaccio-auth-memory": "workspace:*",
-    "customprefix-auth": "workspace:2.0.0"
+    "customprefix-auth": "workspace:2.0.0",
+    "verdaccio-auth-memory": "workspace:*"
   },
   "homepage": "https://verdaccio.org",
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -841,6 +841,9 @@ importers:
 
   packages/loaders:
     dependencies:
+      '@verdaccio/core':
+        specifier: workspace:8.0.0-next-8.17
+        version: link:../core/core
       debug:
         specifier: 4.4.1
         version: 4.4.1(supports-color@5.5.0)
@@ -854,9 +857,6 @@ importers:
       '@verdaccio/config':
         specifier: workspace:8.0.0-next-8.17
         version: link:../config
-      '@verdaccio/core':
-        specifier: workspace:8.0.0-next-8.17
-        version: link:../core/core
       '@verdaccio/logger':
         specifier: workspace:8.0.0-next-8.17
         version: link:../logger/logger


### PR DESCRIPTION

`@verdaccio/core` is needed as a runtime dependency. See: https://github.com/verdaccio/verdaccio/blob/31a18f8f613925abe89ed37b19f227ce25da9c1b/packages/loaders/src/utils.ts#L3

```
Error: Cannot find module '@verdaccio/core'
Require stack:
- /home/runner/.cache/bazel/_bazel_runner/f47b8283cc0f5922f9455b06771398a1/sandbox/processwrapper-sandbox/3053/execroot/_main/bazel-out/k8-fastbuild/bin/tests/legacy-cli/e2e.esbuild_node22_/e2e.esbuild_node22.runfiles/_main/node_modules/.aspect_rules_js/@verdaccio+loaders@8.0.0-next-8.7/node_modules/@verdaccio/loaders/build/plugin-async-loader.js
```