### PR TITLE
feat(logger): support redacting sensitive data

### DIFF
--- a/.changeset/cuddly-paws-laugh.md
+++ b/.changeset/cuddly-paws-laugh.md
@@ -1,4 +1,5 @@
 ---
+'@verdaccio/config': patch
 '@verdaccio/logger-commons': patch
 '@verdaccio/types': patch
 ---

--- a/.changeset/cuddly-paws-laugh.md
+++ b/.changeset/cuddly-paws-laugh.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/logger-commons': patch
+'@verdaccio/types': patch
+---
+
+feat(logger): support redacting sensitive data

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -210,7 +210,16 @@ middlewares:
 
 # Log settings
 # https://verdaccio.org/docs/logger
-log: { type: stdout, format: pretty, level: http }
+# Redaction: https://getpino.io/#/docs/redaction
+# Synchronous logging: https://getpino.io/#/docs/asynchronous
+log:
+  type: stdout
+  format: pretty
+  level: http
+#  redact:
+#    paths: ['req.header.authorization','req.header.cookie','req.remoteAddress','req.remotePort','ip','remoteIP','user','msg']
+#    censor: '<redacted>'
+#  sync: true
 
 # Feature flags (experimental settings that can be changed or removed in the future)
 # https://verdaccio.org/docs/configuration#experiments

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -210,7 +210,16 @@ middlewares:
 
 # Log settings
 # https://verdaccio.org/docs/logger
-log: { type: stdout, format: pretty, level: http }
+# Redaction: https://getpino.io/#/docs/redaction
+# Synchronous logging: https://getpino.io/#/docs/asynchronous
+log:
+  type: stdout
+  format: pretty
+  level: http
+#  redact:
+#    paths: ['req.header.authorization','req.header.cookie','req.remoteAddress','req.remotePort','ip','remoteIP','user','msg']
+#    censor: '<redacted>'
+#  sync: true
 
 # Feature flags (experimental settings that can be changed or removed in the future)
 # https://verdaccio.org/docs/configuration#experiments

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -20,13 +20,20 @@ export type LoggerType = 'stdout' | 'file';
 export type LoggerFormat = 'pretty' | 'pretty-timestamped' | 'json';
 export type LoggerLevel = 'fatal' | 'error' | 'warn' | 'info' | 'http' | 'debug' | 'trace';
 
+export type LoggerRedact = {
+  paths: string[];
+  censor?: string;
+  remove?: boolean;
+};
+
 export type LoggerConfigItem = {
   type?: LoggerType;
   format?: LoggerFormat;
   path?: string;
   level?: LoggerLevel;
   colors?: boolean;
-  async?: boolean;
+  sync?: boolean;
+  redact?: LoggerRedact;
 };
 
 export interface ConfigWithHttps extends Config {

--- a/packages/logger/logger-commons/src/logger.ts
+++ b/packages/logger/logger-commons/src/logger.ts
@@ -25,10 +25,8 @@ export type LogPlugin = {
   options?: any[];
 };
 
-type LoggerOptions = { level?: string; path?: string; colors?: boolean; sync?: boolean };
-
 export function createLogger(
-  options: LoggerOptions = { level: 'http' },
+  options: LoggerConfigItem = { level: 'http' },
   // eslint-disable-next-line no-undef
   // @ts-ignore
   destination: NodeJS.WritableStream = pino.destination(1),
@@ -46,6 +44,8 @@ export function createLogger(
       req: pino.stdSerializers.req,
       res: pino.stdSerializers.res,
     },
+    sync: options.sync,
+    redact: options.redact,
   };
 
   debug('has prettifier? %o', !isProd());
@@ -124,32 +124,17 @@ export function prepareSetup(options: LoggerConfigItem = DEFAULT_LOGGER_CONF, pi
       loggerConfig
     );
   }
-  const pinoConfig = { level: loggerConfig.level };
   if (loggerConfig.type === 'file') {
     debug('logging file enabled');
     const destination = pino.destination(loggerConfig.path);
     /* eslint-disable */
     /* istanbul ignore next */
     process.on('SIGUSR2', () => destination.reopen());
-    // @ts-ignore
-    logger = createLogger(
-      { level: loggerConfig.level, path: loggerConfig.path, colors: loggerConfig.colors },
-      // @ts-ignore
-      destination,
-      loggerConfig.format,
-      pino
-    );
+    logger = createLogger(loggerConfig, destination, loggerConfig.format, pino);
     return logger;
   } else {
     debug('logging stdout enabled');
-    // @ts-ignore
-    logger = createLogger(
-      { level: loggerConfig.level, colors: loggerConfig.colors },
-      // @ts-ignore
-      pino.destination(1),
-      loggerConfig.format,
-      pino
-    );
+    logger = createLogger(loggerConfig, pino.destination(1), loggerConfig.format, pino);
     return logger;
   }
 }

--- a/website/docs/logger.md
+++ b/website/docs/logger.md
@@ -28,6 +28,28 @@ log: { type: file, path: verdaccio.log, level: info }
 Use `SIGUSR2` to notify the application, the log-file was rotated and it needs to reopen it.
 Note: Rotating log stream is not supported in cluster mode. [See here](https://github.com/trentm/node-bunyan#stream-type-rotating-file)
 
+Sensitive data can be masked or removed using [log redaction](https://getpino.io/#/docs/redaction).
+
+```yaml
+log:
+  type: stdout
+  format: pretty
+  level: http
+  redact:
+    paths:
+      [
+        'req.header.authorization',
+        'req.header.cookie',
+        'req.remoteAddress',
+        'req.remotePort',
+        'ip',
+        'remoteIP',
+        'user',
+        'msg',
+      ]
+    censor: '<redacted>'
+```
+
 ### Configuration {#configuration}
 
 | Property | Type    | Required | Example                                        | Support | Description                                       |
@@ -37,3 +59,5 @@ Note: Rotating log stream is not supported in cluster mode. [See here](https://g
 | format   | string  | No       | [pretty, pretty-timestamped]                   | all     | output format                                     |
 | level    | string  | No       | [fatal, error, warn, info, http, debug, trace] | all     | verbose level                                     |
 | colors   | boolean | No       | false                                          | v5.7.0  | disable or enable colors                          |
+| redact   | object  | No       | see above                                      |         | redact sensitive data                             |
+| sync     | boolean | No       | true                                           |         | turn on synchronous logging                       |


### PR DESCRIPTION
### Logger

Allow configuring [pino log redaction](https://getpino.io/#/docs/redaction) to remove or mask sensitive data.

Example:

```yaml
log: 
  type: stdout
  format: json
  level: http
  redact:
    paths: ['req.header.authorization','req.header.cookie','req.remoteAddress','req.remotePort','ip','remoteIP','user','msg']
    censor: '<redacted>'
```

Also fixes passing the `sync` option to pino (which isn't [documented](https://verdaccio.org/docs/logger)). 

### Middleware

Authorization and cookies are already redacted by [middleware](https://github.com/verdaccio/verdaccio/blob/5fef0b629a430a27b714489abd1ee377231e479e/packages/middleware/src/middlewares/log.ts#L18-L26). This code could be deleted if we set `log.redact.paths.` to this default:

```yaml
log:
  redact:
    paths: ['req.header.authorization','req.header.cookie']
    censor: '<Classified>'
```
