### PR TITLE
fix(express): middleware registration order

### DIFF
--- a/.changeset/new-apes-speak.md
+++ b/.changeset/new-apes-speak.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/server': patch
+---
+
+fix(express): middleware registration order

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -105,9 +105,10 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<Ex
     plugins.push(auditPlugin);
   }
 
-  plugins.forEach((plugin: pluginUtils.ExpressMiddleware<IConfig, {}, Auth>) => {
+  // Ensure sequential execution in order, and that each registration completes before the next one starts
+  for (const plugin of plugins) {
     plugin.register_middlewares(app, auth, storage);
-  });
+  }
 
   // For package manager requests
   app.use(apiEndpoint(config, auth, storage, logger));


### PR DESCRIPTION
When using several middleware plugins, the registration order was not stable. This change ensures sequential execution in order, and that each registration completes before the next one starts.