### PR TITLE
chore(ui-theme): reduce package size

### DIFF
--- a/.changeset/silent-flowers-perform.md
+++ b/.changeset/silent-flowers-perform.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-theme': patch
+---
+
+chore(ui-theme): reduce package size

--- a/packages/plugins/ui-theme/vite.config.mjs
+++ b/packages/plugins/ui-theme/vite.config.mjs
@@ -98,7 +98,8 @@ export default defineConfig(({ command }) => ({
     outDir: 'static',
     emptyOutDir: true,
     assetsDir: '',
-    sourcemap: 'inline',
+    sourcemap: false,
+    minify: true,
     rolldownOptions: {
       input: { main: path.resolve(__dirname, './src/index.tsx') },
       output: {


### PR DESCRIPTION
The v8 theme is 3.9 MB but v9 went up to 13.4 MB mostly due to source maps.

After the change, the theme will be about 2.2 MB and loads much faster.