### PR TITLE
chore: add types for createConfigFolder

### DIFF
--- a/.changeset/friendly-worms-drum.md
+++ b/.changeset/friendly-worms-drum.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/config': patch
+---
+
+chore: add types for createConfigFolder

--- a/.github/workflows/plugin-generator-e2e.yaml
+++ b/.github/workflows/plugin-generator-e2e.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20, 22, 23]
+        node-version: [20, 22, 24]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Build application with Node ${{ matrix.node_version }}
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ matrix.node_version }}
       - name: install verdaccio
-        run: npm install -g verdaccio@5
+        run: npm install -g verdaccio@6
       - name: Start server
         run: verdaccio -c e2e/docker/generator-e2e/generator.yaml &
       - name: ping server

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -72,6 +72,10 @@ auth:
     # Maximum amount of users allowed to register, defaults to "+inf".
     # You can set this to -1 to disable registration.
     # max_users: 1000
+    # Hash algorithm, possible options are: "bcrypt", "md5", "sha1", "crypt".
+    # algorithm: bcrypt # by default is crypt, but is recommended use bcrypt for new installations
+    # Rounds number for "bcrypt", will be ignored for other algorithms.
+    # rounds: 10
 
 # A list of other known repositories we can talk to
 # https://verdaccio.org/docs/configuration#uplinks

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -78,7 +78,7 @@ export function readDefaultConfig(): string {
   return fs.readFileSync(pathDefaultConf, 'utf8');
 }
 
-function createConfigFolder(configLocation): void {
+function createConfigFolder(configLocation: SetupDirectory): void {
   const folder = path.dirname(configLocation.path);
   debug(`creating default config file folder at %o`, folder);
   fs.mkdirSync(folder, { recursive: true });


### PR DESCRIPTION
**Configuration and Type Safety Improvements:**

* Added TypeScript types to the `createConfigFolder` function in `config-path.ts`, improving code reliability and maintainability.
* Documented new authentication options in `default.yaml`, including configurable hash algorithms and bcrypt rounds, to help users better secure their installations.

**Release Documentation:**

* Added a changeset entry to document the patch release for the new types in `createConfigFolder`.