### PR TITLE
fix(middleware): logging aborted requests

### DIFF
--- a/.changeset/brown-impalas-change.md
+++ b/.changeset/brown-impalas-change.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/middleware': patch
+'@verdaccio/core': patch
+---
+
+fix(middleware): logging aborted requests

--- a/packages/core/core/src/constants.ts
+++ b/packages/core/core/src/constants.ts
@@ -66,12 +66,12 @@ export const HEADERS = {
  * HTTP status codes used throughout Verdaccio.
  */
 export const HTTP_STATUS = {
-  /** 202: The request has been accepted for processing, but the processing is not yet complete. */
-  ACCEPTED: httpCodes.ACCEPTED,
   /** 200: Standard response for successful HTTP requests. */
   OK: httpCodes.OK,
   /** 201: The request has been fulfilled and resulted in a new resource being created. */
   CREATED: httpCodes.CREATED,
+  /** 202: The request has been accepted for processing, but the processing is not yet complete. */
+  ACCEPTED: httpCodes.ACCEPTED,
   /** 300: Indicates multiple options for the resource from which the client may choose. */
   MULTIPLE_CHOICES: httpCodes.MULTIPLE_CHOICES,
   /** 304: Indicates that the resource has not been modified since the last request. */
@@ -92,6 +92,8 @@ export const HTTP_STATUS = {
   UNSUPPORTED_MEDIA: httpCodes.UNSUPPORTED_MEDIA_TYPE,
   /** 422: The request was well-formed but was unable to be followed due to semantic errors. */
   BAD_DATA: httpCodes.UNPROCESSABLE_ENTITY,
+  /** 499: The request was aborted by the client. */
+  CLIENT_CLOSED_REQUEST: 499,
   /** 500: The server has encountered a situation it doesn't know how to handle. */
   INTERNAL_ERROR: httpCodes.INTERNAL_SERVER_ERROR,
   /** 501: The request method is not supported by the server and cannot be handled. */
@@ -130,6 +132,7 @@ export const LOG_STATUS_MESSAGE =
   "@{status}, user: @{user}(@{remoteIP}), req: '@{request.method} @{request.url}'";
 export const LOG_VERDACCIO_ERROR = `${LOG_STATUS_MESSAGE}, error: @{!error}`;
 export const LOG_VERDACCIO_BYTES = `${LOG_STATUS_MESSAGE}, bytes: @{bytes.in}/@{bytes.out}`;
+export const LOG_VERDACCIO_ABORT = `${LOG_STATUS_MESSAGE}, request aborted by client`;
 
 export const ROLES = {
   $ALL: '$all',

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -12,12 +12,7 @@ export { rateLimit } from './middlewares/rate-limit';
 export { userAgent } from './middlewares/user-agent';
 export { webMiddleware, renderWebMiddleware } from './middlewares/web';
 export { errorReportingMiddleware, handleError } from './middlewares/error';
-export {
-  log,
-  LOG_STATUS_MESSAGE,
-  LOG_VERDACCIO_BYTES,
-  LOG_VERDACCIO_ERROR,
-} from './middlewares/log';
+export { log } from './middlewares/log';
 export * from './types';
 export * from './middlewares/api_urls';
 export * from './middlewares/web/web-urls';

--- a/packages/middleware/src/middlewares/security-headers.ts
+++ b/packages/middleware/src/middlewares/security-headers.ts
@@ -3,7 +3,7 @@ import { HEADERS } from '@verdaccio/core';
 import { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '../types';
 
 // TODO: remove, was relocated to web package
-// @ts-deprecated
+// @deprecated use @verdaccio/web instead
 export function setSecurityWebHeaders(
   req: $RequestExtend,
   res: $ResponseExtend,

--- a/packages/middleware/test/log.spec.ts
+++ b/packages/middleware/test/log.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import request from 'supertest';
-import { test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { HTTP_STATUS } from '@verdaccio/core';
 import { logger, setup } from '@verdaccio/logger';
@@ -19,11 +19,88 @@ test('should log request', async () => {
   const app = getApp([]);
   // @ts-ignore
   app.use(log(logger));
-  // @ts-ignore
   app.get('/:package', (req, res) => {
     res.status(HTTP_STATUS.OK).json({});
   });
 
   // TODO: pending output
   return request(app).get('/react').expect(HTTP_STATUS.OK);
+});
+
+test('should log request aborted by user', async () => {
+  const app = getApp([]);
+  // Create a mock child logger to spy on
+  const mockChildLogger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    http: vi.fn(),
+  };
+
+  const mockLogger = {
+    child: vi.fn(() => mockChildLogger),
+  };
+
+  // @ts-ignore
+  app.use(log(mockLogger));
+
+  app.get('/slow/:package', (req, res) => {
+    // Simulate a slow response - will be aborted before completing
+    setTimeout(() => {
+      res.status(HTTP_STATUS.OK).json({});
+    }, 1000);
+  });
+
+  // Create a direct request to the app to have better control over socket events
+  const server = app.listen(0);
+  const address = server.address();
+  const port = typeof address === 'string' ? parseInt(address) : address?.port;
+
+  if (!port) {
+    throw new Error('Failed to get server port');
+  }
+
+  try {
+    // Make request that we'll abort
+    const http = require('http');
+    const req = http.request({
+      hostname: 'localhost',
+      port: port,
+      path: '/slow/react',
+      method: 'GET',
+    });
+
+    // Handle expected error when we destroy the connection
+    req.on('error', (err) => {
+      // Expected error when destroying connection - ignore it
+      if (err.code === 'ECONNRESET') {
+        return;
+      }
+      throw err;
+    });
+
+    // Start the request
+    req.end();
+
+    // Abort after a short delay to simulate user cancellation
+    setTimeout(() => {
+      req.destroy();
+    }, 100);
+
+    // Wait for the abort to be processed
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Verify that the abort was logged
+    expect(mockChildLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: expect.objectContaining({
+          method: 'GET',
+          url: '/slow/react',
+        }),
+        status: 499, // CLIENT_CLOSED_REQUEST
+      }),
+      expect.stringContaining('request aborted by client')
+    );
+  } finally {
+    server.close();
+  }
 });


### PR DESCRIPTION
With http logging, the log contains a status 200 entry for each request. Examples:

```
info <-- ::1 requested 'GET /'
http <-- 200, user: null(::1), req: 'GET /', bytes: 0/0
http <-- 200, user: null(::1), req: 'GET /', bytes: 0/517
info <-- ::1 requested 'POST /-/v1/login'
http <-- 200, user: x(::1), req: 'POST /-/v1/login', bytes: 15/0
http <-- 404, user: x(::1), req: 'POST /-/v1/login', bytes: 15/150
info <-- ::1 requested 'PUT /-/user/org.couchdb.user:x'
http <-- 200, user: x(::1), req: 'PUT /-/user/org.couchdb.user:x', bytes: 137/0
http <-- 401, user: x(::1), req: 'PUT /-/user/org.couchdb.user:x', error: bad username/password, access denied
```

This entry was caused by `req.close` event handler. This event should be processed *only for aborted requests* (when no `end` event is emitted). The problem is that completed requests emit `close` and `end` events leading to the issue.

This change replaced the `req.close` event with `socket.close` and `socket.error` to handle aborts properly. Aborted requests will now appear as a warning with status 499, client_closed_request. The incorrect status 200 does not appear anymore.

```
warn <-- 499, user: null(::1), req: 'GET /', request aborted by client
```
