### PR TITLE
chore(deps): api, auth, cli, config, url

### DIFF
--- a/.changeset/cool-emus-know.md
+++ b/.changeset/cool-emus-know.md
@@ -1,0 +1,9 @@
+---
+'@verdaccio/url': patch
+'@verdaccio/config': patch
+'@verdaccio/auth': patch
+'@verdaccio/api': patch
+'@verdaccio/cli': patch
+---
+
+chore(deps): api, auth, cli, config, url

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -48,20 +48,18 @@
     "@verdaccio/logger": "workspace:8.0.0-next-8.24",
     "@verdaccio/middleware": "workspace:8.0.0-next-8.24",
     "@verdaccio/store": "workspace:8.0.0-next-8.24",
-    "abortcontroller-polyfill": "1.7.8",
-    "body-parser": "1.20.3",
-    "cookies": "0.9.1",
     "debug": "4.4.3",
     "express": "4.21.2",
     "lodash": "4.17.21",
-    "mime": "2.6.0",
-    "semver": "7.7.3"
+    "mime": "2.6.0"
   },
   "devDependencies": {
     "@verdaccio/test-helper": "workspace:4.0.0-next-8.8",
     "@verdaccio/types": "workspace:13.0.0-next-8.8",
     "mockdate": "3.0.5",
-    "supertest": "7.1.4"
+    "nock": "13.5.6",
+    "supertest": "7.1.4",
+    "vitest": "3.2.4"
   },
   "funding": {
     "type": "opencollective",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -55,7 +55,8 @@
     "@verdaccio/types": "workspace:13.0.0-next-8.8",
     "@verdaccio/logger": "workspace:8.0.0-next-8.24",
     "express": "4.21.2",
-    "supertest": "7.1.4"
+    "supertest": "7.1.4",
+    "vitest": "3.2.4"
   },
   "funding": {
     "type": "opencollective",

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express';
+import type { NextFunction, Request, Response } from 'express';
 
 import { VerdaccioError } from '@verdaccio/core';
 import { AuthPackageAllow, JWTSignOptions, Logger, RemoteUser } from '@verdaccio/types';

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -53,11 +53,12 @@
     "@verdaccio/node-api": "workspace:8.0.0-next-8.24",
     "clipanion": "4.0.0-rc.4",
     "envinfo": "7.19.0",
-    "kleur": "4.1.5",
     "semver": "7.7.3"
   },
   "devDependencies": {
-    "ts-node": "10.9.2"
+    "@verdaccio/types": "workspace:13.0.0-next-8.8",
+    "ts-node": "10.9.2",
+    "vitest": "3.2.4"
   },
   "funding": {
     "type": "opencollective",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -45,11 +45,11 @@
     "@verdaccio/core": "workspace:8.0.0-next-8.24",
     "debug": "4.4.3",
     "js-yaml": "4.1.0",
-    "lodash": "4.17.21",
-    "minimatch": "7.4.6"
+    "lodash": "4.17.21"
   },
   "devDependencies": {
-    "@types/minimatch": "5.1.2"
+    "@verdaccio/types": "workspace:13.0.0-next-8.8",
+    "vitest": "3.2.4"
   },
   "funding": {
     "type": "opencollective",

--- a/packages/core/url/package.json
+++ b/packages/core/url/package.json
@@ -35,11 +35,9 @@
   "dependencies": {
     "@verdaccio/core": "workspace:8.0.0-next-8.24",
     "debug": "4.4.3",
-    "lodash": "4.17.21",
     "validator": "13.15.15"
   },
   "devDependencies": {
-    "@verdaccio/types": "workspace:13.0.0-next-8.8",
     "node-mocks-http": "1.14.1",
     "vitest": "3.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -572,15 +572,6 @@ importers:
       '@verdaccio/store':
         specifier: workspace:8.0.0-next-8.24
         version: link:../store
-      abortcontroller-polyfill:
-        specifier: 1.7.8
-        version: 1.7.8
-      body-parser:
-        specifier: 1.20.3
-        version: 1.20.3
-      cookies:
-        specifier: 0.9.1
-        version: 0.9.1
       debug:
         specifier: 4.4.3
         version: 4.4.3(supports-color@5.5.0)
@@ -593,9 +584,6 @@ importers:
       mime:
         specifier: 2.6.0
         version: 2.6.0
-      semver:
-        specifier: 7.7.3
-        version: 7.7.3
     devDependencies:
       '@verdaccio/test-helper':
         specifier: workspace:4.0.0-next-8.8
@@ -606,9 +594,15 @@ importers:
       mockdate:
         specifier: 3.0.5
         version: 3.0.5
+      nock:
+        specifier: 13.5.6
+        version: 13.5.6
       supertest:
         specifier: 7.1.4
         version: 7.1.4
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.0)(typescript@5.3.3))(sass@1.93.2)(terser@5.31.3)
 
   packages/auth:
     dependencies:
@@ -649,6 +643,9 @@ importers:
       supertest:
         specifier: 7.1.4
         version: 7.1.4
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.0)(typescript@5.3.3))(sass@1.93.2)(terser@5.31.3)
 
   packages/cli:
     dependencies:
@@ -670,16 +667,19 @@ importers:
       envinfo:
         specifier: 7.19.0
         version: 7.19.0
-      kleur:
-        specifier: 4.1.5
-        version: 4.1.5
       semver:
         specifier: 7.7.3
         version: 7.7.3
     devDependencies:
+      '@verdaccio/types':
+        specifier: workspace:13.0.0-next-8.8
+        version: link:../core/types
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@24.10.0)(typescript@5.3.3)
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.0)(typescript@5.3.3))(sass@1.93.2)(terser@5.31.3)
 
   packages/config:
     dependencies:
@@ -695,13 +695,13 @@ importers:
       lodash:
         specifier: 4.17.21
         version: 4.17.21
-      minimatch:
-        specifier: 7.4.6
-        version: 7.4.6
     devDependencies:
-      '@types/minimatch':
-        specifier: 5.1.2
-        version: 5.1.2
+      '@verdaccio/types':
+        specifier: workspace:13.0.0-next-8.8
+        version: link:../core/types
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.0)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.0)(typescript@5.3.3))(sass@1.93.2)(terser@5.31.3)
 
   packages/core/core:
     dependencies:
@@ -800,16 +800,10 @@ importers:
       debug:
         specifier: 4.4.3
         version: 4.4.3(supports-color@5.5.0)
-      lodash:
-        specifier: 4.17.21
-        version: 4.17.21
       validator:
         specifier: 13.15.15
         version: 13.15.15
     devDependencies:
-      '@verdaccio/types':
-        specifier: workspace:13.0.0-next-8.8
-        version: link:../types
       node-mocks-http:
         specifier: 1.14.1
         version: 1.14.1
@@ -6217,9 +6211,6 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
-  abortcontroller-polyfill@1.7.8:
-    resolution: {integrity: sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==}
-
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -6235,18 +6226,9 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.2.0:
-    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
-    engines: {node: '>=0.4.0'}
-
   acorn-walk@8.3.3:
     resolution: {integrity: sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==}
     engines: {node: '>=0.4.0'}
-
-  acorn@8.10.0:
-    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.12.1:
     resolution: {integrity: sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==}
@@ -7240,10 +7222,6 @@ packages:
 
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
-
-  cookies@0.9.1:
-    resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
-    engines: {node: '>= 0.8'}
 
   copy-text-to-clipboard@3.2.2:
     resolution: {integrity: sha512-T6SqyLd1iLuqPA90J5N4cTalrtovCySh58iiZDGJ6FGznbclKh4UI+FGacQSgFzwKG77W7XT5gwbVEbd9cIH1A==}
@@ -10040,11 +10018,6 @@ packages:
   katex@0.16.18:
     resolution: {integrity: sha512-LRuk0rPdXrecAFwQucYjMiIs0JFefk6N1q/04mlw14aVIVgxq1FO0MA9RiIIGVaKOB5GIP5GH4aBBNraZERmaQ==}
     hasBin: true
-
-  keygrip@1.1.0:
-    resolution: {integrity: sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==}
-    engines: {node: '>= 0.6'}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   keyv@4.5.3:
     resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
@@ -14105,10 +14078,6 @@ packages:
 
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
-
-  tsscmp@1.0.6:
-    resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
-    engines: {node: '>=0.6.x'}
 
   tsutils@3.21.0:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
@@ -20588,8 +20557,6 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  abortcontroller-polyfill@1.7.8: {}
-
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -20603,13 +20570,9 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-walk@8.2.0: {}
-
   acorn-walk@8.3.3:
     dependencies:
       acorn: 8.14.0
-
-  acorn@8.10.0: {}
 
   acorn@8.12.1: {}
 
@@ -21721,11 +21684,6 @@ snapshots:
   cookie@0.7.2: {}
 
   cookiejar@2.1.4: {}
-
-  cookies@0.9.1:
-    dependencies:
-      depd: 2.0.0
-      keygrip: 1.1.0
 
   copy-text-to-clipboard@3.2.2: {}
 
@@ -25222,10 +25180,6 @@ snapshots:
   katex@0.16.18:
     dependencies:
       commander: 8.3.0
-
-  keygrip@1.1.0:
-    dependencies:
-      tsscmp: 1.0.6
 
   keyv@4.5.3:
     dependencies:
@@ -29638,8 +29592,8 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 20.14.12
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.3
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
@@ -29656,8 +29610,8 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
       '@types/node': 24.10.0
-      acorn: 8.10.0
-      acorn-walk: 8.2.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.3
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
@@ -29682,8 +29636,6 @@ snapshots:
   tslib@1.14.1: {}
 
   tslib@2.6.3: {}
-
-  tsscmp@1.0.6: {}
 
   tsutils@3.21.0(typescript@5.3.3):
     dependencies:


### PR DESCRIPTION
Another round of clean-up. Checked with `npx depcheck`.

- Remove unused deps
- Add missing deps
- Fix express import for @verdaccio/auth (since it is a devDependency)


