### PR TITLE
fix: running without auth plugin

### DIFF
--- a/.changeset/fast-falcons-change.md
+++ b/.changeset/fast-falcons-change.md
@@ -1,6 +1,7 @@
 ---
 '@verdaccio/loaders': patch
 '@verdaccio/auth': patch
+'@verdaccio/types': patch
 ---
 
 fix: running without auth plugin

--- a/.changeset/fast-falcons-change.md
+++ b/.changeset/fast-falcons-change.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/loaders': patch
+'@verdaccio/auth': patch
+---
+
+fix: running without auth plugin

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -47,8 +47,7 @@
     "@verdaccio/loaders": "workspace:8.0.0-next-8.8",
     "@verdaccio/signature": "workspace:8.0.0-next-8.10",
     "debug": "4.4.1",
-    "lodash": "4.17.21",
-    "verdaccio-htpasswd": "workspace:13.0.0-next-8.18"
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@verdaccio/middleware": "workspace:8.0.0-next-8.18",

--- a/packages/auth/src/utils.ts
+++ b/packages/auth/src/utils.ts
@@ -157,7 +157,7 @@ export function isAuthHeaderValid(authorization: string): boolean {
  * @param logger {Logger}
  * @returns object of default implementations.
  */
-export function getDefaultPlugins(logger: Logger): pluginUtils.Auth<Config> {
+export function getDefaultPluginMethods(logger: Logger): pluginUtils.Auth<Config> {
   return {
     authenticate(_user: string, _password: string, cb: pluginUtils.AuthCallback): void {
       debug('triggered default authenticate method');

--- a/packages/auth/test/auth-utils.spec.ts
+++ b/packages/auth/test/auth-utils.spec.ts
@@ -144,7 +144,7 @@ describe('Auth utilities', () => {
         name: 'foo',
         version: undefined,
         access: ['foo'],
-        unpublish: [],
+        unpublish: false,
       };
 
       // const type = 'access';

--- a/packages/auth/test/auth-utils.spec.ts
+++ b/packages/auth/test/auth-utils.spec.ts
@@ -27,7 +27,7 @@ import {
   Auth,
   allow_action,
   getApiToken,
-  getDefaultPlugins,
+  getDefaultPluginMethods,
 } from '../src';
 
 setup({});
@@ -122,14 +122,14 @@ describe('Auth utilities', () => {
 
   describe('getDefaultPlugins', () => {
     test('authentication should fail by default (default)', () => {
-      const plugin = getDefaultPlugins({ trace: vi.fn() });
+      const plugin = getDefaultPluginMethods(logger);
       plugin.authenticate('foo', 'bar', (error: any) => {
         expect(error).toEqual(errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
       });
     });
 
     test('add user should not fail by default (default)', () => {
-      const plugin = getDefaultPlugins({ trace: vi.fn() });
+      const plugin = getDefaultPluginMethods(logger);
       // @ts-ignore
       plugin.adduser('foo', 'bar', (error: any, access: any) => {
         expect(error).toEqual(null);
@@ -144,14 +144,14 @@ describe('Auth utilities', () => {
         name: 'foo',
         version: undefined,
         access: ['foo'],
-        unpublish: false,
+        unpublish: [],
       };
 
       // const type = 'access';
       test.each(['access', 'publish', 'unpublish'])(
         'should restrict %s to anonymous users',
         (type) => {
-          allow_action(type as ActionsAllowed, { trace: vi.fn() })(
+          allow_action(type as ActionsAllowed, logger)(
             createAnonymousRemoteUser(),
             {
               ...packageAccess,
@@ -168,7 +168,7 @@ describe('Auth utilities', () => {
       test.each(['access', 'publish', 'unpublish'])(
         'should allow %s to anonymous users',
         (type) => {
-          allow_action(type as ActionsAllowed, { trace: vi.fn() })(
+          allow_action(type as ActionsAllowed, logger)(
             createAnonymousRemoteUser(),
             {
               ...packageAccess,
@@ -185,7 +185,7 @@ describe('Auth utilities', () => {
       test.each(['access', 'publish', 'unpublish'])(
         'should allow %s only if user is anonymous if the logged user has groups',
         (type) => {
-          allow_action(type as ActionsAllowed, { trace: vi.fn() })(
+          allow_action(type as ActionsAllowed, logger)(
             createRemoteUser('juan', ['maintainer', 'admin']),
             {
               ...packageAccess,
@@ -202,7 +202,7 @@ describe('Auth utilities', () => {
       test.each(['access', 'publish', 'unpublish'])(
         'should allow %s only if user is anonymous match any other groups',
         (type) => {
-          allow_action(type as ActionsAllowed, { trace: vi.fn() })(
+          allow_action(type as ActionsAllowed, logger)(
             createRemoteUser('juan', ['maintainer', 'admin']),
             {
               ...packageAccess,
@@ -219,7 +219,7 @@ describe('Auth utilities', () => {
       test.each(['access', 'publish', 'unpublish'])(
         'should not allow %s anonymous if other groups are defined and does not match',
         (type) => {
-          allow_action(type as ActionsAllowed, { trace: vi.fn() })(
+          allow_action(type as ActionsAllowed, logger)(
             createRemoteUser('juan', ['maintainer', 'admin']),
             {
               ...packageAccess,

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -51,7 +51,7 @@ describe('AuthTest', () => {
       expect(auth).toBeDefined();
     });
 
-    test('should load default auth plugin', async () => {
+    test('should load default auth plugin methods', async () => {
       const config: Config = new AppConfig({ ...authProfileConf, auth: undefined });
       config.checkSecretKey('12345');
 
@@ -600,6 +600,7 @@ describe('AuthTest', () => {
             config.checkSecretKey(secret);
             const auth = new Auth(config, logger);
             await auth.init();
+            // expect failure with "bad authorization header"
             const app = await getServer(auth);
             return supertest(app)
               .get(`/`)
@@ -644,6 +645,7 @@ describe('AuthTest', () => {
             const auth = new Auth(config, logger);
             await auth.init();
             const token = auth.aesEncrypt(payload) as string;
+            // expect failure with "unknown error"
             const app = await getServer(auth);
             return await supertest(app)
               .get(`/`)

--- a/packages/core/types/src/manifest.ts
+++ b/packages/core/types/src/manifest.ts
@@ -3,7 +3,7 @@ export interface PackageAccess {
   publish?: string[];
   proxy?: string[];
   access?: string[];
-  unpublish?: string[];
+  unpublish?: string[] | boolean; // false means fallback to publish access
 }
 
 export interface PackageList {

--- a/packages/loaders/src/plugin-async-loader.ts
+++ b/packages/loaders/src/plugin-async-loader.ts
@@ -57,7 +57,7 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
   pluginCategory: string = 'unknown'
 ): Promise<PluginType<T>[]> {
   const logger = pluginOptions?.logger;
-  const pluginsIds = Object.keys(pluginConfigs);
+  const pluginsIds = Object.keys(pluginConfigs || {});
   const { config } = pluginOptions;
   let plugins: PluginType<T>[] = [];
   for (let pluginId of pluginsIds) {

--- a/packages/loaders/test/partials/config/no-plugin.yaml
+++ b/packages/loaders/test/partials/config/no-plugin.yaml
@@ -1,0 +1,2 @@
+# no plugin
+auth:

--- a/packages/loaders/test/plugin_loader_async.spec.ts
+++ b/packages/loaders/test/plugin_loader_async.spec.ts
@@ -193,6 +193,15 @@ describe('plugin loader', () => {
     });
   });
 
+  describe('no plugins', () => {
+    test('should not fail if config section exists but no plugins are configured', async () => {
+      const config = getConfig('no-plugin.yaml');
+      const plugins = await asyncLoadPlugin(config.auth, { config, logger }, authSanitize);
+
+      expect(plugins).toHaveLength(0);
+    });
+  });
+
   describe('legacy merge configs', () => {
     // whenever 6.x and 7.x version are out of support, we can remove this test
     test('should merge configuration with plugin configuration', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,9 +630,6 @@ importers:
       lodash:
         specifier: 4.17.21
         version: 4.17.21
-      verdaccio-htpasswd:
-        specifier: workspace:13.0.0-next-8.18
-        version: link:../plugins/htpasswd
     devDependencies:
       '@verdaccio/logger':
         specifier: workspace:8.0.0-next-8.18


### PR DESCRIPTION
Closes #5192 

- Fixes regression in 6.1.x (`TypeError: Cannot convert undefined or null to object` in plugin loader). It's now possible again to run without an `auth` plugin using an empty `auth:` section in config. The default plugin methods will be used (*not* htpasswd). 
- Removes the special method to load `htpasswd` and the dependency since the plugin loader imports it already.
- Renames private methods related to auth fallback methods
- Fixes some minor ts error in tests