### PR TITLE
fix: Docker image not listening on IPv6 (6.x)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,4 +101,4 @@ ENTRYPOINT ["uid_entrypoint"]
 
 # Default command to start Verdaccio using the custom config
 # - Uses environment variables for protocol and port binding
-CMD verdaccio --config /verdaccio/conf/config.yaml --listen $VERDACCIO_PROTOCOL://0.0.0.0:$VERDACCIO_PORT
+CMD verdaccio --config /verdaccio/conf/config.yaml --listen $VERDACCIO_PROTOCOL://[::]:$VERDACCIO_PORT


### PR DESCRIPTION
Currently the Docker image listens to `0.0.0.0`, which limits it to IPv4 and breaks deployments in IPv6-only environments. See verdaccio/charts#175.

This PR changes the listening address to `::` which creates a dual stack listening socket, hence it is no longer limited to either IPv4 or IPv6.

This is the backport for 6.x.