### PR TITLE
fix(package-filter): fix O(n²) complexity in cleanupDistFiles

### DIFF
--- a/.changeset/calm-ligers-mix.md
+++ b/.changeset/calm-ligers-mix.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/package-filter': patch
+---
+
+fix(package-filter): fix O(n²) complexity in cleanupDistFiles

--- a/packages/plugins/package-filter/src/utils/manifestUtils.ts
+++ b/packages/plugins/package-filter/src/utils/manifestUtils.ts
@@ -130,13 +130,12 @@ export function setupCreatedAndModified(manifest: Manifest): void {
  */
 export function cleanupDistFiles(manifest: Manifest): void {
   const distFiles = manifest._distfiles;
-  Object.entries(distFiles).forEach(([key, file]) => {
-    const fileUrl = file.url;
-    const versionPointingToFile = Object.values(manifest.versions).find(
-      (v) => v.dist?.tarball === fileUrl
-    );
-
-    if (!versionPointingToFile) {
+  // Build a Set of active tarball URLs in one pass — O(n) instead of O(n²)
+  const activeTarballs = new Set(
+    Object.values(manifest.versions).map((v) => (v as { dist?: { tarball?: string } }).dist?.tarball)
+  );
+  Object.keys(distFiles).forEach((key) => {
+    if (!activeTarballs.has(distFiles[key].url)) {
       delete distFiles[key];
     }
   });

--- a/packages/plugins/package-filter/src/utils/manifestUtils.ts
+++ b/packages/plugins/package-filter/src/utils/manifestUtils.ts
@@ -132,7 +132,9 @@ export function cleanupDistFiles(manifest: Manifest): void {
   const distFiles = manifest._distfiles;
   // Build a Set of active tarball URLs in one pass — O(n) instead of O(n²)
   const activeTarballs = new Set(
-    Object.values(manifest.versions).map((v) => (v as { dist?: { tarball?: string } }).dist?.tarball)
+    Object.values(manifest.versions)
+      .map((v) => v.dist?.tarball)
+      .filter((tarball): tarball is string => typeof tarball === 'string')
   );
   Object.keys(distFiles).forEach((key) => {
     if (!activeTarballs.has(distFiles[key].url)) {

--- a/packages/plugins/package-filter/test/manifestUtils.test.ts
+++ b/packages/plugins/package-filter/test/manifestUtils.test.ts
@@ -4,6 +4,7 @@ import { DIST_TAGS } from '@verdaccio/core';
 import type { Manifest } from '@verdaccio/types';
 
 import {
+  cleanupDistFiles,
   cleanupTime,
   getLatestVersion,
   setupCreatedAndModified,
@@ -23,6 +24,61 @@ function createManifest(overrides: Partial<Manifest> = {}): Manifest {
     ...overrides,
   } as unknown as Manifest;
 }
+
+describe('cleanupDistFiles', () => {
+  test('removes _distfiles entries not referenced by any version', () => {
+    const manifest = createManifest({
+      versions: {
+        '1.0.0': { dist: { tarball: 'https://registry.npmjs.org/test-pkg/-/test-pkg-1.0.0.tgz' } },
+      } as any,
+      _distfiles: {
+        'test-pkg-1.0.0.tgz': {
+          url: 'https://registry.npmjs.org/test-pkg/-/test-pkg-1.0.0.tgz',
+          sha: '',
+        },
+        'test-pkg-0.9.0.tgz': {
+          url: 'https://registry.npmjs.org/test-pkg/-/test-pkg-0.9.0.tgz',
+          sha: '',
+        },
+      } as any,
+    });
+    cleanupDistFiles(manifest);
+    expect(Object.keys(manifest._distfiles)).toEqual(['test-pkg-1.0.0.tgz']);
+  });
+
+  test('retains _distfiles entries referenced by a version', () => {
+    const url = 'https://registry.npmjs.org/test-pkg/-/test-pkg-2.0.0.tgz';
+    const manifest = createManifest({
+      versions: {
+        '2.0.0': { dist: { tarball: url } },
+      } as any,
+      _distfiles: {
+        'test-pkg-2.0.0.tgz': { url, sha: '' },
+      } as any,
+    });
+    cleanupDistFiles(manifest);
+    expect(manifest._distfiles['test-pkg-2.0.0.tgz'].url).toBe(url);
+  });
+
+  test('handles multiple versions sharing the same tarball URL', () => {
+    const sharedUrl = 'https://registry.npmjs.org/test-pkg/-/test-pkg-1.0.0.tgz';
+    const manifest = createManifest({
+      versions: {
+        '1.0.0': { dist: { tarball: sharedUrl } },
+        '1.0.0-alias': { dist: { tarball: sharedUrl } },
+      } as any,
+      _distfiles: {
+        'test-pkg-1.0.0.tgz': { url: sharedUrl, sha: '' },
+        'test-pkg-orphan.tgz': {
+          url: 'https://registry.npmjs.org/test-pkg/-/test-pkg-orphan.tgz',
+          sha: '',
+        },
+      } as any,
+    });
+    cleanupDistFiles(manifest);
+    expect(Object.keys(manifest._distfiles)).toEqual(['test-pkg-1.0.0.tgz']);
+  });
+});
 
 describe('cleanupTime', () => {
   test('handles manifest without time property', () => {

--- a/packages/store/test/fixtures/config/unpublishPackage.yaml
+++ b/packages/store/test/fixtures/config/unpublishPackage.yaml
@@ -1,11 +1,14 @@
 uplinks:
   ver:
-    url: https://registry.verdaccio.org/
+    url: https://fake.domain.org/
 packages:
   '@*/*':
     access: $all
     publish: $all
     proxy: ver
+  'upstream':
+    access: $all
+    publish: $all
   '*':
     access: $all
     publish: $all


### PR DESCRIPTION
The previous implementation used Array.find() inside a forEach loop, resulting in O(n²) time complexity: for each _distfiles entry, it scanned all manifest.versions to find a matching tarball URL.

For packages with thousands of versions (e.g. @graphql-codegen/* with 5000-6000 versions), this caused severe performance degradation:
- Blocked the Node.js event loop on every metadata request
- Caused K8s Pod liveness probe timeouts and Pod restarts under load

Fix: build a Set of active tarball URLs in one O(n) pass, then check
each _distfiles entry against the Set in O(1). Total complexity: O(n).

Benchmarked on a real project (`time npm i install`):
- Before: 17:54 with original plugin
- After:   7:03 with this fix