### PR TITLE
chore: add lockfile check to husky pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'master'
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths:
       - .changeset/**
       - .github/workflows/ci.yml

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+echo "Checking pnpm lockfile is up-to-date..."
+if ! pnpm install --frozen-lockfile --lockfile-only 2>/dev/null; then
+  echo "ERROR: pnpm lockfile is out of date. Run 'pnpm install' and commit the updated lockfile."
+  exit 1
+fi
+
 #./node_modules/.bin/lint-staged
 npm run husky:pre-commit

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "vite-plugin-dts": "4.5.4"
   },
   "scripts": {
-    "prepare": "husky install",
+    "prepare": "husky",
     "husky:pre-commit": "lint-staged",
     "clean": "pnpm --filter \"./packages/**\" clean",
     "build": "pnpm --filter \"./packages/**\" build",
@@ -138,7 +138,7 @@
     "crowdin:upload": "crowdin upload sources --auto-update --config ./crowdin.yaml",
     "crowdin:download": "crowdin download --verbose --config ./crowdin.yaml",
     "crowdin:sync": "pnpm crowdin:upload && pnpm crowdin:download",
-    "postinstall": "husky install",
+    "postinstall": "husky",
     "local:registry": "pnpm --filter ...@verdaccio/local-publish start",
     "local:snapshots": "changeset version --snapshot",
     "local:publish": "cross-env npm_config_registry=http://localhost:4873 changeset publish --no-git-tag",


### PR DESCRIPTION
Uses `--lockfile-only` which only validates/generates the lockfile without actually installing any packages into `node_modules`. Combined with `--frozen-lockfile` it just checks whether the lockfile matches the manifests — no downloads, no installs.

Also fixes `husky install is deprecated` warning during `pnpm install`.