### PR TITLE
fix: improve button color contrast for accessibility

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -29,8 +29,8 @@ const Header = (): React.ReactElement => {
             style={{ marginTop: '8px' }}
           />
           <div className={styles['header--links']}>
-            <a href="/Talks" className="link-secondary">
-              WATCH
+            <a href="/Talks" className={cx('link-secondary', 'secondarySpecialButton')}>
+              <Translate>WATCH</Translate>
             </a>
             <Link to={useBaseUrl('/docs/what-is-verdaccio')} className="link-primary">
               <Translate>GET STARTED</Translate>

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -143,3 +143,7 @@ html[data-theme='dark'] {
   background-color: #ffd700;
   color: #1595de;
 }
+.secondarySpecialButton{
+  background-color: #f3f3f3;
+  color: #1a1a1a;
+}


### PR DESCRIPTION
This PR fixes the color contrast issue on the special button to ensure it meets accessibility standards. The button's text color has been updated to provide better readability against its background.

befor : 
<img width="648" height="237" alt="image" src="https://github.com/user-attachments/assets/2eca3f03-f564-46fa-b03c-dd90f4c6f1f3" />
after:
<img width="630" height="302" alt="image" src="https://github.com/user-attachments/assets/3e2c4c00-a510-4cf0-9b52-f75519fb8107" />

both in the dark and the light mode