### PR TITLE
chore: replace globby with tinyglobby

### DIFF
--- a/.changeset/blue-hats-float.md
+++ b/.changeset/blue-hats-float.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/local-storage': patch
+---
+
+chore: replace globby with tinyglobby

--- a/packages/plugins/local-storage/package.json
+++ b/packages/plugins/local-storage/package.json
@@ -40,7 +40,7 @@
     "@verdaccio/file-locking": "workspace:14.0.0-next-9.2",
     "@verdaccio/utils": "workspace:9.0.0-next-9.6",
     "debug": "4.4.3",
-    "globby": "11.1.0",
+    "tinyglobby": "0.2.15",
     "lodash": "4.17.23",
     "lowdb": "1.0.0",
     "sanitize-filename": "1.6.3"

--- a/packages/plugins/local-storage/src/dir-utils.ts
+++ b/packages/plugins/local-storage/src/dir-utils.ts
@@ -1,6 +1,6 @@
 import buildDebug from 'debug';
-import globby from 'globby';
 import { join } from 'node:path';
+import { glob } from 'tinyglobby';
 
 import type { searchUtils } from '@verdaccio/core';
 import { validationUtils } from '@verdaccio/core';
@@ -13,7 +13,7 @@ const debug = buildDebug('verdaccio:plugin:local-storage:utils');
  * @return a promise that resolves to an array of absolute paths
  */
 export async function getFolders(storagePath: string, pattern = '*'): Promise<string[]> {
-  const files = await globby(pattern, {
+  const files = await glob(pattern, {
     // @ts-ignore
     cwd: storagePath,
     expandDirectories: true,
@@ -24,7 +24,6 @@ export async function getFolders(storagePath: string, pattern = '*'): Promise<st
     dot: false,
     followSymbolicLinks: true,
     caseSensitiveMatch: true,
-    unique: true,
     // FIXME: add here list of forbiden patterns
     // don't include scoped folders.
     // ignore: [`@*`],

--- a/packages/plugins/local-storage/src/dir-utils.ts
+++ b/packages/plugins/local-storage/src/dir-utils.ts
@@ -28,7 +28,12 @@ export async function getFolders(storagePath: string, pattern = '*'): Promise<st
     // don't include scoped folders.
     // ignore: [`@*`],
   });
-  return files;
+
+  // Remove trailing slashes to remain compatible with globby
+  const globFiles = files.map((file) =>
+    typeof file === 'string' && file.endsWith('/') ? file.replace(/\/+$/, '') : file
+  );
+  return globFiles;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -815,9 +815,6 @@ importers:
       debug:
         specifier: 4.4.3
         version: 4.4.3(supports-color@5.5.0)
-      globby:
-        specifier: 11.1.0
-        version: 11.1.0
       lodash:
         specifier: 4.17.23
         version: 4.17.23
@@ -827,6 +824,9 @@ importers:
       sanitize-filename:
         specifier: 1.6.3
         version: 1.6.3
+      tinyglobby:
+        specifier: 0.2.15
+        version: 0.2.15
     devDependencies:
       '@verdaccio/logger':
         specifier: workspace:9.0.0-next-9.6


### PR DESCRIPTION
Replaces `globby`

<img width="1156" height="343" alt="image" src="https://github.com/user-attachments/assets/e8f74ed3-93bb-40ca-92ea-701770d31101" />

with `tinyglobby`

<img width="270" height="98" alt="image" src="https://github.com/user-attachments/assets/7cb0f72f-53d6-4724-9b85-a0d7f0a42f3e" />

https://github.com/es-tooling/module-replacements/blob/main/docs/modules/globby.md
https://superchupu.dev/tinyglobby