### PR TITLE
chore: remove dev dependency pinst

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "kleur": "4.1.5",
     "nock": "13.5.6",
     "node-mocks-http": "^1.16.2",
-    "pinst": "2.1.6",
     "prettier": "3.6.2",
     "selfsigned": "3.0.1",
     "standard-version": "9.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5464,13 +5464,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fromentries@npm:^1.3.2":
-  version: 1.3.2
-  resolution: "fromentries@npm:1.3.2"
-  checksum: 10c0/63938819a86e39f490b0caa1f6b38b8ad04f41ccd2a1c144eb48a21f76e4dbc074bc62e97abb053c7c1f541ecc70cf0b8aaa98eed3fe02206db9b6f9bb9a6a47
-  languageName: node
-  linkType: hard
-
 "fs-extra@npm:10.1.0":
   version: 10.1.0
   resolution: "fs-extra@npm:10.1.0"
@@ -8052,17 +8045,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pinst@npm:2.1.6":
-  version: 2.1.6
-  resolution: "pinst@npm:2.1.6"
-  dependencies:
-    fromentries: "npm:^1.3.2"
-  bin:
-    pinst: bin.js
-  checksum: 10c0/2e97ad8707878e9231a5a990214d5eeb3f73daa8cf7fd75acf5765f93672f630c8a66fee9d897aee1f4c3bfc5b09c1a80ac23e016f0deb599bfe07e28e9ea307
-  languageName: node
-  linkType: hard
-
 "pirates@npm:^4.0.6":
   version: 4.0.6
   resolution: "pirates@npm:4.0.6"
@@ -10056,7 +10038,6 @@ __metadata:
     mime: "npm:3.0.0"
     nock: "npm:13.5.6"
     node-mocks-http: "npm:^1.16.2"
-    pinst: "npm:2.1.6"
     prettier: "npm:3.6.2"
     selfsigned: "npm:3.0.1"
     semver: "npm:7.7.2"


### PR DESCRIPTION
not usage detected