### PR TITLE
fix: handle missing host header in URL basename resolution

### DIFF
--- a/.changeset/warm-pandas-glow.md
+++ b/.changeset/warm-pandas-glow.md
@@ -1,0 +1,7 @@
+---
+'@verdaccio/middleware': patch
+---
+
+fix: handle missing host header in URL basename resolution
+
+Use `URL.canParse()` before constructing a `new URL()` for basename extraction in `renderHTML`, falling back to the raw base string when the URL is not parseable (e.g., when the request has no host header).

--- a/packages/middleware/src/middlewares/web/utils/renderHTML.ts
+++ b/packages/middleware/src/middlewares/web/utils/renderHTML.ts
@@ -55,7 +55,7 @@ export default function renderHTML(
 ) {
   const { url_prefix } = config;
   const base = getPublicUrl(config?.url_prefix, requestOptions);
-  const basename = new URL(base).pathname;
+  const basename = URL.canParse(base) ? new URL(base).pathname : base;
   const language = config?.i18n?.web ?? DEFAULT_LANGUAGE;
   const hideDeprecatedVersions = config?.web?.hideDeprecatedVersions ?? false;
   // @ts-ignore

--- a/packages/middleware/test/render.spec.ts
+++ b/packages/middleware/test/render.spec.ts
@@ -101,6 +101,17 @@ describe('test web server', () => {
         expect(__VERDACCIO_BASENAME_UI_OPTIONS.favicon).toEqual('');
       });
 
+      test('should render successfully when request has no host header', async () => {
+        const response = await supertest(initializeServer('default-test.yaml'))
+          .get('/')
+          .set('Accept', HEADERS.TEXT_HTML)
+          .unset('Host')
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.TEXT_HTML_UTF8)
+          .expect(HTTP_STATUS.OK);
+        const dom = new JSDOM(response.text, { runScripts: 'dangerously' });
+        expect(dom.window.__VERDACCIO_BASENAME_UI_OPTIONS.basename).toEqual('/');
+      });
+
       test.todo('should default title');
       test.todo('should need html cache');
     });


### PR DESCRIPTION
Use `URL.canParse()` before constructing a `new URL()` for basename extraction in `renderHTML`, falling back to the raw base string when the URL is not parseable (e.g., when the request has no host header).