### PR TITLE
chore: fix vite build errors

### DIFF
--- a/.changeset/metal-masks-reflect.md
+++ b/.changeset/metal-masks-reflect.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+chore: fix vite build errors

--- a/.changeset/metal-masks-reflect.md
+++ b/.changeset/metal-masks-reflect.md
@@ -1,5 +1,6 @@
 ---
 '@verdaccio/ui-components': patch
+'@verdaccio/ui-theme': patch
 ---
 
-chore: fix vite build errors
+chore: fix vite build warnings and errors

--- a/packages/plugins/ui-theme/package.json
+++ b/packages/plugins/ui-theme/package.json
@@ -16,6 +16,9 @@
   },
   "homepage": "https://verdaccio.org",
   "main": "index.js",
+  "dependencies": {
+    "debug": "4.4.3"
+  },
   "devDependencies": {
     "@mui/material": "7.3.9",
     "@testing-library/dom": "10.4.1",

--- a/packages/plugins/ui-theme/vite.config.mjs
+++ b/packages/plugins/ui-theme/vite.config.mjs
@@ -100,6 +100,7 @@ export default defineConfig(({ command }) => ({
     assetsDir: '',
     sourcemap: false,
     minify: true,
+    chunkSizeWarningLimit: 2560,
     rolldownOptions: {
       input: { main: path.resolve(__dirname, './src/index.tsx') },
       output: {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -25,10 +25,8 @@
     "test": "cross-env TZ=UTC vitest run",
     "clean": "rimraf ./build",
     "type-check": "tsc --noEmit -p tsconfig.build.json",
-    "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
-    "build:js": "vite build",
     "watch": "vite build --watch",
-    "build": "pnpm run build:js && pnpm run build:types",
+    "build": "vite build",
     "start": "cross-env BROWSER=none storybook dev -p 6006",
     "build-storybook": "storybook build"
   },
@@ -39,9 +37,11 @@
     "@microlink/react-json-view": "1.31.12",
     "@mui/icons-material": "7.3.9",
     "@mui/material": "7.3.9",
+    "@mui/system": "7.3.9",
     "@verdaccio/ui-i18n": "workspace:10.0.0-next-9.2",
     "country-flag-icons": "1.6.15",
     "dayjs": "1.11.20",
+    "debug": "4.4.3",
     "dompurify": "3.3.3",
     "highlight.js": "11.11.1",
     "i18next": "25.8.18",
@@ -85,9 +85,6 @@
     "vite": "^8.0.0",
     "vitest": "4.1.0",
     "whatwg-fetch": "3.6.20"
-  },
-  "resolutions": {
-    "msw": "2.12.10"
   },
   "msw": {
     "workerDirectory": [

--- a/packages/ui-components/src/Theme/modes.ts
+++ b/packages/ui-components/src/Theme/modes.ts
@@ -5,6 +5,19 @@ import { baseColors } from './colors';
 
 export type ThemeMode = 'light' | 'dark';
 
+export const customPaletteColors = {
+  black: '#000',
+  cyanBlue: '#253341',
+  greyLight: '#d3d3d3',
+  greyLight2: '#908ba1',
+  greyDark2: '#586069',
+  greyGainsboro: '#e3e3e3',
+  greyAthens: '#d3dddd',
+  snow: '#f9f9f9',
+  love: '#e25555',
+  nobel01: '#999999',
+} as const;
+
 const DARK_MODE_PRIMARY = common.white;
 
 export const getModePalette = (mode: ThemeMode, primaryColor?: string): PaletteOptions => {
@@ -20,6 +33,7 @@ export const getModePalette = (mode: ThemeMode, primaryColor?: string): PaletteO
         default: '#1a202c',
         paper: '#2d3748',
       },
+      ...customPaletteColors,
     };
   }
 
@@ -31,5 +45,6 @@ export const getModePalette = (mode: ThemeMode, primaryColor?: string): PaletteO
       default: '#f4f4f4',
       paper: '#ffffff',
     },
+    ...customPaletteColors,
   };
 };

--- a/packages/ui-components/src/Theme/theme.ts
+++ b/packages/ui-components/src/Theme/theme.ts
@@ -11,7 +11,32 @@ export type Theme = MuiTheme & CustomizedTheme;
 declare module '@mui/material/styles' {
   interface Theme extends CustomTheme {}
   interface ThemeOptions extends CustomTheme {}
+  interface Palette {
+    black: string;
+    cyanBlue: string;
+    greyLight: string;
+    greyLight2: string;
+    greyDark2: string;
+    greyGainsboro: string;
+    greyAthens: string;
+    snow: string;
+    love: string;
+    nobel01: string;
+  }
+  interface PaletteOptions {
+    black?: string;
+    cyanBlue?: string;
+    greyLight?: string;
+    greyLight2?: string;
+    greyDark2?: string;
+    greyGainsboro?: string;
+    greyAthens?: string;
+    snow?: string;
+    love?: string;
+    nobel01?: string;
+  }
 }
+
 declare module '@mui/material/styles/createTheme' {
   interface Theme extends CustomizedTheme {}
 

--- a/packages/ui-components/src/components/FundButton/FundButton.tsx
+++ b/packages/ui-components/src/components/FundButton/FundButton.tsx
@@ -16,7 +16,7 @@ const StyledLink = styled(LinkExternal)<{ theme?: Theme }>(({ theme }) => ({
 }));
 
 const StyledFavoriteIcon = styled(Favorite)<{ theme?: Theme }>(({ theme }) => ({
-  color: theme.palette.orange,
+  color: theme.palette.love,
 }));
 
 const StyledFundStrong = styled('strong')({

--- a/packages/ui-components/src/components/LoginDialog/LoginDialogCloseButton.tsx
+++ b/packages/ui-components/src/components/LoginDialog/LoginDialogCloseButton.tsx
@@ -9,8 +9,8 @@ import type { Theme } from '../../';
 
 const StyledIconButton = styled(IconButton)<{ theme?: Theme }>(({ theme }) => ({
   position: 'absolute',
-  right: theme.spacing() / 2,
-  top: theme.spacing() / 2,
+  right: theme.spacing(0.5),
+  top: theme.spacing(0.5),
   color: theme.palette.grey[500],
   zIndex: 99,
 }));

--- a/packages/ui-components/src/components/LoginForm/styles.tsx
+++ b/packages/ui-components/src/components/LoginForm/styles.tsx
@@ -42,8 +42,8 @@ const StyledAvatar = styled(Avatar)<{ theme?: Theme }>(({ theme }) => ({
 
 const StyledIconButton = styled(IconButton)<{ theme?: Theme }>(({ theme }) => ({
   position: 'absolute',
-  right: theme.spacing() / 2,
-  top: theme.spacing() / 2,
+  right: theme.spacing(0.5),
+  top: theme.spacing(0.5),
   color: theme.palette.grey[500],
 }));
 

--- a/packages/ui-components/src/components/Package/Package.tsx
+++ b/packages/ui-components/src/components/Package/Package.tsx
@@ -240,18 +240,18 @@ const iconStyle = ({ theme }: { theme: Theme }) => css`
   fill: ${theme.palette.mode === 'light' ? grey[900] : common.white};
 `;
 
-const StyledVersion = styled(Version)`
+const StyledVersion = styled(Version)<{ theme?: Theme }>`
   ${iconStyle};
 `;
 
-const StyledFileBinary = styled(FileBinary)`
+const StyledFileBinary = styled(FileBinary)<{ theme?: Theme }>`
   ${iconStyle};
 `;
 
-const StyledLaw = styled(Law)`
+const StyledLaw = styled(Law)<{ theme?: Theme }>`
   ${iconStyle};
 `;
 
-const StyledTime = styled(Time)`
+const StyledTime = styled(Time)<{ theme?: Theme }>`
   ${iconStyle};
 `;

--- a/packages/ui-components/src/components/Readme/Readme.tsx
+++ b/packages/ui-components/src/components/Readme/Readme.tsx
@@ -2,25 +2,26 @@ import styled from '@emotion/styled';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
-import 'highlight.js/styles/github-dark.css';
-import 'highlight.js/styles/github.css';
+import { useTheme } from '@mui/material/styles';
 import React from 'react';
 
-import { useCustomTheme } from '../../';
 import './github-markdown.css';
+import './hljs-github-dark.css';
+import './hljs-github-light.css';
 import type { Props } from './types';
 import { parseReadme } from './utils';
 
 const Readme: React.FC<Props> = ({ description }) => {
-  // @ts-ignore
-  const { isDarkMode } = useCustomTheme();
+  const theme = useTheme();
+  const dataTheme = theme.palette.mode;
 
   return (
     <Card sx={{ mb: 2 }}>
       <CardContent>
         <Box data-testid="readme" sx={{ m: 2 }}>
           <Wrapper
-            className={`markdown-body ${isDarkMode ? 'markdown-dark' : 'markdown-light'}`}
+            className="markdown-body hljs"
+            data-theme={dataTheme}
             dangerouslySetInnerHTML={{ __html: parseReadme(description) as string }}
           />
         </Box>

--- a/packages/ui-components/src/components/Readme/github-markdown.css
+++ b/packages/ui-components/src/components/Readme/github-markdown.css
@@ -2,129 +2,173 @@
 
 .markdown-body pre code span {
   font-family: monospace;
-  font-size: 1em;
 }
 
 /* Output from https://github.com/sindresorhus/generate-github-markdown-css without media selectors and transparent background */
 
-.markdown-dark {
-  /*dark*/
+.markdown-body {
+  --base-size-16: 1rem;
+  --base-size-24: 1.5rem;
+  --base-size-4: 0.25rem;
+  --base-size-40: 2.5rem;
+  --base-size-8: 0.5rem;
+  --base-text-weight-medium: 500;
+  --base-text-weight-normal: 400;
+  --base-text-weight-semibold: 600;
+  --borderWidth-thin: 0.0625rem;
+  --borderRadius-full: 624.938rem;
+  --borderRadius-medium: 0.375rem;
+  --stack-padding-condensed: 0.5rem;
+  --stack-padding-normal: 1rem;
+  --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono,
+    monospace;
+  --fontStack-sansSerif: 'Mona Sans VF', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
+    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --text-body-size-small: var(--base-text-size-xs);
+  --h6-size: 0.75rem;
+  --fgColor-accent: Highlight;
+}
+[data-theme='dark'].markdown-body {
+  /* dark — bg tokens align with Theme/modes.ts (paper #2d3748, default #1a202c) */
   color-scheme: dark;
-  --color-prettylights-syntax-comment: #8b949e;
+  --fgColor-accent: #4493f8;
+  --bgColor-attention-muted: #bb800926;
+  --bgColor-default: #2d3748;
+  --bgColor-muted: #1a202c;
+  --bgColor-neutral-muted: #656c7633;
+  --borderColor-accent-emphasis: #1f6feb;
+  --borderColor-attention-emphasis: #9e6a03;
+  --borderColor-attention-muted: #bb800966;
+  --borderColor-danger-emphasis: #da3633;
+  --borderColor-default: #3d444d;
+  --borderColor-done-emphasis: #8957e5;
+  --borderColor-success-emphasis: #238636;
+  --color-prettylights-syntax-brackethighlighter-angle: #9198a1;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
+  --color-prettylights-syntax-carriage-return-bg: #b62324;
+  --color-prettylights-syntax-carriage-return-text: #f0f6fc;
+  --color-prettylights-syntax-comment: #9198a1;
   --color-prettylights-syntax-constant: #79c0ff;
+  --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
   --color-prettylights-syntax-entity: #d2a8ff;
-  --color-prettylights-syntax-storage-modifier-import: #c9d1d9;
   --color-prettylights-syntax-entity-tag: #7ee787;
   --color-prettylights-syntax-keyword: #ff7b72;
-  --color-prettylights-syntax-string: #a5d6ff;
-  --color-prettylights-syntax-variable: #ffa657;
-  --color-prettylights-syntax-brackethighlighter-unmatched: #f85149;
-  --color-prettylights-syntax-invalid-illegal-text: #f0f6fc;
-  --color-prettylights-syntax-invalid-illegal-bg: #8e1519;
-  --color-prettylights-syntax-carriage-return-text: #f0f6fc;
-  --color-prettylights-syntax-carriage-return-bg: #b62324;
-  --color-prettylights-syntax-string-regexp: #7ee787;
-  --color-prettylights-syntax-markup-list: #f2cc60;
-  --color-prettylights-syntax-markup-heading: #1f6feb;
-  --color-prettylights-syntax-markup-italic: #c9d1d9;
-  --color-prettylights-syntax-markup-bold: #c9d1d9;
-  --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
-  --color-prettylights-syntax-markup-deleted-bg: #67060c;
-  --color-prettylights-syntax-markup-inserted-text: #aff5b4;
-  --color-prettylights-syntax-markup-inserted-bg: #033a16;
-  --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+  --color-prettylights-syntax-markup-bold: #f0f6fc;
   --color-prettylights-syntax-markup-changed-bg: #5a1e02;
-  --color-prettylights-syntax-markup-ignored-text: #c9d1d9;
+  --color-prettylights-syntax-markup-changed-text: #ffdfb6;
+  --color-prettylights-syntax-markup-deleted-bg: #67060c;
+  --color-prettylights-syntax-markup-deleted-text: #ffdcd7;
+  --color-prettylights-syntax-markup-heading: #1f6feb;
   --color-prettylights-syntax-markup-ignored-bg: #1158c7;
+  --color-prettylights-syntax-markup-ignored-text: #f0f6fc;
+  --color-prettylights-syntax-markup-inserted-bg: #033a16;
+  --color-prettylights-syntax-markup-inserted-text: #aff5b4;
+  --color-prettylights-syntax-markup-italic: #f0f6fc;
+  --color-prettylights-syntax-markup-list: #f2cc60;
   --color-prettylights-syntax-meta-diff-range: #d2a8ff;
-  --color-prettylights-syntax-brackethighlighter-angle: #8b949e;
-  --color-prettylights-syntax-sublimelinter-gutter-mark: #484f58;
-  --color-prettylights-syntax-constant-other-reference-link: #a5d6ff;
-  --color-fg-default: #e6edf3;
-  --color-fg-muted: #848d97;
-  --color-fg-subtle: #6e7681;
-  --color-canvas-default: #0d1117; 
-  --color-canvas-subtle: #161b22;
-  --color-border-default: #30363d;
-  --color-border-muted: #21262d;
-  --color-neutral-muted: rgba(110,118,129,0.4);
-  --color-accent-fg: #2f81f7;
-  --color-accent-emphasis: #1f6feb;
-  --color-success-fg: #3fb950;
-  --color-success-emphasis: #238636;
-  --color-attention-fg: #d29922;
-  --color-attention-emphasis: #9e6a03;
-  --color-attention-subtle: rgba(187,128,9,0.15);
-  --color-danger-fg: #f85149;
-  --color-danger-emphasis: #da3633;
-  --color-done-fg: #a371f7;
-  --color-done-emphasis: #8957e5;
+  --color-prettylights-syntax-storage-modifier-import: #f0f6fc;
+  --color-prettylights-syntax-string: #a5d6ff;
+  --color-prettylights-syntax-string-regexp: #7ee787;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #3d444d;
+  --color-prettylights-syntax-variable: #ffa657;
+  --fgColor-attention: #d29922;
+  --fgColor-danger: #f85149;
+  --fgColor-default: #f0f6fc;
+  --fgColor-done: #ab7df8;
+  --fgColor-muted: #9198a1;
+  --fgColor-success: #3fb950;
+  --borderColor-muted: #3d444db3;
+  --color-prettylights-syntax-invalid-illegal-bg: var(--bgColor-danger-muted);
+  --color-prettylights-syntax-invalid-illegal-text: var(--fgColor-danger);
+  --focus-outlineColor: var(--borderColor-accent-emphasis);
+  --selection-bgColor: #1f6febb3;
+  --borderColor-neutral-muted: var(--borderColor-muted);
 }
 
-.markdown-light {
-  /*light*/
+[data-theme='light'].markdown-body {
+  /* light */
   color-scheme: light;
-  --color-prettylights-syntax-comment: #57606a;
-  --color-prettylights-syntax-constant: #0550ae;
-  --color-prettylights-syntax-entity: #6639ba;
-  --color-prettylights-syntax-storage-modifier-import: #24292f;
-  --color-prettylights-syntax-entity-tag: #116329;
-  --color-prettylights-syntax-keyword: #cf222e;
-  --color-prettylights-syntax-string: #0a3069;
-  --color-prettylights-syntax-variable: #953800;
+  --fgColor-danger: #d1242f;
+  --bgColor-attention-muted: #fff8c5;
+  --bgColor-muted: darkgray;
+  --bgColor-neutral-muted: #818b981f;
+  --borderColor-accent-emphasis: #0969da;
+  --borderColor-attention-emphasis: #9a6700;
+  --borderColor-attention-muted: #d4a72c66;
+  --borderColor-danger-emphasis: #cf222e;
+  --borderColor-default: #d1d9e0;
+  --borderColor-done-emphasis: #8250df;
+  --borderColor-success-emphasis: #1a7f37;
+  --color-prettylights-syntax-brackethighlighter-angle: #59636e;
   --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
-  --color-prettylights-syntax-invalid-illegal-text: #f6f8fa;
-  --color-prettylights-syntax-invalid-illegal-bg: #82071e;
-  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
   --color-prettylights-syntax-carriage-return-bg: #cf222e;
-  --color-prettylights-syntax-string-regexp: #116329;
-  --color-prettylights-syntax-markup-list: #3b2300;
-  --color-prettylights-syntax-markup-heading: #0550ae;
-  --color-prettylights-syntax-markup-italic: #24292f;
-  --color-prettylights-syntax-markup-bold: #24292f;
-  --color-prettylights-syntax-markup-deleted-text: #82071e;
-  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
-  --color-prettylights-syntax-markup-inserted-text: #116329;
-  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
-  --color-prettylights-syntax-markup-changed-text: #953800;
-  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
-  --color-prettylights-syntax-markup-ignored-text: #eaeef2;
-  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
-  --color-prettylights-syntax-meta-diff-range: #8250df;
-  --color-prettylights-syntax-brackethighlighter-angle: #57606a;
-  --color-prettylights-syntax-sublimelinter-gutter-mark: #8c959f;
+  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
+  --color-prettylights-syntax-comment: #59636e;
+  --color-prettylights-syntax-constant: #0550ae;
   --color-prettylights-syntax-constant-other-reference-link: #0a3069;
-  --color-fg-default: #1F2328;
-  --color-fg-muted: #656d76;
-  --color-fg-subtle: #6e7781;
-  --color-canvas-default: #ffffff;
-  --color-canvas-subtle: #f6f8fa;
-  --color-border-default: #d0d7de;
-  --color-border-muted: hsla(210,18%,87%,1);
-  --color-neutral-muted: rgba(175,184,193,0.2);
-  --color-accent-fg: #0969da;
-  --color-accent-emphasis: #0969da;
-  --color-success-fg: #1a7f37;
-  --color-success-emphasis: #1f883d;
-  --color-attention-fg: #9a6700;
-  --color-attention-emphasis: #9a6700;
-  --color-attention-subtle: #fff8c5;
-  --color-danger-fg: #d1242f;
-  --color-danger-emphasis: #cf222e;
-  --color-done-fg: #8250df;
-  --color-done-emphasis: #8250df;
+  --color-prettylights-syntax-entity: #6639ba;
+  --color-prettylights-syntax-entity-tag: #0550ae;
+  --color-prettylights-syntax-invalid-illegal-text: var(--fgColor-danger);
+  --color-prettylights-syntax-keyword: #cf222e;
+  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
+  --color-prettylights-syntax-markup-changed-text: #953800;
+  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
+  --color-prettylights-syntax-markup-deleted-text: #82071e;
+  --color-prettylights-syntax-markup-heading: #0550ae;
+  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
+  --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
+  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
+  --color-prettylights-syntax-markup-inserted-text: #116329;
+  --color-prettylights-syntax-markup-list: #3b2300;
+  --color-prettylights-syntax-meta-diff-range: #8250df;
+  --color-prettylights-syntax-string: #0a3069;
+  --color-prettylights-syntax-string-regexp: #116329;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
+  --color-prettylights-syntax-variable: #953800;
+  --fgColor-accent: #0969da;
+  --fgColor-attention: #9a6700;
+  --fgColor-done: #8250df;
+  --fgColor-muted: #59636e;
+  --fgColor-success: #1a7f37;
+  --bgColor-default: #fff;
+  --borderColor-muted: #d1d9e0b3;
+  --color-prettylights-syntax-invalid-illegal-bg: var(--bgColor-danger-muted);
+  --color-prettylights-syntax-markup-bold: #1f2328;
+  --color-prettylights-syntax-markup-italic: #1f2328;
+  --color-prettylights-syntax-storage-modifier-import: #1f2328;
+  --fgColor-default: #1f2328;
+  --focus-outlineColor: var(--borderColor-accent-emphasis);
+  --selection-bgColor: #0969da33;
+  --borderColor-neutral-muted: var(--borderColor-muted);
 }
 
 .markdown-body {
-  -ms-text-size-adjust: 100%;
   -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
   margin: 0;
-  color: var(--color-fg-default);
-  background-color: transparent; /* var(--color-canvas-default); */
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-weight: var(--base-text-weight-normal, 400);
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-default);
+  font-family: var(
+    --fontStack-sansSerif,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    'Noto Sans',
+    Helvetica,
+    Arial,
+    sans-serif,
+    'Apple Color Emoji',
+    'Segoe UI Emoji'
+  );
+  overflow-wrap: break-word;
   font-size: 16px;
   line-height: 1.5;
-  word-wrap: break-word;
+}
+
+.markdown-body a {
+  text-decoration: underline;
+  text-underline-offset: 0.2rem;
 }
 
 .markdown-body .octicon {
@@ -163,8 +207,8 @@
 }
 
 .markdown-body a {
-  background-color: transparent;
-  color: var(--color-accent-fg);
+  background-color: #0000;
+  color: var(--fgColor-accent);
   text-decoration: none;
 }
 
@@ -184,28 +228,24 @@
 }
 
 .markdown-body h1 {
-  margin: .67em 0;
+  margin: 0.67em 0;
   font-weight: var(--base-text-weight-semibold, 600);
-  padding-bottom: .3em;
+  border-bottom: 1px solid var(--borderColor-muted);
+  padding-bottom: 0.3em;
   font-size: 2em;
-  border-bottom: 1px solid var(--color-border-muted);
 }
 
 .markdown-body mark {
-  background-color: var(--color-attention-subtle);
-  color: var(--color-fg-default);
-}
-
-.markdown-body small {
-  font-size: 90%;
+  background-color: var(--bgColor-attention-muted);
+  color: var(--fgColor-default);
 }
 
 .markdown-body sub,
 .markdown-body sup {
+  vertical-align: baseline;
   font-size: 75%;
   line-height: 0;
   position: relative;
-  vertical-align: baseline;
 }
 
 .markdown-body sub {
@@ -218,9 +258,8 @@
 
 .markdown-body img {
   border-style: none;
-  max-width: 100%;
   box-sizing: content-box;
-  background-color: var(--color-canvas-default);
+  max-width: 100%;
 }
 
 .markdown-body code,
@@ -232,19 +271,19 @@
 }
 
 .markdown-body figure {
-  margin: 1em 40px;
+  margin: 1em var(--base-size-40);
 }
 
 .markdown-body hr {
   box-sizing: content-box;
+  border-bottom: 1px solid var(--borderColor-muted);
+  background: 0 0;
   overflow: hidden;
-  background: transparent;
-  border-bottom: 1px solid var(--color-border-muted);
-  height: .25em;
-  padding: 0;
-  margin: 24px 0;
-  background-color: var(--color-border-default);
+  height: 0.25em;
+  margin: var(--base-size-24) 0;
+  background-color: var(--borderColor-default);
   border: 0;
+  padding: 0;
 }
 
 .markdown-body input {
@@ -256,33 +295,40 @@
   line-height: inherit;
 }
 
-.markdown-body [type=button],
-.markdown-body [type=reset],
-.markdown-body [type=submit] {
+.markdown-body [type='button'],
+.markdown-body [type='reset'],
+.markdown-body [type='submit'] {
   -webkit-appearance: button;
   appearance: button;
 }
 
-.markdown-body [type=checkbox],
-.markdown-body [type=radio] {
+.markdown-body [type='checkbox'],
+.markdown-body [type='radio'] {
   box-sizing: border-box;
   padding: 0;
 }
 
-.markdown-body [type=number]::-webkit-inner-spin-button,
-.markdown-body [type=number]::-webkit-outer-spin-button {
+.markdown-body [type='number']::-webkit-inner-spin-button {
   height: auto;
 }
 
-.markdown-body [type=search]::-webkit-search-cancel-button,
-.markdown-body [type=search]::-webkit-search-decoration {
+.markdown-body [type='number']::-webkit-outer-spin-button {
+  height: auto;
+}
+
+.markdown-body [type='search']::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.markdown-body [type='search']::-webkit-search-decoration {
   -webkit-appearance: none;
   appearance: none;
 }
 
 .markdown-body ::-webkit-input-placeholder {
   color: inherit;
-  opacity: .54;
+  opacity: 0.54;
 }
 
 .markdown-body ::-webkit-file-upload-button {
@@ -296,27 +342,28 @@
 }
 
 .markdown-body ::placeholder {
-  color: var(--color-fg-subtle);
+  color: var(--fgColor-muted);
   opacity: 1;
 }
 
-.markdown-body hr::before {
+.markdown-body hr:before {
+  content: '';
   display: table;
-  content: "";
 }
 
-.markdown-body hr::after {
-  display: table;
+.markdown-body hr:after {
   clear: both;
-  content: "";
+  content: '';
+  display: table;
 }
 
 .markdown-body table {
   border-spacing: 0;
   border-collapse: collapse;
-  display: block;
+  font-variant: tabular-nums;
   width: max-content;
   max-width: 100%;
+  display: block;
   overflow: auto;
 }
 
@@ -329,56 +376,63 @@
   cursor: pointer;
 }
 
-.markdown-body details:not([open])>*:not(summary) {
-  display: none !important;
-}
-
 .markdown-body a:focus,
-.markdown-body [role=button]:focus,
-.markdown-body input[type=radio]:focus,
-.markdown-body input[type=checkbox]:focus {
-  outline: 2px solid var(--color-accent-fg);
+.markdown-body [role='button']:focus,
+.markdown-body input[type='radio']:focus,
+.markdown-body input[type='checkbox']:focus {
+  outline: 2px solid var(--focus-outlineColor);
   outline-offset: -2px;
   box-shadow: none;
 }
 
 .markdown-body a:focus:not(:focus-visible),
-.markdown-body [role=button]:focus:not(:focus-visible),
-.markdown-body input[type=radio]:focus:not(:focus-visible),
-.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
-  outline: solid 1px transparent;
+.markdown-body [role='button']:focus:not(:focus-visible),
+.markdown-body input[type='radio']:focus:not(:focus-visible),
+.markdown-body input[type='checkbox']:focus:not(:focus-visible) {
+  outline: 1px solid #0000;
 }
 
 .markdown-body a:focus-visible,
-.markdown-body [role=button]:focus-visible,
-.markdown-body input[type=radio]:focus-visible,
-.markdown-body input[type=checkbox]:focus-visible {
-  outline: 2px solid var(--color-accent-fg);
+.markdown-body [role='button']:focus-visible,
+.markdown-body input[type='radio']:focus-visible,
+.markdown-body input[type='checkbox']:focus-visible {
+  outline: 2px solid var(--focus-outlineColor);
   outline-offset: -2px;
   box-shadow: none;
 }
 
 .markdown-body a:not([class]):focus,
 .markdown-body a:not([class]):focus-visible,
-.markdown-body input[type=radio]:focus,
-.markdown-body input[type=radio]:focus-visible,
-.markdown-body input[type=checkbox]:focus,
-.markdown-body input[type=checkbox]:focus-visible {
+.markdown-body input[type='radio']:focus,
+.markdown-body input[type='radio']:focus-visible,
+.markdown-body input[type='checkbox']:focus,
+.markdown-body input[type='checkbox']:focus-visible {
   outline-offset: 0;
 }
 
 .markdown-body kbd {
-  display: inline-block;
-  padding: 3px 5px;
-  font: 11px ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
-  line-height: 10px;
-  color: var(--color-fg-default);
+  padding: var(--base-size-4);
+  font: 11px
+    var(
+      --fontStack-monospace,
+      ui-monospace,
+      SFMono-Regular,
+      SF Mono,
+      Menlo,
+      Consolas,
+      Liberation Mono,
+      monospace
+    );
+  color: var(--fgColor-default);
   vertical-align: middle;
-  background-color: var(--color-canvas-subtle);
-  border: solid 1px var(--color-neutral-muted);
-  border-bottom-color: var(--color-neutral-muted);
+  background-color: var(--bgColor-muted);
+  border: solid 1px var(--borderColor-neutral-muted);
+  border-bottom-color: var(--borderColor-neutral-muted);
+  box-shadow: inset 0 -1px 0 var(--borderColor-neutral-muted);
   border-radius: 6px;
-  box-shadow: inset 0 -1px 0 var(--color-neutral-muted);
+  max-width: 100%;
+  line-height: 10px;
+  display: inline-block;
 }
 
 .markdown-body h1,
@@ -387,17 +441,17 @@
 .markdown-body h4,
 .markdown-body h5,
 .markdown-body h6 {
-  margin-top: 24px;
-  margin-bottom: 16px;
+  margin-top: var(--base-size-24);
+  margin-bottom: var(--base-size-16);
   font-weight: var(--base-text-weight-semibold, 600);
   line-height: 1.25;
 }
 
 .markdown-body h2 {
   font-weight: var(--base-text-weight-semibold, 600);
-  padding-bottom: .3em;
+  border-bottom: 1px solid var(--borderColor-muted);
+  padding-bottom: 0.3em;
   font-size: 1.5em;
-  border-bottom: 1px solid var(--color-border-muted);
 }
 
 .markdown-body h3 {
@@ -412,13 +466,13 @@
 
 .markdown-body h5 {
   font-weight: var(--base-text-weight-semibold, 600);
-  font-size: .875em;
+  font-size: 0.875em;
 }
 
 .markdown-body h6 {
   font-weight: var(--base-text-weight-semibold, 600);
-  font-size: .85em;
-  color: var(--color-fg-muted);
+  color: var(--fgColor-muted);
+  font-size: 0.85em;
 }
 
 .markdown-body p {
@@ -426,11 +480,15 @@
   margin-bottom: 10px;
 }
 
+.markdown-body small {
+  font-size: 90%;
+}
+
 .markdown-body blockquote {
   margin: 0;
+  color: var(--fgColor-muted);
+  border-left: 0.25em solid var(--borderColor-default);
   padding: 0 1em;
-  color: var(--color-fg-muted);
-  border-left: .25em solid var(--color-border-default);
 }
 
 .markdown-body ul,
@@ -459,52 +517,154 @@
 .markdown-body tt,
 .markdown-body code,
 .markdown-body samp {
-  font-family: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+  font-family: var(
+    --fontStack-monospace,
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    Liberation Mono,
+    monospace
+  );
   font-size: 12px;
 }
 
 .markdown-body pre {
+  font-family: var(
+    --fontStack-monospace,
+    ui-monospace,
+    SFMono-Regular,
+    SF Mono,
+    Menlo,
+    Consolas,
+    Liberation Mono,
+    monospace
+  );
   margin-top: 0;
   margin-bottom: 0;
-  font-family: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
   font-size: 12px;
-  word-wrap: normal;
+  overflow-wrap: normal;
 }
 
 .markdown-body .octicon {
-  display: inline-block;
-  overflow: visible !important;
   vertical-align: text-bottom;
   fill: currentColor;
+  display: inline-block;
+  overflow: visible !important;
 }
 
-.markdown-body input::-webkit-outer-spin-button,
-.markdown-body input::-webkit-inner-spin-button {
+.markdown-body .Box-body.scrollable-overlay {
+  max-height: 400px;
+  overflow-y: scroll;
+}
+
+.markdown-body .Box-body .help {
+  padding-top: var(--base-size-8);
+  color: var(--fgColor-muted);
+  text-align: center;
   margin: 0;
-  -webkit-appearance: none;
+}
+
+.markdown-body input::-webkit-outer-spin-button {
   appearance: none;
+  margin: 0;
+}
+
+.markdown-body input::-webkit-inner-spin-button {
+  appearance: none;
+  margin: 0;
+}
+
+.markdown-body .border {
+  border: var(--borderWidth-thin, 1px) solid var(--borderColor-default) !important;
+}
+
+.markdown-body .border-0 {
+  border: 0 !important;
+}
+
+.markdown-body .circle {
+  border-radius: var(--borderRadius-full, 50%) !important;
+}
+
+.markdown-body .color-fg-muted {
+  color: var(--fgColor-muted) !important;
+}
+
+.markdown-body .color-bg-default {
+  background-color: var(--bgColor-default) !important;
+}
+
+.markdown-body .color-border-subtle {
+  border-color: var(--borderColor-muted) !important;
+}
+
+.markdown-body .mb-0 {
+  margin-bottom: 0 !important;
+}
+
+.markdown-body .ml-1 {
+  margin-left: var(--base-size-4, 4px) !important;
 }
 
 .markdown-body .mr-2 {
   margin-right: var(--base-size-8, 8px) !important;
 }
 
-.markdown-body::before {
-  display: table;
-  content: "";
+.markdown-body .my-2 {
+  margin-top: var(--base-size-8, 8px) !important;
+  margin-bottom: var(--base-size-8, 8px) !important;
 }
 
-.markdown-body::after {
+.markdown-body .p-0 {
+  padding: 0 !important;
+}
+
+.markdown-body .py-0 {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}
+
+.markdown-body .f6 {
+  font-size: var(--h6-size, 12px) !important;
+}
+
+.markdown-body .text-bold {
+  font-weight: var(--base-text-weight-semibold, 600) !important;
+}
+
+.markdown-body .d-inline-block {
+  display: inline-block !important;
+}
+
+.markdown-body .sr-only {
+  width: 1px;
+  height: 1px;
+  clip-path: rect(0 0 0 0);
+  overflow-wrap: normal;
+  border: 0;
+  padding: 0;
+  position: absolute;
+  overflow: hidden;
+}
+
+.markdown-body:before {
+  content: '';
   display: table;
+}
+
+.markdown-body:after {
   clear: both;
-  content: "";
+  content: '';
+  display: table;
 }
 
-.markdown-body>*:first-child {
+.markdown-body > :first-child {
   margin-top: 0 !important;
 }
 
-.markdown-body>*:last-child {
+.markdown-body > :last-child {
   margin-bottom: 0 !important;
 }
 
@@ -514,12 +674,12 @@
 }
 
 .markdown-body .absent {
-  color: var(--color-danger-fg);
+  color: var(--fgColor-danger);
 }
 
 .markdown-body .anchor {
   float: left;
-  padding-right: 4px;
+  padding-right: var(--base-size-4);
   margin-left: -20px;
   line-height: 1;
 }
@@ -537,14 +697,14 @@
 .markdown-body pre,
 .markdown-body details {
   margin-top: 0;
-  margin-bottom: 16px;
+  margin-bottom: var(--base-size-16);
 }
 
-.markdown-body blockquote>:first-child {
+.markdown-body blockquote > :first-child {
   margin-top: 0;
 }
 
-.markdown-body blockquote>:last-child {
+.markdown-body blockquote > :last-child {
   margin-bottom: 0;
 }
 
@@ -554,7 +714,7 @@
 .markdown-body h4 .octicon-link,
 .markdown-body h5 .octicon-link,
 .markdown-body h6 .octicon-link {
-  color: var(--color-fg-default);
+  color: var(--fgColor-default);
   vertical-align: middle;
   visibility: hidden;
 }
@@ -589,8 +749,8 @@
 .markdown-body h5 code,
 .markdown-body h6 tt,
 .markdown-body h6 code {
-  padding: 0 .2em;
   font-size: inherit;
+  padding: 0 0.2em;
 }
 
 .markdown-body summary h1,
@@ -613,8 +773,8 @@
 
 .markdown-body summary h1,
 .markdown-body summary h2 {
-  padding-bottom: 0;
   border-bottom: 0;
+  padding-bottom: 0;
 }
 
 .markdown-body ul.no-list,
@@ -623,27 +783,24 @@
   list-style-type: none;
 }
 
-.markdown-body ol[type="a s"] {
+.markdown-body ol[type='a\ s'] {
   list-style-type: lower-alpha;
 }
 
-.markdown-body ol[type="A s"] {
+.markdown-body ol[type='A\ s'] {
   list-style-type: upper-alpha;
 }
 
-.markdown-body ol[type="i s"] {
+.markdown-body ol[type='i\ s'] {
   list-style-type: lower-roman;
 }
 
-.markdown-body ol[type="I s"] {
+.markdown-body ol[type='I\ s'] {
   list-style-type: upper-roman;
 }
 
-.markdown-body ol[type="1"] {
-  list-style-type: decimal;
-}
-
-.markdown-body div>ol:not([type]) {
+.markdown-body ol[type='1'],
+.markdown-body div > ol:not([type]) {
   list-style-type: decimal;
 }
 
@@ -655,12 +812,12 @@
   margin-bottom: 0;
 }
 
-.markdown-body li>p {
-  margin-top: 16px;
+.markdown-body li > p {
+  margin-top: var(--base-size-16);
 }
 
-.markdown-body li+li {
-  margin-top: .25em;
+.markdown-body li + li {
+  margin-top: 0.25em;
 }
 
 .markdown-body dl {
@@ -668,16 +825,20 @@
 }
 
 .markdown-body dl dt {
-  padding: 0;
-  margin-top: 16px;
+  margin-top: var(--base-size-16);
   font-size: 1em;
   font-style: italic;
   font-weight: var(--base-text-weight-semibold, 600);
+  padding: 0;
+}
+
+.markdown-body dl dt + dt {
+  margin-top: 0;
 }
 
 .markdown-body dl dd {
-  padding: 0 16px;
-  margin-bottom: 16px;
+  padding: 0 var(--base-size-16);
+  margin-bottom: var(--base-size-16);
 }
 
 .markdown-body table th {
@@ -686,39 +847,39 @@
 
 .markdown-body table th,
 .markdown-body table td {
+  border: 1px solid var(--borderColor-default);
   padding: 6px 13px;
-  border: 1px solid var(--color-border-default);
 }
 
-.markdown-body table td>:last-child {
+.markdown-body table td > :last-child {
   margin-bottom: 0;
 }
 
 .markdown-body table tr {
-  background-color: var(--color-canvas-default);
-  border-top: 1px solid var(--color-border-muted);
+  background-color: var(--bgColor-default);
+  border-top: 1px solid var(--borderColor-muted);
 }
 
 .markdown-body table tr:nth-child(2n) {
-  background-color: var(--color-canvas-subtle);
+  background-color: var(--bgColor-muted);
 }
 
 .markdown-body table img {
-  background-color: transparent;
+  background-color: #0000;
 }
 
-.markdown-body img[align=right] {
+.markdown-body img[align='right'] {
   padding-left: 20px;
 }
 
-.markdown-body img[align=left] {
+.markdown-body img[align='left'] {
   padding-right: 20px;
 }
 
 .markdown-body .emoji {
-  max-width: none;
   vertical-align: text-top;
-  background-color: transparent;
+  background-color: #0000;
+  max-width: none;
 }
 
 .markdown-body span.frame {
@@ -726,68 +887,68 @@
   overflow: hidden;
 }
 
-.markdown-body span.frame>span {
-  display: block;
+.markdown-body span.frame > span {
   float: left;
+  border: 1px solid var(--borderColor-default);
   width: auto;
-  padding: 7px;
   margin: 13px 0 0;
+  padding: 7px;
+  display: block;
   overflow: hidden;
-  border: 1px solid var(--color-border-default);
 }
 
 .markdown-body span.frame span img {
-  display: block;
   float: left;
+  display: block;
 }
 
 .markdown-body span.frame span span {
-  display: block;
-  padding: 5px 0 0;
   clear: both;
-  color: var(--color-fg-default);
+  color: var(--fgColor-default);
+  padding: 5px 0 0;
+  display: block;
 }
 
 .markdown-body span.align-center {
+  clear: both;
   display: block;
   overflow: hidden;
-  clear: both;
 }
 
-.markdown-body span.align-center>span {
-  display: block;
-  margin: 13px auto 0;
-  overflow: hidden;
+.markdown-body span.align-center > span {
   text-align: center;
+  margin: 13px auto 0;
+  display: block;
+  overflow: hidden;
 }
 
 .markdown-body span.align-center span img {
-  margin: 0 auto;
   text-align: center;
+  margin: 0 auto;
 }
 
 .markdown-body span.align-right {
+  clear: both;
   display: block;
   overflow: hidden;
-  clear: both;
 }
 
-.markdown-body span.align-right>span {
-  display: block;
-  margin: 13px 0 0;
-  overflow: hidden;
+.markdown-body span.align-right > span {
   text-align: right;
+  margin: 13px 0 0;
+  display: block;
+  overflow: hidden;
 }
 
 .markdown-body span.align-right span img {
-  margin: 0;
   text-align: right;
+  margin: 0;
 }
 
 .markdown-body span.float-left {
-  display: block;
   float: left;
   margin-right: 13px;
+  display: block;
   overflow: hidden;
 }
 
@@ -796,27 +957,27 @@
 }
 
 .markdown-body span.float-right {
-  display: block;
   float: right;
   margin-left: 13px;
+  display: block;
   overflow: hidden;
 }
 
-.markdown-body span.float-right>span {
-  display: block;
-  margin: 13px auto 0;
-  overflow: hidden;
+.markdown-body span.float-right > span {
   text-align: right;
+  margin: 13px auto 0;
+  display: block;
+  overflow: hidden;
 }
 
 .markdown-body code,
 .markdown-body tt {
-  padding: .2em .4em;
-  margin: 0;
-  font-size: 85%;
   white-space: break-spaces;
-  background-color: var(--color-neutral-muted);
+  background-color: var(--bgColor-neutral-muted);
   border-radius: 6px;
+  margin: 0;
+  padding: 0.2em 0.4em;
+  font-size: 85%;
 }
 
 .markdown-body code br,
@@ -825,6 +986,7 @@
 }
 
 .markdown-body del code {
+  -webkit-text-decoration: inherit;
   text-decoration: inherit;
 }
 
@@ -836,62 +998,61 @@
   font-size: 100%;
 }
 
-.markdown-body pre>code {
-  padding: 0;
-  margin: 0;
+.markdown-body pre > code {
   word-break: normal;
   white-space: pre;
-  background: transparent;
+  background: 0 0;
   border: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .markdown-body .highlight {
-  margin-bottom: 16px;
+  margin-bottom: var(--base-size-16);
 }
 
 .markdown-body .highlight pre {
-  margin-bottom: 0;
   word-break: normal;
+  margin-bottom: 0;
 }
 
 .markdown-body .highlight pre,
 .markdown-body pre {
-  padding: 16px;
-  overflow: auto;
+  padding: var(--base-size-16);
+  color: var(--fgColor-default);
+  background-color: var(--bgColor-muted);
+  border-radius: 6px;
   font-size: 85%;
   line-height: 1.45;
-  color: var(--color-fg-default);
-  background-color: var(--color-canvas-subtle);
-  border-radius: 6px;
+  overflow: auto;
 }
 
 .markdown-body pre code,
 .markdown-body pre tt {
-  display: inline;
-  max-width: auto;
-  padding: 0;
-  margin: 0;
-  overflow: visible;
   line-height: inherit;
-  word-wrap: normal;
-  background-color: transparent;
+  overflow-wrap: normal;
+  background-color: #0000;
   border: 0;
+  margin: 0;
+  padding: 0;
+  display: inline;
+  overflow: visible;
 }
 
 .markdown-body .csv-data td,
 .markdown-body .csv-data th {
-  padding: 5px;
-  overflow: hidden;
-  font-size: 12px;
-  line-height: 1;
   text-align: left;
   white-space: nowrap;
+  padding: 5px;
+  font-size: 12px;
+  line-height: 1;
+  overflow: hidden;
 }
 
 .markdown-body .csv-data .blob-num {
-  padding: 10px 8px 9px;
+  padding: 10px var(--base-size-8) 9px;
   text-align: right;
-  background: var(--color-canvas-default);
+  background: var(--bgColor-default);
   border: 0;
 }
 
@@ -901,56 +1062,116 @@
 
 .markdown-body .csv-data th {
   font-weight: var(--base-text-weight-semibold, 600);
-  background: var(--color-canvas-subtle);
+  background: var(--bgColor-muted);
   border-top: 0;
 }
 
-.markdown-body [data-footnote-ref]::before {
-  content: "[";
+.markdown-body [data-footnote-ref]:before {
+  content: '[';
 }
 
-.markdown-body [data-footnote-ref]::after {
-  content: "]";
+.markdown-body [data-footnote-ref]:after {
+  content: ']';
 }
 
 .markdown-body .footnotes {
+  color: var(--fgColor-muted);
+  border-top: 1px solid var(--borderColor-default);
   font-size: 12px;
-  color: var(--color-fg-muted);
-  border-top: 1px solid var(--color-border-default);
 }
 
 .markdown-body .footnotes ol {
-  padding-left: 16px;
+  padding-left: var(--base-size-16);
 }
 
 .markdown-body .footnotes ol ul {
+  padding-left: var(--base-size-16);
+  margin-top: var(--base-size-16);
   display: inline-block;
-  padding-left: 16px;
-  margin-top: 16px;
 }
 
 .markdown-body .footnotes li {
   position: relative;
 }
 
-.markdown-body .footnotes li:target::before {
-  position: absolute;
-  top: -8px;
-  right: -8px;
-  bottom: -8px;
-  left: -24px;
+.markdown-body .footnotes li:target:before {
+  top: calc(var(--base-size-8) * -1);
+  right: calc(var(--base-size-8) * -1);
+  bottom: calc(var(--base-size-8) * -1);
+  left: calc(var(--base-size-24) * -1);
   pointer-events: none;
-  content: "";
-  border: 2px solid var(--color-accent-emphasis);
+  content: '';
+  border: 2px solid var(--borderColor-accent-emphasis);
   border-radius: 6px;
+  position: absolute;
 }
 
 .markdown-body .footnotes li:target {
-  color: var(--color-fg-default);
+  color: var(--fgColor-default);
 }
 
 .markdown-body .footnotes .data-footnote-backref g-emoji {
   font-family: monospace;
+}
+
+.markdown-body :is() {
+  content: '';
+  width: 100%;
+  height: 100%;
+  min-height: 48px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%) translateY(-50%);
+}
+
+.markdown-body .Box {
+  background-color: var(--bgColor-default);
+  border-color: var(--borderColor-default);
+  border-radius: var(--borderRadius-medium);
+  border-style: solid;
+  border-width: var(--borderWidth-thin);
+}
+
+.markdown-body .Box--condensed {
+  line-height: 1.25;
+}
+
+.markdown-body .Box--condensed .Box-body,
+.markdown-body .Box--condensed .Box-footer,
+.markdown-body .Box--condensed .Box-header {
+  padding: var(--stack-padding-condensed) var(--stack-padding-normal);
+}
+
+.markdown-body .Box--condensed .Box-row {
+  padding: var(--stack-padding-condensed) var(--stack-padding-normal);
+}
+
+.markdown-body .Box-header {
+  background-color: var(--bgColor-muted);
+  border-color: var(--borderColor-default);
+  border-top-left-radius: var(--borderRadius-medium);
+  border-top-right-radius: var(--borderRadius-medium);
+  border-style: solid;
+  border-width: var(--borderWidth-thin);
+  margin: calc(var(--borderWidth-thin) * -1) calc(var(--borderWidth-thin) * -1) 0;
+  padding: var(--stack-padding-normal);
+}
+
+.markdown-body .Box-body {
+  border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
+  padding: var(--stack-padding-normal);
+}
+
+.markdown-body .Box-body:last-of-type {
+  border-bottom-left-radius: var(--borderRadius-medium);
+  border-bottom-right-radius: var(--borderRadius-medium);
+  margin-bottom: calc(var(--borderWidth-thin) * -1);
+}
+
+.markdown-body .tmp-px-3 {
+  padding-right: var(--base-size-16, 16px) !important;
+  padding-left: var(--base-size-16, 16px) !important;
 }
 
 .markdown-body .pl-c {
@@ -1010,8 +1231,8 @@
 }
 
 .markdown-body .pl-sr .pl-cce {
-  font-weight: bold;
   color: var(--color-prettylights-syntax-string-regexp);
+  font-weight: 700;
 }
 
 .markdown-body .pl-ml {
@@ -1021,18 +1242,18 @@
 .markdown-body .pl-mh,
 .markdown-body .pl-mh .pl-en,
 .markdown-body .pl-ms {
-  font-weight: bold;
   color: var(--color-prettylights-syntax-markup-heading);
+  font-weight: 700;
 }
 
 .markdown-body .pl-mi {
-  font-style: italic;
   color: var(--color-prettylights-syntax-markup-italic);
+  font-style: italic;
 }
 
 .markdown-body .pl-mb {
-  font-weight: bold;
   color: var(--color-prettylights-syntax-markup-bold);
+  font-weight: 700;
 }
 
 .markdown-body .pl-md {
@@ -1056,8 +1277,8 @@
 }
 
 .markdown-body .pl-mdr {
-  font-weight: bold;
   color: var(--color-prettylights-syntax-meta-diff-range);
+  font-weight: 700;
 }
 
 .markdown-body .pl-ba {
@@ -1069,19 +1290,36 @@
 }
 
 .markdown-body .pl-corl {
-  text-decoration: underline;
   color: var(--color-prettylights-syntax-constant-other-reference-link);
+  text-decoration: underline;
+}
+
+.markdown-body [role='button']:focus:not(:focus-visible),
+.markdown-body [role='tabpanel'][tabindex='0']:focus:not(:focus-visible),
+.markdown-body button:focus:not(:focus-visible),
+.markdown-body summary:focus:not(:focus-visible),
+.markdown-body a:focus:not(:focus-visible) {
+  box-shadow: none;
+  outline: none;
+}
+
+.markdown-body [tabindex='0']:focus:not(:focus-visible),
+.markdown-body details-dialog:focus:not(:focus-visible) {
+  outline: none;
 }
 
 .markdown-body g-emoji {
-  display: inline-block;
   min-width: 1ch;
-  font-family: "Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
-  font-size: 1em;
-  font-style: normal !important;
-  font-weight: var(--base-text-weight-normal, 400);
-  line-height: 1;
+  font-family:
+    Apple Color Emoji,
+    Segoe UI Emoji,
+    Segoe UI Symbol;
+  font-weight: var(--base-text-weight-normal);
   vertical-align: -0.075em;
+  line-height: 1;
+  display: inline-block;
+  font-style: normal !important;
+  font-size: 1.25em;
 }
 
 .markdown-body g-emoji img {
@@ -1089,20 +1327,133 @@
   height: 1em;
 }
 
+.markdown-body .commit-tease-sha {
+  font-family: var(--fontStack-monospace);
+  color: var(--fgColor-default);
+  font-size: 90%;
+  display: inline-block;
+}
+
+.markdown-body .blob-wrapper {
+  overflow: auto hidden;
+}
+
+.markdown-body .blob-wrapper table tr:nth-child(2n) {
+  background-color: #0000;
+}
+
+.markdown-body .blob-wrapper-embedded {
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.markdown-body .blob-num {
+  width: 1%;
+  min-width: 50px;
+  font-family: var(--fontStack-monospace);
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-muted);
+  text-align: right;
+  white-space: nowrap;
+  vertical-align: top;
+  cursor: pointer;
+  -webkit-user-select: none;
+  user-select: none;
+  padding-left: 10px;
+  padding-right: 10px;
+  line-height: 20px;
+  position: relative;
+}
+
+.markdown-body .blob-num:hover {
+  color: var(--fgColor-default);
+}
+
+.markdown-body .blob-num:before {
+  content: attr(data-line-number);
+}
+
+.markdown-body .blob-num.non-expandable {
+  cursor: default;
+}
+
+.markdown-body .blob-num.non-expandable:hover {
+  color: var(--fgColor-muted);
+}
+
+.markdown-body .blob-code {
+  vertical-align: top;
+  padding-left: 10px;
+  padding-right: 10px;
+  line-height: 20px;
+  position: relative;
+}
+
+.markdown-body .blob-code-inner {
+  font-family: var(--fontStack-monospace);
+  font-size: var(--text-body-size-small);
+  color: var(--fgColor-default);
+  overflow-wrap: anywhere;
+  white-space: pre;
+  display: table-cell;
+  overflow: visible;
+}
+
+.markdown-body .blob-code-inner .x-first {
+  border-top-left-radius: 0.2em;
+  border-bottom-left-radius: 0.2em;
+}
+
+.markdown-body .blob-code-inner .x-last {
+  border-top-right-radius: 0.2em;
+  border-bottom-right-radius: 0.2em;
+}
+
+.markdown-body .blob-code-inner.highlighted,
+.markdown-body .blob-code-inner .highlighted {
+  background-color: var(--bgColor-attention-muted);
+  box-shadow: inset 2px 0 0 var(--borderColor-attention-muted);
+}
+
+.markdown-body .blob-code-inner::selection,
+.markdown-body .blob-code-inner ::selection {
+  background-color: var(--selection-bgColor);
+}
+
+.markdown-body .blob-code-inner.blob-code-addition,
+.markdown-body .blob-code-inner.blob-code-deletion {
+  position: relative;
+  padding-left: 22px !important;
+}
+
+.markdown-body a:has(> p, > div, > pre, > blockquote) {
+  display: block;
+}
+
+.markdown-body a:has(> p, > div, > pre, > blockquote):not(:has(.snippet-clipboard-content, > pre)) {
+  width: fit-content;
+}
+
+.markdown-body
+  a:has(> p, > div, > pre, > blockquote):has(.snippet-clipboard-content, > pre):focus-visible {
+  outline: 2px solid var(--focus-outlineColor);
+  outline-offset: 2px;
+}
+
 .markdown-body .task-list-item {
   list-style-type: none;
 }
 
 .markdown-body .task-list-item label {
-  font-weight: var(--base-text-weight-normal, 400);
+  font-weight: var(--base-text-weight-normal);
 }
 
 .markdown-body .task-list-item.enabled label {
   cursor: pointer;
 }
 
-.markdown-body .task-list-item+.task-list-item {
-  margin-top: 4px;
+.markdown-body .task-list-item + .task-list-item {
+  margin-top: var(--base-size-4);
 }
 
 .markdown-body .task-list-item .handle {
@@ -1110,25 +1461,66 @@
 }
 
 .markdown-body .task-list-item-checkbox {
-  margin: 0 .2em .25em -1.4em;
   vertical-align: middle;
+  margin: 0 0.2em 0.25em -1.4em;
 }
 
-.markdown-body .contains-task-list:dir(rtl) .task-list-item-checkbox {
-  margin: 0 -1.6em .25em .2em;
-}
-
-.markdown-body .contains-task-list {
-  position: relative;
+.markdown-body
+  ul:is(
+    :lang(ae),
+    :lang(ar),
+    :lang(arc),
+    :lang(bcc),
+    :lang(bqi),
+    :lang(ckb),
+    :lang(dv),
+    :lang(fa),
+    :lang(glk),
+    :lang(he),
+    :lang(ku),
+    :lang(mzn),
+    :lang(nqo),
+    :lang(pnb),
+    :lang(ps),
+    :lang(sd),
+    :lang(ug),
+    :lang(ur),
+    :lang(yi)
+  )
+  .task-list-item-checkbox,
+.markdown-body
+  ol:is(
+    :lang(ae),
+    :lang(ar),
+    :lang(arc),
+    :lang(bcc),
+    :lang(bqi),
+    :lang(ckb),
+    :lang(dv),
+    :lang(fa),
+    :lang(glk),
+    :lang(he),
+    :lang(ku),
+    :lang(mzn),
+    :lang(nqo),
+    :lang(pnb),
+    :lang(ps),
+    :lang(sd),
+    :lang(ug),
+    :lang(ur),
+    :lang(yi)
+  )
+  .task-list-item-checkbox {
+  margin: 0 -1.6em 0.25em 0.2em;
 }
 
 .markdown-body .contains-task-list:hover .task-list-item-convert-container,
 .markdown-body .contains-task-list:focus-within .task-list-item-convert-container {
-  display: block;
   width: auto;
-  height: 24px;
+  height: var(--base-size-24);
+  clip-path: none;
+  display: block;
   overflow: visible;
-  clip: auto;
 }
 
 .markdown-body ::-webkit-calendar-picker-indicator {
@@ -1137,62 +1529,126 @@
 
 .markdown-body .markdown-alert {
   padding: var(--base-size-8) var(--base-size-16);
-  margin-bottom: 16px;
+  margin-bottom: var(--base-size-16);
   color: inherit;
-  border-left: .25em solid var(--color-border-default);
+  border-left: 0.25em solid var(--borderColor-default);
 }
 
-.markdown-body .markdown-alert>:first-child {
+.markdown-body .markdown-alert > :first-child {
   margin-top: 0;
 }
 
-.markdown-body .markdown-alert>:last-child {
+.markdown-body .markdown-alert > :last-child {
   margin-bottom: 0;
 }
 
 .markdown-body .markdown-alert .markdown-alert-title {
-  display: flex;
   font-weight: var(--base-text-weight-medium, 500);
   align-items: center;
   line-height: 1;
+  display: flex;
 }
 
 .markdown-body .markdown-alert.markdown-alert-note {
-  border-left-color: var(--color-accent-emphasis);
+  border-left-color: var(--borderColor-accent-emphasis);
 }
 
 .markdown-body .markdown-alert.markdown-alert-note .markdown-alert-title {
-  color: var(--color-accent-fg);
+  color: var(--fgColor-accent);
 }
 
 .markdown-body .markdown-alert.markdown-alert-important {
-  border-left-color: var(--color-done-emphasis);
+  border-left-color: var(--borderColor-done-emphasis);
 }
 
 .markdown-body .markdown-alert.markdown-alert-important .markdown-alert-title {
-  color: var(--color-done-fg);
+  color: var(--fgColor-done);
 }
 
 .markdown-body .markdown-alert.markdown-alert-warning {
-  border-left-color: var(--color-attention-emphasis);
+  border-left-color: var(--borderColor-attention-emphasis);
 }
 
 .markdown-body .markdown-alert.markdown-alert-warning .markdown-alert-title {
-  color: var(--color-attention-fg);
+  color: var(--fgColor-attention);
 }
 
 .markdown-body .markdown-alert.markdown-alert-tip {
-  border-left-color: var(--color-success-emphasis);
+  border-left-color: var(--borderColor-success-emphasis);
 }
 
 .markdown-body .markdown-alert.markdown-alert-tip .markdown-alert-title {
-  color: var(--color-success-fg);
+  color: var(--fgColor-success);
 }
 
 .markdown-body .markdown-alert.markdown-alert-caution {
-  border-left-color: var(--color-danger-emphasis);
+  border-left-color: var(--borderColor-danger-emphasis);
 }
 
 .markdown-body .markdown-alert.markdown-alert-caution .markdown-alert-title {
-  color: var(--color-danger-fg);
+  color: var(--fgColor-danger);
+}
+
+.markdown-body > :first-child > .heading-element:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body .tab-size[data-tab-size='1'] {
+  tab-size: 1;
+}
+
+.markdown-body .tab-size[data-tab-size='2'] {
+  tab-size: 2;
+}
+
+.markdown-body .tab-size[data-tab-size='3'] {
+  tab-size: 3;
+}
+
+.markdown-body .tab-size[data-tab-size='4'] {
+  tab-size: 4;
+}
+
+.markdown-body .tab-size[data-tab-size='5'] {
+  tab-size: 5;
+}
+
+.markdown-body .tab-size[data-tab-size='6'] {
+  tab-size: 6;
+}
+
+.markdown-body .tab-size[data-tab-size='7'] {
+  tab-size: 7;
+}
+
+.markdown-body .tab-size[data-tab-size='8'] {
+  tab-size: 8;
+}
+
+.markdown-body .tab-size[data-tab-size='9'] {
+  tab-size: 9;
+}
+
+.markdown-body .tab-size[data-tab-size='10'] {
+  tab-size: 10;
+}
+
+.markdown-body .tab-size[data-tab-size='11'] {
+  tab-size: 11;
+}
+
+.markdown-body .tab-size[data-tab-size='12'] {
+  tab-size: 12;
+}
+
+.markdown-body .Box .section-focus .preview-section {
+  display: none;
+}
+
+.markdown-body .Box .section-focus .edit-section {
+  display: block;
+}
+
+.markdown-body .highlight pre:has(+ .zeroclipboard-container) {
+  min-height: 52px;
 }

--- a/packages/ui-components/src/components/Readme/hljs-github-dark.css
+++ b/packages/ui-components/src/components/Readme/hljs-github-dark.css
@@ -1,0 +1,117 @@
+[data-theme='dark'] pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+[data-theme='dark'] code.hljs {
+  padding: 3px 5px;
+}
+/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/
+[data-theme='dark'] .hljs {
+  color: #c9d1d9;
+  background: #0d1117;
+}
+[data-theme='dark'] .hljs-doctag,
+[data-theme='dark'] .hljs-keyword,
+[data-theme='dark'] .hljs-meta .hljs-keyword,
+[data-theme='dark'] .hljs-template-tag,
+[data-theme='dark'] .hljs-template-variable,
+[data-theme='dark'] .hljs-type,
+[data-theme='dark'] .hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #ff7b72;
+}
+[data-theme='dark'] .hljs-title,
+[data-theme='dark'] .hljs-title.class_,
+[data-theme='dark'] .hljs-title.class_.inherited__,
+[data-theme='dark'] .hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #d2a8ff;
+}
+[data-theme='dark'] .hljs-attr,
+[data-theme='dark'] .hljs-attribute,
+[data-theme='dark'] .hljs-literal,
+[data-theme='dark'] .hljs-meta,
+[data-theme='dark'] .hljs-number,
+[data-theme='dark'] .hljs-operator,
+[data-theme='dark'] .hljs-variable,
+[data-theme='dark'] .hljs-selector-attr,
+[data-theme='dark'] .hljs-selector-class,
+[data-theme='dark'] .hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #79c0ff;
+}
+[data-theme='dark'] .hljs-regexp,
+[data-theme='dark'] .hljs-string,
+[data-theme='dark'] .hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #a5d6ff;
+}
+[data-theme='dark'] .hljs-built_in,
+[data-theme='dark'] .hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #ffa657;
+}
+[data-theme='dark'] .hljs-comment,
+[data-theme='dark'] .hljs-code,
+[data-theme='dark'] .hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #8b949e;
+}
+[data-theme='dark'] .hljs-name,
+[data-theme='dark'] .hljs-quote,
+[data-theme='dark'] .hljs-selector-tag,
+[data-theme='dark'] .hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #7ee787;
+}
+[data-theme='dark'] .hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #c9d1d9;
+}
+[data-theme='dark'] .hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #1f6feb;
+  font-weight: bold;
+}
+[data-theme='dark'] .hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #f2cc60;
+}
+[data-theme='dark'] .hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #c9d1d9;
+  font-style: italic;
+}
+[data-theme='dark'] .hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #c9d1d9;
+  font-weight: bold;
+}
+[data-theme='dark'] .hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #aff5b4;
+  background-color: #033a16;
+}
+[data-theme='dark'] .hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+[data-theme='dark'] .hljs-char.escape_,
+[data-theme='dark'] .hljs-link,
+[data-theme='dark'] .hljs-params,
+[data-theme='dark'] .hljs-property,
+[data-theme='dark'] .hljs-punctuation,
+[data-theme='dark'] .hljs-tag {
+  /* purposely ignored */
+}

--- a/packages/ui-components/src/components/Readme/hljs-github-light.css
+++ b/packages/ui-components/src/components/Readme/hljs-github-light.css
@@ -1,0 +1,117 @@
+[data-theme='light'] pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+[data-theme='light'] code.hljs {
+  padding: 3px 5px;
+}
+/*!
+  Theme: GitHub
+  Description: Light theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+
+  Outdated base version: https://github.com/primer/github-syntax-light
+  Current colors taken from GitHub's CSS
+*/
+[data-theme='light'] .hljs {
+  color: #24292e;
+  background: #ffffff;
+}
+[data-theme='light'] .hljs-doctag,
+[data-theme='light'] .hljs-keyword,
+[data-theme='light'] .hljs-meta .hljs-keyword,
+[data-theme='light'] .hljs-template-tag,
+[data-theme='light'] .hljs-template-variable,
+[data-theme='light'] .hljs-type,
+[data-theme='light'] .hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #d73a49;
+}
+[data-theme='light'] .hljs-title,
+[data-theme='light'] .hljs-title.class_,
+[data-theme='light'] .hljs-title.class_.inherited__,
+[data-theme='light'] .hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #6f42c1;
+}
+[data-theme='light'] .hljs-attr,
+[data-theme='light'] .hljs-attribute,
+[data-theme='light'] .hljs-literal,
+[data-theme='light'] .hljs-meta,
+[data-theme='light'] .hljs-number,
+[data-theme='light'] .hljs-operator,
+[data-theme='light'] .hljs-variable,
+[data-theme='light'] .hljs-selector-attr,
+[data-theme='light'] .hljs-selector-class,
+[data-theme='light'] .hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #0064d6;
+}
+[data-theme='light'] .hljs-regexp,
+[data-theme='light'] .hljs-string,
+[data-theme='light'] .hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #032f62;
+}
+[data-theme='light'] .hljs-built_in,
+[data-theme='light'] .hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #e36209;
+}
+[data-theme='light'] .hljs-comment,
+[data-theme='light'] .hljs-code,
+[data-theme='light'] .hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #6a737d;
+}
+[data-theme='light'] .hljs-name,
+[data-theme='light'] .hljs-quote,
+[data-theme='light'] .hljs-selector-tag,
+[data-theme='light'] .hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #22863a;
+}
+[data-theme='light'] .hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #24292e;
+}
+[data-theme='light'] .hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #005cc5;
+  font-weight: bold;
+}
+[data-theme='light'] .hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #735c0f;
+}
+[data-theme='light'] .hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #24292e;
+  font-style: italic;
+}
+[data-theme='light'] .hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #24292e;
+  font-weight: bold;
+}
+[data-theme='light'] .hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #22863a;
+  background-color: #f0fff4;
+}
+[data-theme='light'] .hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #b31d28;
+  background-color: #ffeef0;
+}
+[data-theme='light'] .hljs-char.escape_,
+[data-theme='light'] .hljs-link,
+[data-theme='light'] .hljs-params,
+[data-theme='light'] .hljs-property,
+[data-theme='light'] .hljs-punctuation,
+[data-theme='light'] .hljs-tag {
+  /* purposely ignored */
+}

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -45,11 +45,6 @@ export { default as Success } from './sections/Security/Success';
 export { default as AddUser } from './sections/Security/AddUser';
 export { default as ChangePassword } from './sections/Security/ChangePassword';
 
-// pages
-export { default as FrontPage } from './pages/Front';
-export { default as VersionPage } from './pages/Version';
-export * from './pages/Security';
-
 // layout
 export { VersionLayout } from './layouts/Version';
 

--- a/packages/ui-components/src/sections/Security/AddUser.tsx
+++ b/packages/ui-components/src/sections/Security/AddUser.tsx
@@ -99,7 +99,7 @@ const AddUser: React.FC = () => {
   return createUserEnabled ? (
     <SecurityLayout>
       <SecurityContainer>
-        <SecurityForm component="form" onSubmit={handleSubmit(onSubmit)}>
+        <SecurityForm onSubmit={handleSubmit(onSubmit)}>
           <Typography align="center" component="h1" gutterBottom={true} variant="h4">
             {t('security.addUser.title')}
           </Typography>

--- a/packages/ui-components/src/sections/Security/ChangePassword.tsx
+++ b/packages/ui-components/src/sections/Security/ChangePassword.tsx
@@ -85,7 +85,7 @@ const ChangePassword: React.FC = () => {
   return changePasswordEnabled ? (
     <SecurityLayout>
       <SecurityContainer>
-        <SecurityForm component="form" onSubmit={handleSubmit(onSubmit)}>
+        <SecurityForm onSubmit={handleSubmit(onSubmit)}>
           <Typography align="center" component="h1" gutterBottom={true} variant="h4">
             {t('security.changePassword.title')}
           </Typography>

--- a/packages/ui-components/src/sections/Security/styles.ts
+++ b/packages/ui-components/src/sections/Security/styles.ts
@@ -11,7 +11,7 @@ export const SecurityContainer = styled(Box)(({ theme }) => ({
   backgroundColor: theme.palette.background.default,
 }));
 
-export const SecurityForm = styled(Box)(({ theme }) => ({
+export const SecurityForm = styled('form')(({ theme }) => ({
   width: '100%',
   maxWidth: 420,
   padding: theme.spacing(4),

--- a/packages/ui-components/tools/vite-plugins.mjs
+++ b/packages/ui-components/tools/vite-plugins.mjs
@@ -1,0 +1,48 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Inlines SVG files as base64 data URIs.
+ */
+export function svgInlinePlugin() {
+    return {
+        name: 'svg-inline',
+        enforce: 'pre',
+        load(id) {
+            if (!id.endsWith('.svg')) return;
+            const svg = fs.readFileSync(id);
+            const base64 = svg.toString('base64');
+            return { code: `export default "data:image/svg+xml;base64,${base64}"`, map: null };
+        },
+    };
+}
+
+/**
+ * Library mode extracts CSS to ui-components.css but leaves empty CSS stubs in
+ * preserved modules without wiring the entry to the emitted asset. Downstream
+ * bundlers (e.g. ui-theme) then never include those styles. Prepend a side-effect
+ * import/require on the package entry so the CSS is part of the public graph.
+ */
+export function linkEntryCssPlugin() {
+    return {
+        name: 'link-entry-css',
+        enforce: 'post',
+        generateBundle(_options, bundle) {
+            const cssNames = Object.keys(bundle).filter(
+                (name) => bundle[name].type === 'asset' && name.endsWith('.css')
+            );
+            if (cssNames.length === 0) return;
+            const cssName = path.basename(cssNames[0]);
+            for (const [fileName, chunk] of Object.entries(bundle)) {
+                if (chunk.type !== 'chunk' || !chunk.code) continue;
+                if (fileName === 'index.mjs') {
+                    chunk.code = `import './${cssName}';\n${chunk.code}`;
+                } else if (fileName === 'index.js') {
+                    const lines = chunk.code.split('\n');
+                    lines.splice(1, 0, `require('./${cssName}');`);
+                    chunk.code = lines.join('\n');
+                }
+            }
+        },
+    };
+}

--- a/packages/ui-components/tsconfig.build.json
+++ b/packages/ui-components/tsconfig.build.json
@@ -14,7 +14,7 @@
     "types": ["node", "@testing-library/jest-dom"]
   },
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.stories.tsx", "src/**/*.test.tsx", "src/**/*.test.ts"],
+  "exclude": ["src/**/*.stories.tsx", "src/**/*.test.tsx", "src/**/*.test.ts", "src/test/**"],
   "typedocOptions": {
     "categoryOrder": ["Model", "Component", "Provider", "*"],
     "defaultCategory": "Component",

--- a/packages/ui-components/vite.config.mjs
+++ b/packages/ui-components/vite.config.mjs
@@ -1,62 +1,19 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-import pkg from './package.json' with { type: 'json' };
+import { createLibConfig } from '../../vite.lib.config.mjs';
+import { svgInlinePlugin, linkEntryCssPlugin } from './tools/vite-plugins.mjs';
 
-/**
- * Inlines SVG files as base64 data URIs.
- */
-function svgInlinePlugin() {
-  return {
-    name: 'svg-inline',
-    enforce: 'pre',
-    load(id) {
-      if (!id.endsWith('.svg')) return;
-      const svg = fs.readFileSync(id);
-      const base64 = svg.toString('base64');
-      return { code: `export default "data:image/svg+xml;base64,${base64}"`, map: null };
-    },
-  };
-}
-
-// Externalize all listed dependencies so they are not bundled.
-const externalDeps = new Set([
-  ...Object.keys(pkg.dependencies ?? {}),
-  'react/jsx-runtime',
-  'react/jsx-dev-runtime',
-]);
+const baseConfig = createLibConfig(import.meta.dirname,
+  { bundleDeps: ['react/jsx-runtime', 'react/jsx-dev-runtime'] }
+);
 
 export default defineConfig({
-  plugins: [svgInlinePlugin(), react()],
-
-  build: {
-    outDir: 'build',
-    emptyOutDir: true,
-    sourcemap: true,
-    minify: false,
-    lib: {
-      entry: path.resolve(__dirname, 'src/index.ts'),
-    },
-    rolldownOptions: {
-      external: (id) =>
-        externalDeps.has(id) || [...externalDeps].some((dep) => id.startsWith(`${dep}/`)),
-      output: [
-        {
-          format: 'es',
-          preserveModules: true,
-          preserveModulesRoot: 'src',
-          entryFileNames: '[name].mjs',
-        },
-        {
-          format: 'cjs',
-          preserveModules: true,
-          preserveModulesRoot: 'src',
-          entryFileNames: '[name].js',
-        },
-      ],
-    },
-  },
+  ...baseConfig,
+  plugins: [
+    react(),
+    svgInlinePlugin(),
+    linkEntryCssPlugin(),
+    ...baseConfig.plugins,
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ importers:
         version: 10.1.0
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       eslint:
         specifier: 10.0.3
         version: 10.0.3
@@ -265,7 +265,7 @@ importers:
         version: 15.10.0
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       get-port:
         specifier: 5.1.1
         version: 5.1.1
@@ -295,7 +295,7 @@ importers:
         version: link:../store
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -341,7 +341,7 @@ importers:
         version: link:../signature
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -415,7 +415,7 @@ importers:
         version: link:../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
@@ -492,7 +492,7 @@ importers:
         version: link:../url
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       gunzip-maybe:
         specifier: 1.4.2
         version: 1.4.2
@@ -526,7 +526,7 @@ importers:
         version: link:../core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       validator:
         specifier: 13.15.26
         version: 13.15.26
@@ -548,7 +548,7 @@ importers:
         version: link:../logger
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       got-cjs:
         specifier: 12.5.4
         version: 12.5.4
@@ -579,7 +579,7 @@ importers:
         version: link:../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -619,7 +619,7 @@ importers:
         version: 1.11.20
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       on-exit-leak-free:
         specifier: 2.1.2
         version: 2.1.2
@@ -653,7 +653,7 @@ importers:
         version: link:../core/url
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -696,7 +696,7 @@ importers:
         version: link:../logger
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -761,7 +761,7 @@ importers:
         version: link:../../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
     devDependencies:
       '@types/debug':
         specifier: 4.1.12
@@ -792,7 +792,7 @@ importers:
         version: 2.4.3
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       http-errors:
         specifier: 2.0.1
         version: 2.0.1
@@ -829,7 +829,7 @@ importers:
         version: link:../../core/file-locking
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       globby:
         specifier: 11.1.0
         version: 11.1.0
@@ -863,7 +863,7 @@ importers:
         version: link:../../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       memfs:
         specifier: 4.17.2
         version: 4.17.2
@@ -891,7 +891,7 @@ importers:
         version: link:../../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       semver:
         specifier: 7.7.4
         version: 7.7.4
@@ -994,7 +994,7 @@ importers:
         version: 1.3.5
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       got:
         specifier: 14.6.6
         version: 14.6.6
@@ -1040,7 +1040,7 @@ importers:
         version: link:../proxy
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -1065,7 +1065,7 @@ importers:
         version: 1.2.11
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
     devDependencies:
       '@verdaccio/types':
         specifier: workspace:14.0.0-next-9.4
@@ -1111,7 +1111,7 @@ importers:
         version: 2.8.5
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -1145,7 +1145,7 @@ importers:
         version: link:../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -1188,7 +1188,7 @@ importers:
         version: link:../core/url
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -1237,7 +1237,7 @@ importers:
         version: link:../../middleware
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -1286,7 +1286,7 @@ importers:
         version: 4.0.0-rc.4(typanion@3.14.0)
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
     devDependencies:
       '@verdaccio/config':
         specifier: workspace:9.0.0-next-9.8
@@ -1320,6 +1320,9 @@ importers:
       '@mui/material':
         specifier: 7.3.9
         version: 7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@mui/system':
+        specifier: 7.3.9
+        version: 7.3.9(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
       '@verdaccio/ui-i18n':
         specifier: workspace:10.0.0-next-9.2
         version: link:../core/i18n
@@ -1329,6 +1332,9 @@ importers:
       dayjs:
         specifier: 1.11.20
         version: 1.11.20
+      debug:
+        specifier: 4.4.3
+        version: 4.4.3(supports-color@8.1.1)
       dompurify:
         specifier: 3.3.3
         version: 3.3.3
@@ -1479,7 +1485,7 @@ importers:
         version: link:../plugins/ui-theme
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       verdaccio-audit:
         specifier: workspace:14.0.0-next-9.8
         version: link:../plugins/audit
@@ -1555,7 +1561,7 @@ importers:
         version: link:../core/tarball
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -8377,7 +8383,7 @@ snapshots:
       '@babel/types': 7.28.4
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8477,7 +8483,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8489,7 +8495,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9060,7 +9066,7 @@ snapshots:
   '@eslint/config-array@0.23.3':
     dependencies:
       '@eslint/object-schema': 3.0.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
@@ -10210,7 +10216,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.0.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10220,7 +10226,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -10239,7 +10245,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.0(eslint@10.0.3)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.0.3
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -10256,7 +10262,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/visitor-keys': 8.57.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -10984,7 +10990,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       on-finished: 2.4.1
@@ -11936,7 +11942,7 @@ snapshots:
 
   eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.57.0(eslint@10.0.3)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@10.0.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3))(eslint@10.0.3):
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.0.3
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.13.6
@@ -11970,7 +11976,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.46.2
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.0.3
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
@@ -12127,7 +12133,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -12228,7 +12234,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -12323,7 +12329,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -12730,7 +12736,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12762,7 +12768,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13797,7 +13803,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -13974,7 +13980,7 @@ snapshots:
 
   nock@13.5.6:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -14747,7 +14753,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -14854,7 +14860,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -15203,7 +15209,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.4
       formidable: 3.5.4
@@ -15749,7 +15755,7 @@ snapshots:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,7 +154,7 @@ importers:
         version: 10.1.0
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       eslint:
         specifier: 10.0.3
         version: 10.0.3
@@ -265,7 +265,7 @@ importers:
         version: 15.10.0
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       get-port:
         specifier: 5.1.1
         version: 5.1.1
@@ -295,7 +295,7 @@ importers:
         version: link:../store
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -341,7 +341,7 @@ importers:
         version: link:../signature
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -415,7 +415,7 @@ importers:
         version: link:../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       js-yaml:
         specifier: 4.1.1
         version: 4.1.1
@@ -492,7 +492,7 @@ importers:
         version: link:../url
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       gunzip-maybe:
         specifier: 1.4.2
         version: 1.4.2
@@ -526,7 +526,7 @@ importers:
         version: link:../core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       validator:
         specifier: 13.15.26
         version: 13.15.26
@@ -548,7 +548,7 @@ importers:
         version: link:../logger
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       got-cjs:
         specifier: 12.5.4
         version: 12.5.4
@@ -579,7 +579,7 @@ importers:
         version: link:../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -619,7 +619,7 @@ importers:
         version: 1.11.20
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       on-exit-leak-free:
         specifier: 2.1.2
         version: 2.1.2
@@ -653,7 +653,7 @@ importers:
         version: link:../core/url
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -696,7 +696,7 @@ importers:
         version: link:../logger
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -761,7 +761,7 @@ importers:
         version: link:../../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
     devDependencies:
       '@types/debug':
         specifier: 4.1.12
@@ -792,7 +792,7 @@ importers:
         version: 2.4.3
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       http-errors:
         specifier: 2.0.1
         version: 2.0.1
@@ -829,7 +829,7 @@ importers:
         version: link:../../core/file-locking
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       globby:
         specifier: 11.1.0
         version: 11.1.0
@@ -863,7 +863,7 @@ importers:
         version: link:../../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       memfs:
         specifier: 4.17.2
         version: 4.17.2
@@ -891,7 +891,7 @@ importers:
         version: link:../../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       semver:
         specifier: 7.7.4
         version: 7.7.4
@@ -913,6 +913,10 @@ importers:
         version: link:../../core/types
 
   packages/plugins/ui-theme:
+    dependencies:
+      debug:
+        specifier: 4.4.3
+        version: 4.4.3(supports-color@5.5.0)
     devDependencies:
       '@mui/material':
         specifier: 7.3.9
@@ -994,7 +998,7 @@ importers:
         version: 1.3.5
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       got:
         specifier: 14.6.6
         version: 14.6.6
@@ -1040,7 +1044,7 @@ importers:
         version: link:../proxy
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -1065,7 +1069,7 @@ importers:
         version: 1.2.11
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
     devDependencies:
       '@verdaccio/types':
         specifier: workspace:14.0.0-next-9.4
@@ -1111,7 +1115,7 @@ importers:
         version: 2.8.5
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -1145,7 +1149,7 @@ importers:
         version: link:../core/core
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       jsonwebtoken:
         specifier: 9.0.3
         version: 9.0.3
@@ -1188,7 +1192,7 @@ importers:
         version: link:../core/url
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       lodash-es:
         specifier: 4.17.23
         version: 4.17.23
@@ -1237,7 +1241,7 @@ importers:
         version: link:../../middleware
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -1286,7 +1290,7 @@ importers:
         version: 4.0.0-rc.4(typanion@3.14.0)
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
     devDependencies:
       '@verdaccio/config':
         specifier: workspace:9.0.0-next-9.8
@@ -1334,7 +1338,7 @@ importers:
         version: 1.11.20
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       dompurify:
         specifier: 3.3.3
         version: 3.3.3
@@ -1485,7 +1489,7 @@ importers:
         version: link:../plugins/ui-theme
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       verdaccio-audit:
         specifier: workspace:14.0.0-next-9.8
         version: link:../plugins/audit
@@ -1561,7 +1565,7 @@ importers:
         version: link:../core/tarball
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       express:
         specifier: 5.2.1
         version: 5.2.1
@@ -8383,7 +8387,7 @@ snapshots:
       '@babel/types': 7.28.4
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -8483,7 +8487,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -8495,7 +8499,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9066,7 +9070,7 @@ snapshots:
   '@eslint/config-array@0.23.3':
     dependencies:
       '@eslint/object-schema': 3.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.4
     transitivePeerDependencies:
       - supports-color
@@ -10216,7 +10220,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.57.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.0.3
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -10226,7 +10230,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -10245,7 +10249,7 @@ snapshots:
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/typescript-estree': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/utils': 8.57.0(eslint@10.0.3)(typescript@5.9.3)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.0.3
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -10262,7 +10266,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.57.0
       '@typescript-eslint/visitor-keys': 8.57.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -10990,7 +10994,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.1
       on-finished: 2.4.1
@@ -11942,7 +11946,7 @@ snapshots:
 
   eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.1(@typescript-eslint/utils@8.57.0(eslint@10.0.3)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@10.0.3))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@10.0.3)(typescript@5.9.3))(eslint@10.0.3))(eslint@10.0.3):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.0.3
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.13.6
@@ -11976,7 +11980,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.46.2
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.0.3
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
@@ -12133,7 +12137,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -12234,7 +12238,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -12329,7 +12333,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -12736,7 +12740,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12768,7 +12772,7 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13803,7 +13807,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.0
@@ -13980,7 +13984,7 @@ snapshots:
 
   nock@13.5.6:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -14753,7 +14757,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -14860,7 +14864,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -15209,7 +15213,7 @@ snapshots:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-safe-stringify: 2.1.1
       form-data: 4.0.4
       formidable: 3.5.4
@@ -15755,7 +15759,7 @@ snapshots:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@5.9.3)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.17

--- a/vite.lib.config.mjs
+++ b/vite.lib.config.mjs
@@ -120,7 +120,6 @@ export function createLibConfig(dirname, options = {}) {
             {
               format: 'cjs',
               entryFileNames: '[name].js',
-              interop: 'auto',
               esModule: true,
               exports: 'named',
               ...sharedOutput,


### PR DESCRIPTION
Vite build of UI had a few issues:

- Styling of readme and syntax highlighting was broken because CSS bundling didn't work anymore
- Theme customization regarding color palette was lost
- Missing debug dependency

Changes - `ui-components`:

- Switched to `vite.lib.config.ts` which creates types and removed `tsc` from build
- Added `linkEntryCssPlugin` which makes sure CSS is part of the graph and therefore picked up by ui-theme
- Readme styling rework 
	- updated `github-markdown.css` 
	- included `hljs-github-light.css` / `hljs-github-dark.css` (instead of conflicting imports)
	- theming based on default `@mui` behavior (using data-theme)
- Added custom colors palette to theme
- Adjusted a few components for the new styling/build setup
- Excluded `src/test` from build
- Removed obsolete `resolution` for `msw` since all deps use same msw version anyway (see `pnpm why msw`)

Changes - `ui-theme`:

- Added `debug` dependency which is used in index.js
- Increase chuck size limit to avoid build warning
- Fixed `INEFFECTIVE_DYNAMIC_IMPORT` of pages

Changes - `vite.lib.config.ts`:

- Removed `interop` setting which is obsolete with `rolldownOptions`

Ref: Build errors after switching to vite dts:

[dts-type-issues.log](https://github.com/user-attachments/files/26390102/dts-type-issues.log)
