### PR TITLE
fix: minor logger missing type

### DIFF
--- a/.changeset/pretty-news-do.md
+++ b/.changeset/pretty-news-do.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/types': patch
+---
+
+fix: minor logger missing type

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -9,6 +9,7 @@ export type TypeToken = 'Bearer' | 'Basic';
 export interface Logger {
   child: (conf: any) => any;
   debug: (conf: any, template?: string) => void;
+  fatal: (conf: any, template?: string) => void;
   error: (conf: any, template?: string) => void;
   http: (conf: any, template?: string) => void;
   trace: (conf: any, template?: string) => void;


### PR DESCRIPTION
This pull request introduces a minor fix to the logger interface in `@verdaccio/types` by adding a missing type definition for the `fatal` logging method.

Logger interface update:

* Added the `fatal` method to the `Logger` interface in `packages/core/types/src/configuration.ts` to ensure all logger levels are properly typed.

