### PR TITLE
fix: allow config changes in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ ADD packages/config/src/conf/docker.yaml /verdaccio/conf/config.yaml
 
 RUN adduser -u $VERDACCIO_USER_UID -S -D -h $VERDACCIO_APPDIR -g "$VERDACCIO_USER_NAME user" -s /sbin/nologin $VERDACCIO_USER_NAME && \
     chmod -R +x $VERDACCIO_APPDIR/packages/verdaccio/bin $VERDACCIO_APPDIR/docker-bin && \
-    chown -R $VERDACCIO_USER_UID:root /verdaccio/storage && \
-    chmod -R g=u /verdaccio/storage /etc/passwd
+    chown -R $VERDACCIO_USER_UID:root /verdaccio/storage /verdaccio/conf && \
+    chmod -R g=u /verdaccio/storage /verdaccio/conf /etc/passwd
 
 USER $VERDACCIO_USER_UID
 


### PR DESCRIPTION
Changes the ownership of the config directory from root to Verdaccio user. This way you can make config changes and restart the server more easily.