### PR TITLE
Update @types/supertest and improve test typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/send": "0.17.4",
     "@types/serve-static": "1.15.7",
     "@types/superagent": "4.1.24",
-    "@types/supertest": "2.0.16",
+    "@types/supertest": "6.0.3",
     "@types/validator": "13.12.0",
     "@types/webpack": "5.28.5",
     "@types/webpack-env": "1.18.5",

--- a/packages/api/test/integration/_helper.ts
+++ b/packages/api/test/integration/_helper.ts
@@ -2,6 +2,7 @@ import { Application } from 'express';
 import _ from 'lodash';
 import path from 'node:path';
 import supertest from 'supertest';
+import { App } from 'supertest/types';
 import { expect } from 'vitest';
 
 import { parseConfigFile } from '@verdaccio/config';
@@ -27,7 +28,7 @@ setup({});
 
 export const buildToken = authUtils.buildToken;
 
-export const getConf = (conf) => {
+export const getConf = (conf: string) => {
   const configPath = path.join(__dirname, 'config', conf);
   const config = parseConfigFile(configPath);
   // custom config to avoid conflict with other tests
@@ -35,12 +36,12 @@ export const getConf = (conf) => {
   return config;
 };
 
-export async function initializeServer(configName): Promise<Application> {
+export async function initializeServer(configName: string): Promise<Application> {
   const config = getConf(configName);
   return initializeServerHelper(config, [apiMiddleware], Storage);
 }
 
-export function createUser(app, name: string, password: string): supertest.Test {
+export function createUser(app: App, name: string, password: string): supertest.Test {
   return supertest(app)
     .put(`/-/user/org.couchdb.user:${name}`)
     .send({
@@ -61,7 +62,7 @@ export async function getNewToken(app: any, credentials: any): Promise<string> {
   return token;
 }
 
-export async function generateTokenCLI(app, token, payload): Promise<any> {
+export async function generateTokenCLI(app: App, token: string, payload: any): Promise<any> {
   return supertest(app)
     .post('/-/npm/v1/tokens')
     .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
@@ -70,7 +71,7 @@ export async function generateTokenCLI(app, token, payload): Promise<any> {
     .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET);
 }
 
-export async function deleteTokenCLI(app, token, tokenToDelete): Promise<any> {
+export async function deleteTokenCLI(app: App, token: string, tokenToDelete: string): Promise<any> {
   return supertest(app)
     .delete(`/-/npm/v1/tokens/token/${tokenToDelete}`)
     .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
@@ -80,7 +81,7 @@ export async function deleteTokenCLI(app, token, tokenToDelete): Promise<any> {
 }
 
 export function publishVersionWithToken(
-  app,
+  app: App,
   pkgName: string,
   version: string,
   token: string,
@@ -98,7 +99,7 @@ export function publishVersionWithToken(
 }
 
 export function publishVersion(
-  app,
+  app: App,
   pkgName: string,
   version: string,
   distTags?: GenericBody,
@@ -152,7 +153,7 @@ export function starPackage(
 }
 
 export function changeOwners(
-  app,
+  app: App,
   options: {
     maintainers: Author[];
     name: string;
@@ -182,7 +183,7 @@ export function changeOwners(
   return test;
 }
 
-export function getDisTags(app, pkgName) {
+export function getDisTags(app: App, pkgName: string): supertest.Test {
   return supertest(app)
     .get(`/-/package/${encodeURIComponent(pkgName)}/dist-tags`)
     .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
@@ -191,7 +192,7 @@ export function getDisTags(app, pkgName) {
 }
 
 export function getPackage(
-  app: any,
+  app: App,
   token: string,
   pkgName: string,
   statusCode: number = HTTP_STATUS.OK

--- a/packages/web/test/helper.ts
+++ b/packages/web/test/helper.ts
@@ -17,7 +17,7 @@ export const getConf = (configName: string) => {
 };
 
 // @deprecated
-export async function initializeServer(configName): Promise<Application> {
+export async function initializeServer(configName: string): Promise<Application> {
   return initializeServerHelper(
     getConf(configName),
     [apiMiddleware, { async: true, routes }],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,8 +192,8 @@ importers:
         specifier: 4.1.24
         version: 4.1.24
       '@types/supertest':
-        specifier: 2.0.16
-        version: 2.0.16
+        specifier: 6.0.3
+        version: 6.0.3
       '@types/validator':
         specifier: 13.12.0
         version: 13.12.0
@@ -5834,6 +5834,9 @@ packages:
   '@types/mem-fs@1.1.5':
     resolution: {integrity: sha512-fnzN9xAKb3IPEoKgAkbpDE+8Q5J+QoCThPTVv3oKDHUe5xBpENP7ZwXC6HZnXBmVPLK5zfUZrphPe6zeCTPyrQ==}
 
+  '@types/methods@1.1.4':
+    resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
   '@types/mime@1.3.3':
     resolution: {integrity: sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==}
 
@@ -5969,8 +5972,11 @@ packages:
   '@types/superagent@4.1.24':
     resolution: {integrity: sha512-mEafCgyKiMFin24SDzWN7yAADt4gt6YawFiNMp0QS5ZPboORfyxFt0s3VzJKhTaKg9py/4FUmrHLTNfJKt9Rbw==}
 
-  '@types/supertest@2.0.16':
-    resolution: {integrity: sha512-6c2ogktZ06tr2ENoZivgm7YnprnhYE4ZoXGMY+oA7IuAf17M8FWvujXZGmxLv8y0PTyts4x5A+erSwVUFA8XSg==}
+  '@types/superagent@8.1.9':
+    resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+
+  '@types/supertest@6.0.3':
+    resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
 
   '@types/text-table@0.2.5':
     resolution: {integrity: sha512-hcZhlNvMkQG/k1vcZ6yHOl6WAYftQ2MLfTHcYRZ2xYZFD8tGVnE3qFV0lj1smQeDSR7/yY0PyuUalauf33bJeA==}
@@ -20293,6 +20299,8 @@ snapshots:
       '@types/node': 20.14.12
       '@types/vinyl': 2.0.12
 
+  '@types/methods@1.1.4': {}
+
   '@types/mime@1.3.3': {}
 
   '@types/mime@3.0.4': {}
@@ -20435,9 +20443,17 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/node': 24.0.3
 
-  '@types/supertest@2.0.16':
+  '@types/superagent@8.1.9':
     dependencies:
-      '@types/superagent': 4.1.24
+      '@types/cookiejar': 2.1.5
+      '@types/methods': 1.1.4
+      '@types/node': 20.14.12
+      form-data: 4.0.4
+
+  '@types/supertest@6.0.3':
+    dependencies:
+      '@types/methods': 1.1.4
+      '@types/superagent': 8.1.9
 
   '@types/text-table@0.2.5': {}
 


### PR DESCRIPTION
Upgraded @types/supertest from 2.0.16 to 6.0.3 and updated test helper functions to use explicit type annotations for better type safety. Also fixed web server test to publish a package before checking the packages API response.