### PR TITLE
chore(docs): troubleshooting link

### DIFF
--- a/website/docs/setup-npm.md
+++ b/website/docs/setup-npm.md
@@ -82,7 +82,7 @@ Both commands relies on web login by default, but adding `--auth-type=legacy` yo
 
 > [Web login is not supported for verdaccio.](https://github.com/verdaccio/verdaccio/issues/3413)
 
-## Troubleshooting
+## Troubleshooting {#troubleshooting}
 
 ### `npm login` with npm@9 or higher
 

--- a/website/versioned_docs/version-6.x/setup-npm.md
+++ b/website/versioned_docs/version-6.x/setup-npm.md
@@ -82,7 +82,7 @@ Both commands relies on web login by default, but adding `--auth-type=legacy` yo
 
 > [Web login is not supported for verdaccio.](https://github.com/verdaccio/verdaccio/issues/3413)
 
-## Troubleshooting
+## Troubleshooting {#troubleshooting}
 
 ### `npm login` with npm@9 or higher
 


### PR DESCRIPTION
The link doesn't work in translations. The `{#troubleshooting}` needs to be added to the translations as well.

<img width="876" height="187" alt="image" src="https://github.com/user-attachments/assets/fcfd61f3-c033-4687-ad61-47568bdc46cb" />
