### PR TITLE
fix(storage): flaky timeout test

### DIFF
--- a/.changeset/real-vans-sin.md
+++ b/.changeset/real-vans-sin.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/store': patch
+---
+
+fix(storage): flaky timeout test

--- a/packages/store/test/fixtures/config/syncDoubleUplinksMetadata.yaml
+++ b/packages/store/test/fixtures/config/syncDoubleUplinksMetadata.yaml
@@ -1,6 +1,6 @@
 uplinks:
   timeout:
-    url: https://registry.domain1.com/
+    url: https://registry.timeout.com/
     timeout: 2s
 packages:
   'timeout':


### PR DESCRIPTION
Fixed config to match mock of uplink

https://github.com/verdaccio/verdaccio/blob/bae7f5735fc353166b0fc5e6bbb3adbc1a0ab6d4/packages/store/test/storage.spec.ts#L1289

Fixes flaky test runs like this one:
https://github.com/verdaccio/verdaccio/actions/runs/23639425439/job/68856257188