### PR TITLE
fix: running without auth plugin

### DIFF
--- a/.changeset/violet-beers-call.md
+++ b/.changeset/violet-beers-call.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/loaders': patch
+'@verdaccio/auth': patch
+---
+
+fix: running without auth plugin

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -76,7 +76,9 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     let plugins = await this.loadPlugin();
 
     debug('auth plugins found %s', plugins.length);
-    if (!plugins || plugins.length === 0) {
+    // Missing auth config or no loaded plugins -> load default htpasswd plugin
+    // Empty auth config (null) -> just use fallback methods
+    if (this.config.auth !== null && (!plugins || plugins.length === 0)) {
       plugins = this.loadDefaultPlugin();
     }
     this.plugins = plugins;

--- a/packages/loaders/src/plugin-async-loader.ts
+++ b/packages/loaders/src/plugin-async-loader.ts
@@ -55,7 +55,7 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
   pluginCategory: string = 'unknown'
 ): Promise<PluginType<T>[]> {
   const logger = pluginOptions?.logger;
-  const pluginsIds = Object.keys(pluginConfigs);
+  const pluginsIds = Object.keys(pluginConfigs || {});
   const { config } = pluginOptions;
   let plugins: PluginType<T>[] = [];
   for (let pluginId of pluginsIds) {

--- a/packages/loaders/test/partials/config/no-plugin.yaml
+++ b/packages/loaders/test/partials/config/no-plugin.yaml
@@ -1,0 +1,2 @@
+# no plugin i.e. use default methods
+auth:

--- a/packages/loaders/test/plugin_loader_async.spec.ts
+++ b/packages/loaders/test/plugin_loader_async.spec.ts
@@ -193,6 +193,15 @@ describe('plugin loader', () => {
     });
   });
 
+  describe('no plugins', () => {
+    test('should not fail if config section exists but no plugins are configured', async () => {
+      const config = getConfig('no-plugin.yaml');
+      const plugins = await asyncLoadPlugin(config.auth, { config, logger }, authSanitize);
+
+      expect(plugins).toHaveLength(0);
+    });
+  });
+
   describe('legacy merge configs', () => {
     // whenever 6.x and 7.x version are out of support, we can remove this test
     test('should merge configuration with plugin configuration', async () => {


### PR DESCRIPTION
Fixes regression in 6.1.x (TypeError: Cannot convert undefined or null to object in plugin loader). It's now possible again to run without an auth plugin using an empty auth: section in config. The default plugin methods will be used (not htpasswd).

Closes https://github.com/verdaccio/verdaccio/issues/5192
