### PR TITLE
docs: fix link path to resolve correctly

### DIFF
--- a/website/docs/docker.md
+++ b/website/docs/docker.md
@@ -122,7 +122,7 @@ COPY --chown=$VERDACCIO_USER_UID:root --from=builder \
   /verdaccio/plugins/verdaccio-auth-memory
 ```
 
-For more information check real plugin examples with Docker in our [source code](https://github.com/verdaccio/verdaccio/tree/master/docker-examples/v5/plugins).
+For more information check real plugin examples with Docker in our [source code](https://github.com/verdaccio/verdaccio/tree/master/docker-examples/v6/plugins).
 
 ### Docker and custom port configuration {#docker-and-custom-port-configuration}
 

--- a/website/versioned_docs/version-6.x/reverse-proxy.md
+++ b/website/versioned_docs/version-6.x/reverse-proxy.md
@@ -87,7 +87,7 @@ You should only add it to your virtual host config, if you are experiencing the 
 
 # Nginx
 
-The following snippet is a full `docker` example can be tested in our [Docker examples repository](https://github.com/verdaccio/verdaccio/tree/5.x/docker-examples/reverse_proxy/nginx).
+The following snippet is a full `docker` example can be tested in our [Docker examples repository](https://github.com/verdaccio/verdaccio/tree/master/docker-examples/v6/reverse_proxy/nginx).
 
 ```nginx
 upstream verdaccio_v4 {


### PR DESCRIPTION
* beginning on this page - https://verdaccio.org/docs/reverse-proxy/ selecting Docker examples repository link took you to nowhere
* pr changes to route directly to the docker-examples v6 code