### PR TITLE
fix: handle malformed Basic auth credentials nicely

### DIFF
--- a/.changeset/funny-numbers-notice.md
+++ b/.changeset/funny-numbers-notice.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/auth': patch
+---
+
+fix: handle malformed Basic auth credentials nicely

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -455,7 +455,13 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
       debug('handle basic token');
       // this should happen when client tries to login with an existing user
       const credentials = convertPayloadToBase64(token).toString();
-      const { user, password } = parseBasicPayload(credentials) as AESPayload;
+      const parsedCredentials = parseBasicPayload(credentials);
+      if (!parsedCredentials) {
+        debug('invalid basic credentials format (missing colon separator)');
+        next(errorUtils.getBadRequest(API_ERROR.BAD_USERNAME_PASSWORD));
+        return;
+      }
+      const { user, password } = parsedCredentials as AESPayload;
       debug('authenticating %o', user);
       this.authenticate(user, password, (err: VerdaccioError | null, user): void => {
         if (!err) {


### PR DESCRIPTION
When a Basic auth header contains a base64-decoded value without a colon separator (e.g. "test" instead of "user:password"), `parseBasicPayload()` returns `undefined`. Previously, the code used a type assertion and attempted to destructure the result directly, causing a TypeError and returning HTTP 500.

Fixed this by adding a null check before destructuring `parseBasicPayload()` result in `handleJWTAPIMiddleware()`

Fixes #5568