### PR TITLE
docs (kubernetes install): remove deprecated warning

### DIFF
--- a/website/docs/kubernetes.md
+++ b/website/docs/kubernetes.md
@@ -23,8 +23,6 @@ helm init
 
 ### Install {#install}
 
-> ⚠️ If you are using this helm chart, please [be aware of the migration of the repository](https://github.com/verdaccio/verdaccio/issues/1767).
-
 Deploy the Helm [verdaccio/verdaccio](https://github.com/verdaccio/charts)
 chart.
 


### PR DESCRIPTION
* referenced issue was closed in 2020
* correct chart is referenced below - so believe this is no longer needed
* feel free to decline if maintainers disagree