### PR TITLE
fix: filter plugin invocation on 304 from uplink

### DIFF
--- a/.changeset/pretty-carrots-smash.md
+++ b/.changeset/pretty-carrots-smash.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/store': patch
+---
+
+Fix inconsistency in filter plugin invocation upon receiving 304 from uplink after uplink.maxage has passed

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -1779,7 +1779,9 @@ class Storage {
         [...uplinksErrors, ...filtersErrors],
       ];
     } else if (found && _.isNil(localManifest) === false) {
-      return [localManifest, uplinksErrors];
+      // apply filter to local manifest (it is cached in unfiltered state)
+      const [filteredManifest, filtersErrors] = await this.applyFilters(localManifest);
+      return [{ ...localManifest, ...filteredManifest }, [...uplinksErrors, ...filtersErrors]];
     } else {
       // if is not found, calculate the right error to return
       debug('uplinks sync failed with %o errors', uplinksErrors.length);

--- a/packages/store/test/storage.spec.ts
+++ b/packages/store/test/storage.spec.ts
@@ -1347,7 +1347,7 @@ describe('storage', () => {
         const [manifest] = await storage.syncUplinksMetadata(fooManifest.name, fooManifest, {
           retry: { limit: 0 },
         });
-        expect(manifest).toBe(fooManifest);
+        expect(manifest).toEqual(fooManifest);
       });
     });
 


### PR DESCRIPTION
Fixes #5412 
- Apply filter plugins to locally cached manifest even when uplink reported 304 as exception.
- Update unit test for uplink returning 304: instead of expecting reference equality, expect deep equality of original manifest to manifest returned from `Storage.syncUplinksMetadata()` call.
- It is suspected that this PR fixes broader range of inconsistency, e.g. when uplink returns 503 or similar response, filtering is now properly applied to cached manifest.