### PR TITLE
fix: restore minimatch major version

### DIFF
--- a/.changeset/pretty-beds-destroy.md
+++ b/.changeset/pretty-beds-destroy.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/core': patch
+---
+
+fix: restore minimatch major version

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -36,7 +36,7 @@
     "ajv": "8.17.1",
     "http-errors": "2.0.0",
     "http-status-codes": "2.3.0",
-    "minimatch": "10.0.1",
+    "minimatch": "7.4.6",
     "process-warning": "1.0.0",
     "semver": "7.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -715,8 +715,8 @@ importers:
         specifier: 2.3.0
         version: 2.3.0
       minimatch:
-        specifier: 10.0.1
-        version: 10.0.1
+        specifier: 7.4.6
+        version: 7.4.6
       process-warning:
         specifier: 1.0.0
         version: 1.0.0
@@ -10956,10 +10956,6 @@ packages:
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -27078,10 +27074,6 @@ snapshots:
       webpack: 5.99.9(webpack-cli@4.10.0)
 
   minimalistic-assert@1.0.1: {}
-
-  minimatch@10.0.1:
-    dependencies:
-      brace-expansion: 2.0.1
 
   minimatch@3.1.2:
     dependencies:


### PR DESCRIPTION
minimatch 10 requires ESM breaks 6.x old versions