### PR TITLE
feat: make asset manifest bundler-agnostic

### DIFF
--- a/.changeset/sixty-countries-play.md
+++ b/.changeset/sixty-countries-play.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/ui-theme': minor
+'@verdaccio/middleware': minor
+---
+
+refactor: make asset manifest bundler-agnostic

--- a/packages/middleware/src/middlewares/web/utils/renderHTML.ts
+++ b/packages/middleware/src/middlewares/web/utils/renderHTML.ts
@@ -12,7 +12,7 @@ import { getPublicUrl, isURLhasValidProtocol } from '@verdaccio/url';
 
 import type { Manifest } from './manifest';
 import renderTemplate from './template';
-import type { WebpackManifest } from './template';
+import type { AssetManifest } from './template';
 import { hasLogin, validatePrimaryColor } from './web-utils';
 
 const DEFAULT_LANGUAGE = 'es-US';
@@ -21,7 +21,7 @@ const cache = new LRU({ max: 500, ttl: 1000 * 60 * 60 });
 const debug = buildDebug('verdaccio:web:render');
 
 const defaultManifestFiles: Manifest = {
-  js: ['runtime.js', 'vendors.js', 'main.js'],
+  js: ['vendors.js', 'main.js'],
   ico: 'favicon.ico',
   css: [],
 };
@@ -47,7 +47,7 @@ export function resolveLogo(
 
 export default function renderHTML(
   config: ConfigYaml,
-  manifest: WebpackManifest,
+  manifest: AssetManifest,
   manifestFiles: Manifest | null | undefined,
   requestOptions: RequestOptions,
   res: Response

--- a/packages/middleware/src/middlewares/web/utils/template.ts
+++ b/packages/middleware/src/middlewares/web/utils/template.ts
@@ -15,12 +15,11 @@ export type Template = {
   scriptsBodyBefore?: string[];
 };
 
-// the outcome of the Webpack Manifest Plugin
-export interface WebpackManifest {
+export interface AssetManifest {
   [key: string]: string;
 }
 
-export default function renderTemplate(template: Template, manifest: WebpackManifest) {
+export default function renderTemplate(template: Template, manifest: AssetManifest) {
   debug('template %o', template);
   debug('manifest %o', manifest);
 

--- a/packages/plugins/ui-theme/index.js
+++ b/packages/plugins/ui-theme/index.js
@@ -5,11 +5,14 @@ const debug = buildDebug('verdaccio:plugin:ui-theme');
 
 const manifest = require('./static/manifest.json');
 
+// Entry-point scripts that must be eagerly loaded in the HTML.
+// Lazy-loaded code-split chunks (e.g. Home.js, Version.js) are excluded
+// so they remain loaded on demand by the bundler runtime.
+const ENTRY_POINTS = ['runtime.js', 'vendors.js', 'main.js'];
+
 function getManifestFiles(manifest) {
   const keys = Object.keys(manifest);
-  const js = keys.filter((k) => k.endsWith('.js'));
-  // ensure main.js loads last (after runtime/vendors)
-  js.sort((a, b) => (a === 'main.js' ? 1 : b === 'main.js' ? -1 : 0));
+  const js = ENTRY_POINTS.filter((entry) => keys.includes(entry));
   const css = keys.filter((k) => k.endsWith('.css'));
   const ico = keys.find((k) => k.endsWith('.ico')) || 'favicon.ico';
   debug('manifest files js: %o', js);

--- a/packages/plugins/ui-theme/index.js
+++ b/packages/plugins/ui-theme/index.js
@@ -1,14 +1,34 @@
+const buildDebug = require('debug');
 const path = require('path');
 
+const debug = buildDebug('verdaccio:plugin:ui-theme');
+
+const manifest = require('./static/manifest.json');
+
+function getManifestFiles(manifest) {
+  const keys = Object.keys(manifest);
+  const js = keys.filter((k) => k.endsWith('.js'));
+  // ensure main.js loads last (after runtime/vendors)
+  js.sort((a, b) => (a === 'main.js' ? 1 : b === 'main.js' ? -1 : 0));
+  const css = keys.filter((k) => k.endsWith('.css'));
+  const ico = keys.find((k) => k.endsWith('.ico')) || 'favicon.ico';
+  debug('manifest files js: %o', js);
+  debug('manifest files css: %o', css);
+  debug('manifest files ico: %o', ico);
+  return { js, css, ico };
+}
+
 module.exports = () => {
+  const staticPath = path.join(__dirname, 'static');
+  const manifestFiles = getManifestFiles(manifest);
+  debug('static path: %o', staticPath);
+  debug('manifest keys: %o', Object.keys(manifest));
   return {
-    // location of the static files, webpack output
-    staticPath: path.join(__dirname, 'static'),
-    // webpack manifest json file
-    manifest: require('./static/manifest.json'),
-    // main manifest files to be loaded
-    manifestFiles: {
-      js: ['runtime.js', 'vendors.js', 'main.js'],
-    },
+    // location of the static files, build output
+    staticPath,
+    // asset manifest json file
+    manifest,
+    // derived from manifest keys — works with any bundler
+    manifestFiles,
   };
 };


### PR DESCRIPTION
Decouple the middleware and theme plugin from webpack-specific
assumptions so the manifest layer works with any bundler (webpack, vite).

- Rename WebpackManifest to AssetManifest in middleware types
- Derive manifestFiles (js/css/ico) from manifest keys instead of
  hardcoding chunk names in ui-theme/index.js
- Drop runtime.js from default manifest fallback (vite has no runtime chunk)
- Add debug logging to ui-theme plugin for manifest resolution