### PR TITLE
chore(ui-theme): stderr during tests

### DIFF
--- a/.changeset/metal-students-return.md
+++ b/.changeset/metal-students-return.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-theme': patch
+---
+
+chore(ui-theme): stderr during tests

--- a/packages/plugins/ui-theme/src/App/App.test.tsx
+++ b/packages/plugins/ui-theme/src/App/App.test.tsx
@@ -4,10 +4,11 @@ import { vi } from 'vitest';
 import { act, renderWith, screen } from '../utils/test-react-testing-library';
 
 vi.mock('@verdaccio/ui-components', async (importOriginal) => {
-  const mod = await importOriginal<typeof import('@verdaccio/ui-components')>();
+  const mod = await importOriginal();
   return {
     ...mod,
     Header: () => <div data-testid="header">Header</div>,
+    Footer: () => <div data-testid="footer">Footer</div>,
     SearchProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   };
 });
@@ -17,7 +18,7 @@ vi.mock('./AppRoute', () => ({
 }));
 
 vi.mock('react-router', async (importOriginal) => {
-  const mod = await importOriginal<typeof import('react-router')>();
+  const mod = await importOriginal();
   return {
     ...mod,
     BrowserRouter: ({ children }: { children: React.ReactNode }) => <>{children}</>,

--- a/packages/plugins/ui-theme/src/components/Support/Support.tsx
+++ b/packages/plugins/ui-theme/src/components/Support/Support.tsx
@@ -44,12 +44,12 @@ const Support = () => {
   return (
     <>
       <Grid container={true} spacing={2}>
-        <Grid item={true} xs={12}>
+        <Grid size={{ xs: 12 }}>
           <Typography component="h2" variant="h6">
             {title}
           </Typography>
         </Grid>
-        <Grid item={true} lg={12} xs={12}>
+        <Grid size={{ lg: 12, xs: 12 }}>
           <span style={{ fontStyle: 'italic', fontSize: '0.75rem' }}>
             <Typography>
               {`Hi, this is a message that I've composed to call your attention to ask 


### PR DESCRIPTION
Fix some of the stderr output during test run:

### Support

```
stderr | src/components/Support/Support.test.tsx > <Support /> > should render the support component
MUI Grid: The `item` prop has been removed and is no longer necessary. You can safely remove it.
MUI Grid: The `xs` prop has been removed. See https://mui.com/material-ui/migration/upgrade-to-grid-v2/ 
for migration instructions.
MUI Grid: The `lg` prop has been removed. See https://mui.com/material-ui/migration/upgrade-to-grid-v2/ 
for migration instructions.
```

Replaced props

### App

```
stderr | src/App/App.test.tsx > <App /> > footer > should display the Footer component
react-i18next:: useTranslation: You will need to pass in an i18next instance by using initReactI18next 
{ code: 'NO_I18NEXT_INSTANCE' }
react-i18next:: Trans: You need to pass in an i18next instance using i18nextReactModule 
{ code: 'NO_I18NEXT_INSTANCE', i18nKey: 'footer.made-with-love-on' }
```

- Mocked footer
- Fixed type warnings