### PR TITLE
chore: replace conditional `require(fs/promises)` pattern

### DIFF
--- a/.changeset/beige-timers-greet.md
+++ b/.changeset/beige-timers-greet.md
@@ -1,0 +1,10 @@
+---
+'@verdaccio/local-storage': patch
+'@verdaccio/file-locking': patch
+'@verdaccio/core': patch
+'verdaccio': patch
+'@verdaccio/loaders': patch
+'@verdaccio/config': patch
+---
+
+chore: replace conditional require(fs/promises) pattern

--- a/packages/config/test/config-parsing.spec.ts
+++ b/packages/config/test/config-parsing.spec.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { describe, expect, test } from 'vitest';
 
@@ -6,8 +6,6 @@ import { fileUtils } from '@verdaccio/core';
 
 import { fromJStoYAML, parseConfigFile } from '../src';
 import { parseConfigurationFile } from './utils';
-
-const { writeFile } = fs.promises ? fs.promises : require('fs/promises');
 
 describe('parse', () => {
   describe('parseConfigFile', () => {

--- a/packages/core/core/src/file-utils.ts
+++ b/packages/core/core/src/file-utils.ts
@@ -1,12 +1,10 @@
-import fs from 'node:fs';
+import { mkdir, mkdtemp } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
 export const Files = {
   DatabaseName: '.verdaccio-db.json',
 };
-
-const { mkdir, mkdtemp } = fs.promises ? fs.promises : require('fs/promises');
 
 /**
  * Create a temporary folder.

--- a/packages/core/file-locking/src/utils.ts
+++ b/packages/core/file-locking/src/utils.ts
@@ -1,9 +1,7 @@
 import locker from 'lockfile';
-import fs from 'node:fs';
+import * as fsP from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
-
-const fsP = fs.promises ? fs.promises : require('fs/promises');
 
 export const readFile = fsP.readFile;
 const statPromise = fsP.stat;

--- a/packages/loaders/src/plugin-async-loader.ts
+++ b/packages/loaders/src/plugin-async-loader.ts
@@ -1,6 +1,6 @@
 import buildDebug from 'debug';
 import _ from 'lodash';
-import fs from 'node:fs';
+import { lstat } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 
 import { PLUGIN_PREFIX, pluginUtils } from '@verdaccio/core';
@@ -8,8 +8,6 @@ import { PLUGIN_PREFIX, pluginUtils } from '@verdaccio/core';
 import { PluginType, isES6, isValid, tryLoad } from './utils';
 
 const debug = buildDebug('verdaccio:plugin:loader:async');
-
-const { lstat } = fs.promises ? fs.promises : require('fs/promises');
 
 async function isDirectory(pathFolder: string) {
   const stat = await lstat(pathFolder);

--- a/packages/plugins/local-storage/src/fs.ts
+++ b/packages/plugins/local-storage/src/fs.ts
@@ -1,7 +1,5 @@
 import fsCallback from 'node:fs';
-import fs from 'node:fs';
-
-const fsP = fs.promises ? fs.promises : require('fs/promises');
+import * as fsP from 'node:fs/promises';
 
 const readFile = fsP.readFile;
 const mkdirPromise = fsP.mkdir;

--- a/packages/verdaccio/src/server/registry.ts
+++ b/packages/verdaccio/src/server/registry.ts
@@ -1,6 +1,6 @@
 import buildDebug from 'debug';
 import { ChildProcess, fork } from 'node:child_process';
-import fs from 'node:fs';
+import { writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { fromJStoYAML } from '@verdaccio/config';
@@ -8,8 +8,6 @@ import { HTTP_STATUS, TOKEN_BEARER, authUtils, fileUtils } from '@verdaccio/core
 import { ConfigYaml } from '@verdaccio/types';
 
 import { ServerQuery } from './request';
-
-const { writeFile } = fs.promises ? fs.promises : require('fs/promises');
 
 const debug = buildDebug('verdaccio:registry');
 


### PR DESCRIPTION
All files now use modern ES module imports from `node:fs/promises` instead of the legacy conditional require pattern, which provides better compatibility and cleaner code.