### PR TITLE
chore(store): nock replywitherror

### DIFF
--- a/.changeset/selfish-pandas-fix.md
+++ b/.changeset/selfish-pandas-fix.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/store': patch
+---
+
+chore(store): nock replywitherror

--- a/packages/store/test/storage.spec.ts
+++ b/packages/store/test/storage.spec.ts
@@ -1956,10 +1956,9 @@ describe('storage', () => {
       });
 
       test('should get ETIMEDOUT with uplink', { retry: 3 }, async () => {
-        nock(domain).get('/foo3').replyWithError({
-          code: 'ETIMEDOUT',
-          error: 'ETIMEDOUT',
-        });
+        const timeoutErr: any = new Error('ETIMEDOUT');
+        timeoutErr.code = 'ETIMEDOUT';
+        nock(domain).get('/foo3').replyWithError(timeoutErr);
         const config = new Config(
           configExample({
             ...getDefaultConfig(),


### PR DESCRIPTION
Related to failing test in https://github.com/verdaccio/verdaccio/pull/5445

Creates a real Error instance and attach .code so downstream libraries handling network errors see an Error object (not a plain object). Should fix the brittle test
