### PR TITLE
feat(config): general support for environment variables in configuration

### DIFF
--- a/.changeset/tiny-countries-flash.md
+++ b/.changeset/tiny-countries-flash.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/config': patch
+---
+
+feat(config): support environment variables everywhere

--- a/packages/config/src/parse.ts
+++ b/packages/config/src/parse.ts
@@ -13,6 +13,63 @@ import { fileExists } from './config-utils';
 const debug = buildDebug('verdaccio:config:parse');
 
 /**
+ * Parses an environment variable value to a string, number, boolean, object, or array.
+ * @param envValue the environment variable value
+ * @returns the parsed value
+ */
+function parseEnvValue(envValue: string): string | number | boolean | object | unknown[] {
+  const trimmed = envValue.trim();
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    try {
+      return JSON.parse(trimmed) as object;
+    } catch {
+      return envValue;
+    }
+  }
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    try {
+      return JSON.parse(trimmed) as unknown[];
+    } catch {
+      return envValue;
+    }
+  }
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (trimmed !== '' && !Number.isNaN(Number(trimmed)) && /^-?\d+(\.\d+)?$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  return envValue;
+}
+
+/**
+ * Replaces config values that match environment variable names (uppercase + underscores) with process.env values.
+ * Supports string, number, boolean, object, and array values.
+ * @param config the config object to replace environment variables in
+ */
+function replaceEnvVars(config: Record<string, unknown>): void {
+  Object.keys(config).forEach((key) => {
+    const value = config[key];
+    if (
+      typeof value === 'string' &&
+      /^[A-Z0-9_]+$/.test(value) &&
+      process.env[value] !== undefined
+    ) {
+      const envValue = process.env[value] as string;
+      debug('replacing config %s value %o with env var %o', key, value, envValue);
+      config[key] = parseEnvValue(envValue);
+    } else if (isObject(value) && value !== null) {
+      replaceEnvVars(value as Record<string, unknown>);
+    } else if (Array.isArray(value)) {
+      value.forEach((item) => {
+        if (isObject(item) && item !== null) {
+          replaceEnvVars(item as Record<string, unknown>);
+        }
+      });
+    }
+  });
+}
+
+/**
  * Parse a config file from yaml to JSON.
  * @param configPath the absolute path of the configuration file
  */
@@ -32,6 +89,8 @@ export function parseConfigFile(configPath: string): ConfigYaml & {
         strict: false,
       }) as ConfigYaml;
 
+      replaceEnvVars(yamlConfig as unknown as Record<string, unknown>);
+
       return Object.assign({}, yamlConfig, {
         configPath,
         // @deprecated use configPath instead
@@ -40,6 +99,9 @@ export function parseConfigFile(configPath: string): ConfigYaml & {
     }
 
     const jsonConfig = require(configPath) as ConfigYaml;
+
+    replaceEnvVars(jsonConfig as unknown as Record<string, unknown>);
+
     return Object.assign({}, jsonConfig, {
       configPath,
       // @deprecated use configPath instead

--- a/packages/config/test/parse-config-from-env.spec.ts
+++ b/packages/config/test/parse-config-from-env.spec.ts
@@ -1,0 +1,46 @@
+import path from 'node:path';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+
+import { getConfigParsed } from '../src';
+
+beforeAll(() => {
+  process.env.TEST_STORAGE_PATH = '/verdaccio/storage';
+  process.env.TEST_LOG_CONFIG = '{"type": "stdout", "format": "pretty", "level": "warn"}';
+  process.env.TEST_WEB_TITLE = 'VerdaccioTestTitle';
+  process.env.TEST_WEB_SHOW_INFO = 'true'; // boolean
+  process.env.TEST_META_SCRIPT_1 =
+    '<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>';
+  process.env.TEST_META_SCRIPT_2 = '<meta name="robots" content="noindex">';
+  process.env.TEST_SERVER_KEEP_ALIVE_TIMEOUT = '60'; // number
+});
+
+afterAll(() => {
+  delete process.env.TEST_STORAGE_PATH;
+  delete process.env.TEST_LOG_CONFIG;
+  delete process.env.TEST_WEB_TITLE;
+  delete process.env.TEST_WEB_SHOW_INFO;
+  delete process.env.TEST_META_SCRIPT_1;
+  delete process.env.TEST_META_SCRIPT_2;
+  delete process.env.TEST_SERVER_KEEP_ALIVE_TIMEOUT;
+});
+
+describe('getConfigParsed with config from env', () => {
+  const partialsDir = path.join(__dirname, './partials/config/yaml');
+
+  test('parses config', () => {
+    const yamlFile = path.join(partialsDir, 'config-from-env.yaml');
+    const config = getConfigParsed(yamlFile);
+    expect(config).toBeDefined();
+    expect(config.storage).toStrictEqual('/verdaccio/storage');
+    expect(config.log?.type).toStrictEqual('stdout');
+    expect(config.log?.format).toStrictEqual('pretty');
+    expect(config.log?.level).toStrictEqual('warn');
+    expect(config.web?.title).toStrictEqual('VerdaccioTestTitle');
+    expect(config.web?.showInfo).toStrictEqual(true); // boolean
+    expect(config.web?.metaScripts).toStrictEqual([
+      '<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>',
+      '<meta name="robots" content="noindex">',
+    ]);
+    expect(config.server?.keepAliveTimeout).toStrictEqual(60); // number
+  });
+});

--- a/packages/config/test/parse-default-config.spec.ts
+++ b/packages/config/test/parse-default-config.spec.ts
@@ -1,0 +1,52 @@
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+import { getConfigParsed } from '../src';
+
+describe('getConfigParsed with default configs', () => {
+  const defaultConfigDir = path.join(__dirname, '../src/conf');
+
+  test('parses default.yaml config', () => {
+    const yamlFile = path.join(defaultConfigDir, 'default.yaml');
+    const config = getConfigParsed(yamlFile);
+    expect(config).toBeDefined();
+    expect(config.storage).toBe('./storage');
+    expect(config.auth.htpasswd.file).toBe('./htpasswd');
+    expect(config.packages['@*/*'].access).toBe('$all');
+    expect(config.packages['@*/*'].publish).toBe('$authenticated');
+    expect(config.packages['@*/*'].proxy).toBe('npmjs');
+    expect(config.packages['**'].access).toBe('$all');
+    expect(config.packages['**'].publish).toBe('$authenticated');
+    expect(config.packages['**'].proxy).toBe('npmjs');
+    expect(config.uplinks['npmjs'].url).toBe('https://registry.npmjs.org/');
+    expect(config.log?.type).toBe('stdout');
+    expect(config.log?.format).toBe('pretty');
+    expect(config.log?.level).toBe('http');
+    expect(config.notify).toBeUndefined();
+    expect(config.store).toBeUndefined();
+    expect(config.url_prefix).toBeUndefined();
+    expect(config.experiments).toBeUndefined();
+  });
+
+  test('parses docker.yaml config', () => {
+    const yamlFile = path.join(defaultConfigDir, 'docker.yaml');
+    const config = getConfigParsed(yamlFile);
+    expect(config).toBeDefined();
+    expect(config.storage).toBe('/verdaccio/storage/data');
+    expect(config.auth.htpasswd.file).toBe('/verdaccio/storage/htpasswd');
+    expect(config.packages['@*/*'].access).toBe('$all');
+    expect(config.packages['@*/*'].publish).toBe('$authenticated');
+    expect(config.packages['@*/*'].proxy).toBe('npmjs');
+    expect(config.packages['**'].access).toBe('$all');
+    expect(config.packages['**'].publish).toBe('$authenticated');
+    expect(config.packages['**'].proxy).toBe('npmjs');
+    expect(config.uplinks['npmjs'].url).toBe('https://registry.npmjs.org/');
+    expect(config.log?.type).toBe('stdout');
+    expect(config.log?.format).toBe('pretty');
+    expect(config.log?.level).toBe('http');
+    expect(config.notify).toBeUndefined();
+    expect(config.store).toBeUndefined();
+    expect(config.url_prefix).toBeUndefined();
+    expect(config.experiments).toBeUndefined();
+  });
+});

--- a/packages/config/test/partials/config/yaml/config-from-env.yaml
+++ b/packages/config/test/partials/config/yaml/config-from-env.yaml
@@ -1,0 +1,13 @@
+storage: TEST_STORAGE_PATH
+
+log: TEST_LOG_CONFIG
+
+web:
+  title: TEST_WEB_TITLE
+  showInfo: TEST_WEB_SHOW_INFO
+  metaScripts:
+    - TEST_META_SCRIPT_1
+    - TEST_META_SCRIPT_2
+
+server:
+  keepAliveTimeout: TEST_SERVER_KEEP_ALIVE_TIMEOUT


### PR DESCRIPTION
This feature allows using environment variables for any part of the Verdaccio configuration. Names of the environment variables must be uppercase + underscore. The variables can contain string, number, boolean, object, and array values.

Closes #1681

PS: If accepted, we can removed the special handling of env variables for selected config items.

Example:

```yaml
storage: TEST_STORAGE_PATH

log: TEST_LOG_CONFIG

web:
  title: TEST_WEB_TITLE
  showInfo: TEST_WEB_SHOW_INFO
  metaScripts:
    - TEST_META_SCRIPT_1
    - TEST_META_SCRIPT_2

server:
  keepAliveTimeout: TEST_SERVER_KEEP_ALIVE_TIMEOUT
```

plus

```env
TEST_STORAGE_PATH = '/verdaccio/storage'
TEST_LOG_CONFIG = '{"type": "stdout", "format": "pretty", "level": "warn"}'
TEST_WEB_TITLE = 'VerdaccioTestTitle'
TEST_WEB_SHOW_INFO = 'true'
TEST_META_SCRIPT_1 = '<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>'
TEST_META_SCRIPT_2 = '<meta name="robots" content="noindex">'
TEST_SERVER_KEEP_ALIVE_TIMEOUT = '60'
```

is equivalent to

```yaml
storage: /verdaccio/storage

log: { type: stdout, format: pretty, level: warn }

web:
  title: VerdaccioTestTitle
  showInfo: true
  metaScripts:
     - '<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>'
     - '<meta name="robots" content="noindex">'

server:
  keepAliveTimeout: 60
```
