### PR TITLE
fix: memory leak in search

### DIFF
--- a/.changeset/silly-phones-refuse.md
+++ b/.changeset/silly-phones-refuse.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/api': patch
+'@verdaccio/web': patch
+---
+
+fix: memory leak in search

--- a/packages/api/src/v1/search.ts
+++ b/packages/api/src/v1/search.ts
@@ -23,7 +23,6 @@ export default function (route, auth: Auth, storage: Storage, logger: Logger): v
           if (err.status && String(err.status).match(/^4\d\d$/)) {
             // auth plugin returns 4xx user error,
             // that's equivalent of !allowed basically
-            allowed = false;
             return resolve(null);
           } else {
             reject(err);
@@ -40,16 +39,16 @@ export default function (route, auth: Auth, storage: Storage, logger: Logger): v
     let [size, from] = ['size', 'from'].map((k) => query[k]);
     let data;
     const abort = new AbortController();
-
-    req.socket.on('close', function () {
+    const onClientClose = (): void => {
       debug('search web aborted');
       abort.abort();
-    });
-
-    size = parseInt(size, 10) || 20;
-    from = parseInt(from, 10) || 0;
+    };
+    req.socket.on('close', onClientClose);
 
     try {
+      size = parseInt(size ?? '20', 10);
+      from = parseInt(from ?? '0', 10);
+
       debug('storage search initiated');
       data = await storage.search({
         query,
@@ -65,7 +64,7 @@ export default function (route, auth: Auth, storage: Storage, logger: Logger): v
 
       const final: searchUtils.SearchItemPkg[] = checkAccessPromises
         .filter((i) => i !== null)
-        .slice(from, size);
+        .slice(from, from + size);
       logger.debug(`search results ${final?.length}`);
 
       const response: searchUtils.SearchResults = {
@@ -77,8 +76,10 @@ export default function (route, auth: Auth, storage: Storage, logger: Logger): v
       res.status(HTTP_STATUS.OK).json(response);
     } catch (error) {
       logger.error({ error }, 'search endpoint has failed @{error.message}');
-      next(next);
+      next(error);
       return;
+    } finally {
+      req.socket.off('close', onClientClose);
     }
   });
 }

--- a/packages/api/src/v1/search.ts
+++ b/packages/api/src/v1/search.ts
@@ -46,8 +46,8 @@ export default function (route, auth: Auth, storage: Storage, logger: Logger): v
     req.socket.on('close', onClientClose);
 
     try {
-      size = parseInt(size ?? '20', 10);
-      from = parseInt(from ?? '0', 10);
+      size = parseInt(Number.isFinite(size) ? size : '20', 10);
+      from = parseInt(Number.isFinite(from) ? from : '0', 10);
 
       debug('storage search initiated');
       data = await storage.search({

--- a/packages/api/test/integration/config/search-abort.yaml
+++ b/packages/api/test/integration/config/search-abort.yaml
@@ -1,0 +1,31 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd-search
+
+web:
+  enable: true
+  title: verdaccio
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  'private-*':
+    access: $all
+    publish: jota
+  '@private/*':
+    access: $all
+    publish: jota
+  '@*/*':
+    access: $all
+    publish: $authenticated
+  '**':
+    access: $all
+    publish: $authenticated
+
+_debug: true

--- a/packages/api/test/integration/search.spec.ts
+++ b/packages/api/test/integration/search.spec.ts
@@ -1,6 +1,7 @@
 import MockDate from 'mockdate';
+import nock from 'nock';
 import supertest from 'supertest';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { HEADERS, HEADER_TYPE, HTTP_STATUS } from '@verdaccio/core';
 
@@ -134,6 +135,29 @@ describe('search', () => {
     });
   });
   describe('error handling', () => {
-    test.todo('should able to abort the request');
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    test('should abort the request when the client disconnects', async () => {
+      nock('https://registry.npmjs.org')
+        .get(/\/-\/v1\/search/)
+        .delay(5000)
+        .reply(200, { objects: [], total: 0, time: '' });
+
+      const app = await initializeServer('search-abort.yaml');
+      const searchUrl =
+        '/-/v1/search?text=abort-integration&size=20&from=0&quality=0.65&popularity=0.98&maintenance=0.5';
+      const req = supertest(app)
+        .get(searchUrl)
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON);
+
+      setImmediate(() => {
+        req.abort();
+      });
+
+      await expect(req).rejects.toThrow();
+    });
   });
 });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -46,6 +46,7 @@
     "@verdaccio/types": "workspace:14.0.0-next-9.4",
     "@types/lodash-es": "4.17.12",
     "jsdom": "28.1.0",
+    "nock": "13.5.6",
     "supertest": "7.1.4",
     "vitest": "4.1.0"
   },

--- a/packages/web/src/api/search.ts
+++ b/packages/web/src/api/search.ts
@@ -41,12 +41,13 @@ function addSearchWebApi(storage: Storage, auth: Auth): Router {
       _res: $ResponseExtend,
       next: $NextFunctionVer
     ): Promise<void> {
+      const abort = new AbortController();
+      const onClientClose = (): void => {
+        debug('search web aborted');
+        abort.abort();
+      };
+      req.socket.on('close', onClientClose);
       try {
-        const abort = new AbortController();
-        req.socket.on('close', function () {
-          debug('search web aborted');
-          abort.abort();
-        });
         const text: string = (req.params.anything as string) ?? '';
         // These values are declared as optimal by npm cli
         // FUTURE: could be overwritten by ui settings.
@@ -81,6 +82,8 @@ function addSearchWebApi(storage: Storage, auth: Auth): Router {
         next(final);
       } catch (err: any) {
         next(errorUtils.getInternalError(err.message));
+      } finally {
+        req.socket.off('close', onClientClose);
       }
     }
   );

--- a/packages/web/test/api.search.test.ts
+++ b/packages/web/test/api.search.test.ts
@@ -1,3 +1,4 @@
+import nock from 'nock';
 import path from 'node:path';
 import supertest from 'supertest';
 import { afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
@@ -27,6 +28,7 @@ describe('test web server', () => {
   });
 
   afterEach(() => {
+    nock.cleanAll();
     Date.now = vi.fn(() => new Date(Date.UTC(2017, 1, 14)).valueOf());
     vi.clearAllMocks();
     mockManifest.mockClear();
@@ -63,7 +65,23 @@ describe('test web server', () => {
     expect(response.body).toHaveLength(3);
   });
 
-  test.todo('search abort request');
+  test('should abort search when the client disconnects', async () => {
+    nock('https://registry.npmjs.org')
+      .get(/\/-\/v1\/search/)
+      .delay(5000)
+      .reply(200, { objects: [], total: 0, time: '' });
+
+    const app = await initializeServer('search-abort.yaml');
+    const req = supertest(app)
+      .get('/-/verdaccio/data/search/abort-integration')
+      .set('Accept', HEADERS.JSON_CHARSET);
+
+    setImmediate(() => {
+      req.abort();
+    });
+
+    await expect(req).rejects.toThrow();
+  });
   // maybe these could be done in storage package to avoid have specifics on this level
   test.todo('search allow request permissions');
   test.todo('search query params, pagination etc');

--- a/packages/web/test/config/search-abort.yaml
+++ b/packages/web/test/config/search-abort.yaml
@@ -1,0 +1,30 @@
+auth:
+  auth-memory:
+    users:
+      test:
+        name: test
+        password: test
+
+web:
+  title: verdaccio
+
+publish:
+  allow_offline: false
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@*/*':
+    access: $anonymous
+    publish: $anonymous
+  '**':
+    access: $anonymous
+    publish: $anonymous
+_debug: true
+
+flags:
+  changePassword: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1578,6 +1578,9 @@ importers:
       jsdom:
         specifier: 28.1.0
         version: 28.1.0(@noble/hashes@1.8.0)
+      nock:
+        specifier: 13.5.6
+        version: 13.5.6
       supertest:
         specifier: 7.1.4
         version: 7.1.4


### PR DESCRIPTION
`req.socket.on('close', …)` was never removed. Each search added another close listener. Those piled up until the connection closed wasting memory and redundant abort() calls.

Used a finally block so the listener is always removed when the route handler finishes (success, error, or early exit).

Plus small fixes for `slice` and `next(error)` so the error middleware receives the actual failure.
