### PR TITLE
chore: vite replace rollupOptions with rolldownOptions

### DIFF
--- a/.changeset/thick-pigs-arrive.md
+++ b/.changeset/thick-pigs-arrive.md
@@ -1,0 +1,7 @@
+---
+'@verdaccio/plugin-verifier': patch
+'@verdaccio/ui-theme': patch
+'@verdaccio/ui-components': patch
+---
+
+chore: vite replace rollupOptions with rolldownOptions

--- a/packages/plugins/ui-theme/vite.config.mjs
+++ b/packages/plugins/ui-theme/vite.config.mjs
@@ -99,7 +99,7 @@ export default defineConfig(({ command }) => ({
     emptyOutDir: true,
     assetsDir: '',
     sourcemap: 'inline',
-    rollupOptions: {
+    rolldownOptions: {
       input: { main: path.resolve(__dirname, './src/index.tsx') },
       output: {
         entryFileNames: '[name].[hash].js',

--- a/packages/tools/plugin-verifier/vite.config.mjs
+++ b/packages/tools/plugin-verifier/vite.config.mjs
@@ -48,7 +48,7 @@ export default defineConfig({
         path.resolve(dirname, 'src/cli.ts'),
       ],
     },
-    rollupOptions: {
+    rolldownOptions: {
       external: isExternal,
       output: [
         {

--- a/packages/ui-components/vite.config.mjs
+++ b/packages/ui-components/vite.config.mjs
@@ -50,7 +50,7 @@ export default defineConfig({
     lib: {
       entry: path.resolve(__dirname, 'src/index.ts'),
     },
-    rollupOptions: {
+    rolldownOptions: {
       external: (id) =>
         externalDeps.has(id) || [...externalDeps].some((dep) => id.startsWith(`${dep}/`)),
       output: [

--- a/vite.lib.config.mjs
+++ b/vite.lib.config.mjs
@@ -102,29 +102,29 @@ export function createLibConfig(dirname, options = {}) {
         entry: entries,
         ...(esmOnly && { formats: ['es'] }),
       },
-      rollupOptions: {
+      rolldownOptions: {
         external: isExternal,
         output: esmOnly
           ? {
-              format: 'es',
-              entryFileNames: '[name].js',
-              ...sharedOutput,
-            }
+            format: 'es',
+            entryFileNames: '[name].js',
+            ...sharedOutput,
+          }
           : [
-              {
-                format: 'es',
-                entryFileNames: '[name].mjs',
-                ...sharedOutput,
-              },
-              {
-                format: 'cjs',
-                entryFileNames: '[name].js',
-                interop: 'auto',
-                esModule: true,
-                exports: 'named',
-                ...sharedOutput,
-              },
-            ],
+            {
+              format: 'es',
+              entryFileNames: '[name].mjs',
+              ...sharedOutput,
+            },
+            {
+              format: 'cjs',
+              entryFileNames: '[name].js',
+              interop: 'auto',
+              esModule: true,
+              exports: 'named',
+              ...sharedOutput,
+            },
+          ],
       },
     },
   });


### PR DESCRIPTION
Fixes warning during build:

```
`optimizeDeps.rollupOptions` / `ssr.optimizeDeps.rollupOptions` is deprecated. 
Use `optimizeDeps.rolldownOptions` instead. 
```

PS: lower part of diff is just indent
