### PR TITLE
chore(ui-components): stderr during tests

### DIFF
--- a/.changeset/hip-hairs-know.md
+++ b/.changeset/hip-hairs-know.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+chore(ui-components): stderr during tests

--- a/packages/ui-components/src/components/Package/Package.test.tsx
+++ b/packages/ui-components/src/components/Package/Package.test.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
-import { cleanupDownloadMocks, setupDownloadMocks } from '../../../vitest/vitestHelpers';
-import { cleanup, fireEvent, renderWith, screen } from '../../test/test-react-testing-library';
+import {
+  cleanupDownloadMocks,
+  mockCreateObjectURL,
+  setupDownloadMocks,
+} from '../../../vitest/vitestHelpers';
+import {
+  cleanup,
+  fireEvent,
+  renderWith,
+  screen,
+  waitFor,
+} from '../../test/test-react-testing-library';
 import Package from './Package';
 
 /**
@@ -39,6 +49,7 @@ afterAll(() => {
 describe('<Package /> component', () => {
   afterEach(() => {
     cleanup();
+    mockCreateObjectURL.mockReset();
   });
 
   test('should load the component', () => {
@@ -82,7 +93,6 @@ describe('<Package /> component', () => {
     );
 
     fireEvent.click(screen.getByTestId('download-tarball'));
-    // TODO: juan
-    // await waitFor(() => expect(store.getState().loading.models.download).toBe(true));
+    await waitFor(() => expect(mockCreateObjectURL).toHaveBeenCalledTimes(1));
   });
 });

--- a/packages/ui-components/src/components/Search/AutoComplete/AutoComplete.test.tsx
+++ b/packages/ui-components/src/components/Search/AutoComplete/AutoComplete.test.tsx
@@ -23,7 +23,14 @@ const defaultProps = () => ({
   renderInput: (params: any) => (
     <TextField {...params} placeholder="Search packages" variant="standard" />
   ),
-  renderOption: (props: any, option: any) => <li {...props}>{option.package.name}</li>,
+  renderOption: (props: any, option: any) => {
+    const { key, ...rest } = props;
+    return (
+      <li key={key} {...rest}>
+        {option.package.name}
+      </li>
+    );
+  },
 });
 
 const makeSuggestion = (name: string) => ({

--- a/packages/ui-components/src/sections/Header/HeaderMenu.tsx
+++ b/packages/ui-components/src/sections/Header/HeaderMenu.tsx
@@ -8,6 +8,9 @@ import { useTranslation } from 'react-i18next';
 import { MenuItem } from '../../';
 import HeaderGreetings from './HeaderGreetings';
 
+// Workaround: MUI v7 MenuProps type resolution breaks inherited PopoverProps.
+const TypedMenu = Menu as React.FC<any>;
+
 interface Props {
   username: string;
   isMenuOpen: boolean;
@@ -37,7 +40,7 @@ const HeaderMenu: React.FC<Props> = ({
       >
         <AccountCircle />
       </IconButton>
-      <Menu
+      <TypedMenu
         anchorEl={anchorEl}
         anchorOrigin={{
           vertical: 'bottom',
@@ -56,7 +59,7 @@ const HeaderMenu: React.FC<Props> = ({
         <MenuItem data-testid="logOutDialogIcon" id="logOutDialogIcon" onClick={onLogout}>
           {t('button.logout')}
         </MenuItem>
-      </Menu>
+      </TypedMenu>
     </>
   );
 };

--- a/packages/ui-components/src/sections/Header/HeaderMenu.tsx
+++ b/packages/ui-components/src/sections/Header/HeaderMenu.tsx
@@ -39,19 +39,15 @@ const HeaderMenu: React.FC<Props> = ({
       </IconButton>
       <Menu
         anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'right',
+        }}
         onClose={onLoggedInMenuClose}
         open={isMenuOpen}
-        slotProps={{
-          root: {
-            anchorOrigin: {
-              vertical: 'bottom',
-              horizontal: 'right',
-            },
-            transformOrigin: {
-              vertical: 'top',
-              horizontal: 'right',
-            },
-          } as any,
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
         }}
       >
         <MenuItem>

--- a/packages/ui-components/src/sections/Security/AddUser.test.tsx
+++ b/packages/ui-components/src/sections/Security/AddUser.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { vi } from 'vitest';
 
 import { mockAddUser } from '../../../vitest/msw-utils';
+import { server } from '../../../vitest/setup';
 import {
   act,
   cleanup,
@@ -133,7 +134,6 @@ describe('<AddUser /> component', () => {
 
   test('should show error message on failed submission', async () => {
     // Override the default handler with a 409 error response
-    const { server } = await import('../../../vitest/server');
     server.use(mockAddUser(409, { error: 'user already exists' }));
 
     window.__VERDACCIO_BASENAME_UI_OPTIONS = {

--- a/packages/ui-components/src/sections/Security/AddUser.test.tsx
+++ b/packages/ui-components/src/sections/Security/AddUser.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { vi } from 'vitest';
 
 import { mockAddUser } from '../../../vitest/msw-utils';
-import { server } from '../../../vitest/setup';
+import { server } from '../../../vitest/server';
 import {
   act,
   cleanup,

--- a/packages/ui-components/src/sections/Security/AddUser.test.tsx
+++ b/packages/ui-components/src/sections/Security/AddUser.test.tsx
@@ -13,10 +13,21 @@ import {
 import { Route } from '../../utils';
 import AddUser from './AddUser';
 
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 describe('<AddUser /> component', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
+    mockNavigate.mockClear();
     cleanup();
   });
 
@@ -35,6 +46,7 @@ describe('<AddUser /> component', () => {
       renderWithRouter(<AddUser />, Route.ADD_USER, [Route.ADD_USER]);
     });
 
+    expect(mockNavigate).toHaveBeenCalledWith('/');
     expect(screen.queryByText('security.addUser.title')).not.toBeInTheDocument();
   });
 

--- a/packages/ui-components/src/sections/Security/ChangePassword.test.tsx
+++ b/packages/ui-components/src/sections/Security/ChangePassword.test.tsx
@@ -12,10 +12,21 @@ import {
 import { Route } from '../../utils';
 import ChangePassword from './ChangePassword';
 
+const mockNavigate = vi.fn();
+
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 describe('<ChangePassword /> component', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
+    mockNavigate.mockClear();
     cleanup();
   });
 
@@ -34,6 +45,7 @@ describe('<ChangePassword /> component', () => {
       renderWithRouter(<ChangePassword />, Route.CHANGE_PASSWORD, [Route.CHANGE_PASSWORD]);
     });
 
+    expect(mockNavigate).toHaveBeenCalledWith('/');
     expect(screen.queryByText('security.changePassword.title')).not.toBeInTheDocument();
   });
 

--- a/packages/ui-components/vitest/msw-utils.ts
+++ b/packages/ui-components/vitest/msw-utils.ts
@@ -77,6 +77,7 @@ export const mockReadme = (packageName: string, content?: string) =>
 export const mockTarball = (fileName = 'verdaccio-1.0.0.tgz') =>
   http.get(`${BASE_URL}/verdaccio/-/${fileName}`, (() => {
     const filePath = path.resolve(import.meta.dirname, `./api/${fileName}`);
+    debug('filePath', filePath);
     const fileContent = fs.readFileSync(filePath);
     return new HttpResponse(fileContent, {
       status: 200,
@@ -155,7 +156,7 @@ export const mockCliLogin = (status = 200, customResponse?: object) =>
  * @param customResponse - Override the default JSON body
  */
 export const mockAddUser = (status = 201, customResponse?: object) =>
-  http.put(`${BASE_URL}/-/web/add-user:*`, (async ({ request }) => {
+  http.put(`${BASE_URL}/-/web/add-user:username`, (async ({ request }) => {
     debug('Received add user request', request.method, request.url);
     const body = (await request.json()) as { name: string; password: string; email?: string };
 


### PR DESCRIPTION
Fix some of the stderr output during test run:

### AddUser, ChangePassword 

```log
stderr | src/sections/Security/ChangePassword.test.tsx > <ChangePassword /> component > 
should redirect to home when changePassword flag is disabled
stderr | src/sections/Security/AddUser.test.tsx > <AddUser /> component > 
should redirect to home when createUser flag is disabled
```

Added mock for useNavigate

### Package

```
stderr | src/components/Package/Package.test.tsx Error during tarball download: 
CustomError: Missing parameter name at 38
```

Fixed by updating the MSW route pattern that was crashing request matching.

### AutoComplete

```
stderr | src/components/Search/AutoComplete/AutoComplete.test.tsx > <AutoComplete /> component > 
should show suggestions when input has value
```

Updated the test renderer in `AutoComplete.test.tsx` to stop spreading key via props.

### Header

```
stderr | src/sections/Header/Header.test.tsx > <Header /> component with logged in state > 
should load the component in logged in state
```

`anchorOrigin` and `transformOrigin` ended up on the root DOM node of the menu, so React warned about unknown attributes. Passed them as normal Menu props (same as Popover), and dropped the incorrect slotProps.root block.


