### PR TITLE
fix: Docker image not listening on IPv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,4 @@ VOLUME /verdaccio/storage
 
 ENTRYPOINT ["uid_entrypoint"]
 
-CMD $VERDACCIO_APPDIR/packages/verdaccio/bin/verdaccio --config /verdaccio/conf/config.yaml --listen $VERDACCIO_PROTOCOL://0.0.0.0:$VERDACCIO_PORT
+CMD $VERDACCIO_APPDIR/packages/verdaccio/bin/verdaccio --config /verdaccio/conf/config.yaml --listen $VERDACCIO_PROTOCOL://[::]:$VERDACCIO_PORT


### PR DESCRIPTION
Currently the Docker image listens to `0.0.0.0`, which limits it to IPv4 and breaks deployments in IPv6-only environments. See verdaccio/charts#175.

This PR changes the listening address to `::` which creates a dual stack listening socket, hence it is no longer limited to either IPv4 or IPv6.