### PR TITLE
fix: filter plugins not loading

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -113,6 +113,6 @@ export default (async function (configHash: ConfigYaml): Promise<express.Applica
 
   const storage = new Storage(config);
   // waits until init calls have been initialized
-  await storage.init(config, []);
+  await storage.init(config);
   return await defineAPI(config, storage);
 });

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -49,19 +49,18 @@ class Storage {
   public config: Config;
   public logger: Logger;
   public uplinks: Record<string, ProxyStorage>;
-  public filters: IPluginFilters;
+  public filters: IPluginFilters | undefined;
 
   public constructor(config: Config) {
     this.config = config;
     this.uplinks = setupUpLinks(config);
     this.logger = logger;
-    this.filters = [];
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     this.localStorage = null;
   }
 
-  public async init(config: Config, filters: IPluginFilters = []): Promise<void> {
+  public async init(config: Config, filters?: IPluginFilters): Promise<void> {
     if (this.localStorage === null) {
       this.filters = filters;
       const storageInstance = await this.loadStorage(config, this.logger);
@@ -703,7 +702,7 @@ class Storage {
             // as a broken filter is a security risk.
             const filterErrors: Error[] = [];
             // This MUST be done serially and not in parallel as they modify packageJsonLocal
-            for (const filter of self.filters) {
+            for (const filter of self.filters ?? []) {
               try {
                 // These filters can assume it's save to modify packageJsonLocal and return it directly for
                 // performance (i.e. need not be pure)

--- a/test/helpers/initializeServer.ts
+++ b/test/helpers/initializeServer.ts
@@ -28,7 +28,7 @@ export async function initializeServer(
   config.configPath = config.storage;
   debug('storage: %s', config.storage);
   const storage = new Storage(config);
-  await storage.init(config, []);
+  await storage.init(config);
   const auth: Auth = new Auth(config, logger, { legacyMergeConfigs: true });
   await auth.init();
   // FUTURE: in v6 auth.init() is being called


### PR DESCRIPTION
Fix #5372

The `filters` variable was previously always initialized to an empty array, meaning the [if statement](https://github.com/verdaccio/verdaccio/blob/d9f40c141fb794e824f026d8bb8c5e0b262af8cb/src/lib/storage.ts#L75) performing a falsy check on the variable would never evalutate to true, resulting in the filters never loading.