### PR TITLE
fix: sanitize tmp filename

### DIFF
--- a/.changeset/breezy-jokes-fry.md
+++ b/.changeset/breezy-jokes-fry.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/local-storage': patch
+---
+
+fix: sanitize tmp filename

--- a/packages/plugins/local-storage/src/local-fs.ts
+++ b/packages/plugins/local-storage/src/local-fs.ts
@@ -241,7 +241,7 @@ export default class LocalFS implements ILocalFSPackageManager {
     // create a temporary file to avoid conflicts or prev corruption files
     const temporalName = path.join(
       this.path,
-      `${fileName}.tmp-${String(Math.random()).replace(/^0\./, '')}`
+      sanitzers(`${fileName}.tmp-${String(Math.random()).replace(/^0\./, '')}`)
     );
 
     debug('write a temporal name %o', temporalName);


### PR DESCRIPTION
Fixes "Uncontrolled data used in path expression" 

<img width="616" height="299" alt="image" src="https://github.com/user-attachments/assets/4e06a484-63df-417e-98bc-8248a66265b1" />
