### PR TITLE
fix: search component improvements

### DIFF
--- a/.changeset/fix-search-ui.md
+++ b/.changeset/fix-search-ui.md
@@ -1,0 +1,13 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+fix: search component improvements
+
+- fix: extract search query from URL path instead of query params to match API routing
+- fix: decode URI components in search query (e.g. `%40` to `@`) for scoped packages
+- fix: resolve undefined package name on search result click when `searchRemote` is disabled
+- feat: display "No results found" message when search yields no matches
+- feat: make detail page tabs full-width on desktop and scrollable on mobile
+- test: add unit tests for AutoComplete component
+- test: update Search tests to cover debounce memoization and cleanup on unmount

--- a/packages/ui-components/src/components/AppRoute/AppRoute.stories.tsx
+++ b/packages/ui-components/src/components/AppRoute/AppRoute.stories.tsx
@@ -93,15 +93,19 @@ const handlers = [
   }),
   http.get('https://my-registry.org/-/verdaccio/data/search/*', async ({ request }) => {
     const url = new URL(request.url);
-    const query = url.searchParams.get('text');
+    const rawQuery = url.pathname.split('/-/verdaccio/data/search/')[1] || '';
+    const query = decodeURIComponent(rawQuery);
+    console.warn('search query', query);
     const packages = searchVerdaccio;
     await delay(600);
     if (!query) {
       return HttpResponse.json(packages);
     }
     const filteredPackages = packages.filter((pkg: { package: { name: string } }) => {
-      return pkg.package.name.match(new RegExp(query, 'i')) !== null;
+      const matches = pkg.package.name.match(new RegExp(query, 'i')) !== null;
+      return matches;
     });
+    console.warn('filteredPackages', filteredPackages);
     return HttpResponse.json(filteredPackages);
   }),
   http.post('https://my-registry.org/-/verdaccio/sec/login', async ({ request }) => {

--- a/packages/ui-components/src/components/Search/AutoComplete/AutoComplete.test.tsx
+++ b/packages/ui-components/src/components/Search/AutoComplete/AutoComplete.test.tsx
@@ -1,0 +1,161 @@
+import TextField from '@mui/material/TextField';
+import React from 'react';
+import { vi } from 'vitest';
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '../../../test/test-react-testing-library';
+import AutoComplete from './AutoComplete';
+import type { OnSelecItem } from './AutoComplete';
+
+const defaultProps = () => ({
+  placeholder: 'Search packages',
+  suggestions: [],
+  suggestionsLoading: false,
+  onSuggestionsFetch: vi.fn(),
+  onCleanSuggestions: vi.fn(),
+  onSelectItem: vi.fn() as unknown as OnSelecItem,
+  getOptionLabel: (option: any) => option?.package?.name ?? '',
+  renderInput: (params: any) => (
+    <TextField {...params} placeholder="Search packages" variant="standard" />
+  ),
+  renderOption: (props: any, option: any) => <li {...props}>{option.package.name}</li>,
+});
+
+const makeSuggestion = (name: string) => ({
+  package: { name, version: '1.0.0', description: '', links: {} },
+});
+
+describe('<AutoComplete /> component', () => {
+  beforeEach(cleanup);
+
+  test('should render with default state', () => {
+    const props = defaultProps();
+    render(<AutoComplete {...props} />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  test('should call onSuggestionsFetch when user types', () => {
+    const props = defaultProps();
+    render(<AutoComplete {...props} />);
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'react' } });
+
+    expect(props.onSuggestionsFetch).toHaveBeenCalledWith({ value: 'react' });
+  });
+
+  test('should call onCleanSuggestions and clear input on reason "clear"', () => {
+    const props = defaultProps();
+    const { container } = render(<AutoComplete {...props} />);
+    const input = screen.getByRole('combobox');
+
+    // Type something first
+    fireEvent.change(input, { target: { value: 'test' } });
+    expect(input).toHaveAttribute('value', 'test');
+
+    // Click the clear button
+    const clearButton = container.querySelector('[aria-label="Clear"]');
+    if (clearButton) {
+      fireEvent.click(clearButton);
+    }
+  });
+
+  test('should not show options when input is empty/whitespace', () => {
+    const props = defaultProps();
+    props.suggestions = [makeSuggestion('verdaccio')] as any;
+    render(<AutoComplete {...props} />);
+    const input = screen.getByRole('combobox');
+
+    fireEvent.focus(input);
+    // filterOptions returns [] when inputValue is empty
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  test('should show suggestions when input has value', async () => {
+    const suggestions = [makeSuggestion('verdaccio'), makeSuggestion('verdaccio-auth')];
+    const props = defaultProps();
+    props.suggestions = suggestions as any;
+
+    render(<AutoComplete {...props} />);
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'verdaccio' } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+  });
+
+  test('should show loading text when suggestionsLoading is true', async () => {
+    const props = defaultProps();
+    props.suggestionsLoading = true;
+
+    render(<AutoComplete {...props} />);
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'loading' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('autoComplete.loading')).toBeInTheDocument();
+    });
+  });
+
+  test('should call onCleanSuggestions and clear input on close', async () => {
+    const suggestions = [makeSuggestion('verdaccio')];
+    const props = defaultProps();
+    props.suggestions = suggestions as any;
+
+    render(<AutoComplete {...props} />);
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'verdaccio' } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    // Close by pressing Escape
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(props.onCleanSuggestions).toHaveBeenCalled();
+  });
+
+  test('should call onSelectItem when an option is selected', async () => {
+    const suggestions = [makeSuggestion('verdaccio')];
+    const props = defaultProps();
+    props.suggestions = suggestions as any;
+
+    render(<AutoComplete {...props} />);
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'verdaccio' } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+    });
+
+    const option = screen.getByText('verdaccio');
+    fireEvent.click(option);
+
+    expect(props.onSelectItem).toHaveBeenCalled();
+  });
+
+  test('should show "no results found" when suggestions are empty and user has typed', async () => {
+    const props = defaultProps();
+    props.suggestions = [];
+
+    render(<AutoComplete {...props} />);
+    const input = screen.getByRole('combobox');
+
+    fireEvent.change(input, { target: { value: 'nonexistent' } });
+
+    await waitFor(() => {
+      expect(screen.getByText('autoComplete.no-results-found')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui-components/src/components/Search/AutoComplete/AutoComplete.tsx
+++ b/packages/ui-components/src/components/Search/AutoComplete/AutoComplete.tsx
@@ -61,13 +61,14 @@ const AutoComplete: FC<Props> = ({
         /* @ts-ignore */
         clearOnBlur={true}
         disablePortal={true}
-        freeSolo={true}
+        filterOptions={(options, state) => (state.inputValue.trim() ? options : [])}
         fullWidth={true}
         getOptionLabel={getOptionLabel}
         id="search-header-suggest"
         inputValue={inputValue}
         loading={suggestionsLoading}
         loadingText={t('autoComplete.loading')}
+        noOptionsText={t('autoComplete.no-results-found')}
         onChange={onSelectItem as any}
         onClose={handleOnClose}
         onInputChange={handleOnInputChange}

--- a/packages/ui-components/src/components/Search/Search.stories.tsx
+++ b/packages/ui-components/src/components/Search/Search.stories.tsx
@@ -1,13 +1,25 @@
 import Box from '@mui/material/Box';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { HttpResponse, http } from 'msw';
-import React from 'react';
-import { MemoryRouter } from 'react-router';
+import React, { useEffect } from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { action } from 'storybook/actions';
 
 import searchVerdaccio from '../../../vitest/api/search-verdaccio.json';
 import { SearchProvider } from '../../providers';
 import Home from '../../sections/Home';
 import Search from './Search';
+
+/**
+ * Fires a Storybook action whenever the route changes (e.g. on search-item click).
+ */
+const NavigationLogger: React.FC = () => {
+  const location = useLocation();
+  useEffect(() => {
+    action('navigate')({ pathname: location.pathname, search: location.search });
+  }, [location]);
+  return null;
+};
 
 type Story = StoryObj<typeof Search>;
 const meta: Meta<typeof Search> = {
@@ -20,11 +32,19 @@ export default meta;
 export const SearchByQuery: Story = {
   render: (args) => (
     <MemoryRouter initialEntries={[`/-/web/detail/storybook`]}>
-      <Box component="section" sx={{ p: 2, border: '1px dashed grey' }}>
-        <SearchProvider>
-          <Search {...args} />
-        </SearchProvider>
-      </Box>
+      <NavigationLogger />
+      <Routes>
+        <Route
+          element={
+            <Box component="section" sx={{ p: 2, border: '1px dashed grey' }}>
+              <SearchProvider>
+                <Search {...args} />
+              </SearchProvider>
+            </Box>
+          }
+          path="*"
+        />
+      </Routes>
     </MemoryRouter>
   ),
   parameters: {
@@ -32,7 +52,8 @@ export const SearchByQuery: Story = {
       handlers: [
         http.get('https://my-registry.org/-/verdaccio/data/search/*', ({ request }) => {
           const url = new URL(request.url);
-          const query = url.searchParams.get('text');
+          const rawQuery = url.pathname.split('/-/verdaccio/data/search/')[1] || '';
+          const query = decodeURIComponent(rawQuery);
 
           const packages = searchVerdaccio;
 

--- a/packages/ui-components/src/components/Search/Search.test.tsx
+++ b/packages/ui-components/src/components/Search/Search.test.tsx
@@ -1,3 +1,4 @@
+import debounce from 'lodash/debounce';
 import React from 'react';
 import { vi } from 'vitest';
 
@@ -14,9 +15,13 @@ import { cleanDescription } from './utils';
 vi.mock('lodash/debounce', () => ({
   default: vi.fn((fn) => {
     // Immediately execute the function for testing
-    return (...args: any[]) => fn(...args);
+    const debounced = (...args: any[]) => fn(...args);
+    debounced.cancel = vi.fn();
+    return debounced;
   }),
 }));
+
+const mockedDebounce = vi.mocked(debounce);
 
 // Add this near the top of your test file, outside describe blocks
 const abortSpy = vi.spyOn(AbortController.prototype, 'abort');
@@ -142,6 +147,54 @@ describe('<Search /> component', () => {
     // // when the page redirects, the list box should be empty again
     expect(listBoxElement).toHaveLength(0);
   }, 5000);
+
+  test('should create a stable debounced function via useMemo', () => {
+    renderWithRouteDetail(<ComponentToBeRendered />);
+    // debounce should be called once on mount with the fetch handler and 300ms delay
+    expect(mockedDebounce).toHaveBeenCalledWith(expect.any(Function), 300);
+    const callCount = mockedDebounce.mock.calls.length;
+
+    // re-render should not create a new debounced instance
+    renderWithRouteDetail(<ComponentToBeRendered />);
+    // debounce is called once per mount, not on every render
+    expect(mockedDebounce).toHaveBeenCalledTimes(callCount * 2);
+  });
+
+  test('should cancel debounced function and abort requests on unmount', async () => {
+    const { unmount, getByPlaceholderText } = renderWithRouteDetail(<ComponentToBeRendered />);
+
+    // get the cancel mock from the last debounced function created
+    const lastDebouncedFn = mockedDebounce.mock.results[mockedDebounce.mock.results.length - 1]
+      .value as any;
+
+    const autoCompleteInput = getByPlaceholderText('search.packages');
+
+    // trigger a search so there's an active AbortController
+    fireEvent.focus(autoCompleteInput);
+    fireEvent.change(autoCompleteInput, { target: { value: 'verdaccio' } });
+
+    await waitFor(() => {
+      expect(autoCompleteInput).toHaveAttribute('value', 'verdaccio');
+    });
+
+    abortSpy.mockClear();
+    unmount();
+
+    // cleanup effect should cancel debounce and abort pending requests
+    expect(lastDebouncedFn.cancel).toHaveBeenCalled();
+    expect(abortSpy).toHaveBeenCalled();
+  });
+
+  test('should not fetch when search value is only whitespace', async () => {
+    renderWithRouteDetail(<ComponentToBeRendered />);
+    const autoCompleteInput = screen.getByPlaceholderText('search.packages');
+
+    fireEvent.focus(autoCompleteInput);
+    fireEvent.change(autoCompleteInput, { target: { value: '   ' } });
+
+    // no abort should be called since no request was started
+    expect(abortSpy).not.toHaveBeenCalled();
+  });
 
   test.todo('handle SearchItem properties, isPrivate, isRemote, isCached');
 });

--- a/packages/ui-components/src/components/Search/Search.tsx
+++ b/packages/ui-components/src/components/Search/Search.tsx
@@ -1,6 +1,6 @@
 import SearchMui from '@mui/icons-material/Search';
 import debounce from 'lodash/debounce';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
@@ -35,10 +35,6 @@ const Search: React.FC = () => {
     }
   }, []);
 
-  useEffect(() => {
-    return () => cancelAllSearchRequests();
-  }, [cancelAllSearchRequests]);
-
   const handleOnBlur = useCallback(
     (event: React.SyntheticEvent) => {
       event.stopPropagation();
@@ -51,28 +47,33 @@ const Search: React.FC = () => {
     (event: React.SyntheticEvent, value: SearchResultWeb, reason: string): void => {
       event.stopPropagation();
       if (reason === 'selectOption') {
-        const pkgName = searchRemote ? value['package'].name : value.name;
+        const pkgName = value['package']?.name ?? value.name;
         navigate(`${Route.DETAIL}${pkgName}`);
       }
     },
     [navigate, searchRemote]
   );
 
+  // Use a ref to always access the latest doSearch without re-creating the debounced function
+  const doSearchRef = useRef(doSearch);
+  doSearchRef.current = doSearch;
+
   /**
-   * Fetch packages from API with Abort Logic.
+   * Stable fetch function that reads the latest doSearch from a ref,
+   * avoiding dependency changes that would break the debounce.
    */
   const handleFetchPackages = useCallback(
     async ({ value }: { value: string }) => {
       if (value?.trim() !== '') {
-        // 2. Abort any previous pending request before starting a new one
+        // Abort any previous pending request before starting a new one
         cancelAllSearchRequests();
 
-        // 3. Create a new controller for the current request
+        // Create a new controller for the current request
         const controller = new AbortController();
         abortControllerRef.current = controller;
 
         try {
-          await doSearch?.({
+          await doSearchRef.current?.({
             text: value,
             signal: controller.signal,
           });
@@ -85,8 +86,22 @@ const Search: React.FC = () => {
         }
       }
     },
-    [doSearch, cancelAllSearchRequests]
+    [cancelAllSearchRequests]
   );
+
+  // Memoize the debounced function so a single instance is reused across renders,
+  // ensuring the debounce timer works correctly instead of creating a new timer per render.
+  const debouncedFetch = useMemo(
+    () => debounce(handleFetchPackages, CONSTANTS.API_DELAY),
+    [handleFetchPackages]
+  );
+
+  useEffect(() => {
+    return () => {
+      debouncedFetch.cancel?.();
+      cancelAllSearchRequests();
+    };
+  }, [debouncedFetch, cancelAllSearchRequests]);
 
   const renderOption = (props, option) => {
     const { key, ...otherProps } = props;
@@ -150,8 +165,7 @@ const Search: React.FC = () => {
       getOptionLabel={getOptionLabel}
       onCleanSuggestions={handleOnBlur}
       onSelectItem={handleClickSearch}
-      // Debounce the entire fetcher wrapper
-      onSuggestionsFetch={debounce(handleFetchPackages, CONSTANTS.API_DELAY)}
+      onSuggestionsFetch={debouncedFetch}
       placeholder={t('search.packages')}
       renderInput={renderInput}
       renderOption={renderOption}

--- a/packages/ui-components/src/sections/Detail/Tabs.tsx
+++ b/packages/ui-components/src/sections/Detail/Tabs.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import Tab from '@mui/material/Tab';
 import { default as MuiTabs } from '@mui/material/Tabs';
-import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
@@ -16,8 +15,7 @@ interface Props {
 
 const DetailContainerTabs: React.FC<Props> = ({ tabPosition, onChange, showUplinks }) => {
   const { t } = useTranslation();
-  const muiTheme = useTheme();
-  const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery('(max-width:599px)');
 
   return (
     <Tabs

--- a/packages/ui-components/src/sections/Detail/Tabs.tsx
+++ b/packages/ui-components/src/sections/Detail/Tabs.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
 import Tab from '@mui/material/Tab';
 import { default as MuiTabs } from '@mui/material/Tabs';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -14,13 +16,16 @@ interface Props {
 
 const DetailContainerTabs: React.FC<Props> = ({ tabPosition, onChange, showUplinks }) => {
   const { t } = useTranslation();
+  const muiTheme = useTheme();
+  const isMobile = useMediaQuery(muiTheme.breakpoints.down('sm'));
+
   return (
     <Tabs
       allowScrollButtonsMobile={true}
       onChange={onChange}
-      scrollButtons="auto"
+      scrollButtons={isMobile ? 'auto' : false}
       value={tabPosition}
-      variant="scrollable"
+      variant={isMobile ? 'scrollable' : 'fullWidth'}
     >
       <Tab data-testid={'readme-tab'} id={'readme-tab'} label={t('tab.readme')} />
       <Tab data-testid={'dependencies-tab'} id={'dependencies-tab'} label={t('tab.dependencies')} />

--- a/packages/ui-components/src/sections/Header/Header.stories.tsx
+++ b/packages/ui-components/src/sections/Header/Header.stories.tsx
@@ -63,7 +63,8 @@ export const HeaderAll: Story = {
         }),
         http.get('https://my-registry.org/-/verdaccio/data/search/*', async ({ request }) => {
           const url = new URL(request.url);
-          const query = url.searchParams.get('text');
+          const rawQuery = url.pathname.split('/-/verdaccio/data/search/')[1] || '';
+          const query = decodeURIComponent(rawQuery);
 
           const packages = searchVerdaccio;
 


### PR DESCRIPTION
#5449

- fix: extract search query from URL path instead of query params to match API routing
- fix: decode URI components in search query (e.g. `%40` to `@`) for scoped packages
- fix: resolve undefined package name on search result click when `searchRemote` is disabled
- feat: display "No results found" message when search yields no matches
- feat: make detail page tabs full-width on desktop and scrollable on mobile
- test: add unit tests for AutoComplete component
- test: update Search tests to cover debounce memoization and cleanup on unmount