### PR TITLE
feat: auto-detect search response shape in the Web UI and remove the …

### DIFF
--- a/.changeset/search-auto-detect-response-shape.md
+++ b/.changeset/search-auto-detect-response-shape.md
@@ -1,0 +1,45 @@
+---
+'@verdaccio/ui-components': minor
+'@verdaccio/config': major
+'@verdaccio/types': major
+---
+
+feat: auto-detect search response shape in the Web UI and remove the `searchRemote` flag
+
+## Breaking Changes
+
+### Removed the `searchRemote` feature flag
+
+The `flags.searchRemote` configuration option has been removed. The Web UI now
+auto-detects the shape of the `/-/verdaccio/data/search/*` response at render
+time, so no flag is required to toggle between local-only and remote-augmented
+results.
+
+**What changed:**
+
+- `FlagsConfig.searchRemote` has been removed from `@verdaccio/types`.
+- `@verdaccio/config` no longer reads or defaults `flags.searchRemote`.
+- The sample `# searchRemote: true` lines in `default.yaml` / `docker.yaml`
+  have been removed.
+- The search UI (`@verdaccio/ui-components`) no longer consults the flag.
+
+**Migration guide:**
+
+Remove `flags.searchRemote` from your `config.yaml` if it is set. No other
+change is required — the Web UI will render both response shapes transparently.
+
+## UI changes
+
+The `Search` component now consumes two response shapes without configuration:
+
+1. **npm-style "search objects"** — entries wrapped in a `package` envelope
+   with `verdaccioPkgCached` / `verdaccioPrivate` metadata. Private / cached /
+   remote chips are rendered as before.
+2. **Flat packument-style** — entries with `name`, `version`, `description`,
+   `dist`, etc. at the top level. Chips are omitted because the shape carries
+   no uplink metadata.
+
+A new `normalizeSearchOption()` helper centralizes the shape detection and is
+covered by unit tests. The `SearchResultWeb` type in `@verdaccio/types` is now
+a union (`SearchResultWebFlat | SearchResultWebWrapped`) that documents both
+shapes.

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -268,7 +268,6 @@ log:
 # Renamed from "experiments" to "flags" in next major release
 # flags:
 #  changePassword: true
-#  searchRemote: true
 
 # Translate your registry, API and web UI
 # List of the available translations https://github.com/verdaccio/verdaccio/blob/master/packages/plugins/ui-theme/src/i18n/ABOUT_TRANSLATIONS.md

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -264,7 +264,6 @@ log:
 # Renamed from "experiments" to "flags" in next major release
 # flags:
 #  changePassword: true
-#  searchRemote: true
 
 # Translate your registry, API and web UI
 # List of the available translations https://github.com/verdaccio/verdaccio/blob/master/packages/plugins/ui-theme/src/i18n/ABOUT_TRANSLATIONS.md

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -79,7 +79,6 @@ class Config implements AppConfig {
     this.security = merge(defaultSecurity, config.security);
     this.server = { ...defaultServerSettings, ...config.server };
     this.flags = {
-      searchRemote: config.flags?.searchRemote ?? true,
       changePassword: config.flags?.changePassword ?? false,
       webLogin: config.flags?.webLogin ?? false,
       createUser: config.flags?.createUser ?? false,

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -90,14 +90,6 @@ export type RateLimit = {
  */
 export type FlagsConfig = {
   /**
-   * Enables searching for packages in remote registries.
-   * If `false`, only the local registry will be queried.
-   *
-   * @default false
-   */
-  searchRemote?: boolean;
-
-  /**
    * Enables user password change functionality.
    *
    * @default false

--- a/packages/core/types/src/search.ts
+++ b/packages/core/types/src/search.ts
@@ -21,8 +21,65 @@ export type SearchPackageBody = {
   maintainers?: PublisherMaintainer[];
 };
 
-export type SearchResultWeb = {
+/**
+ * Flat response shape, e.g. from the local registry packument-style search:
+ *
+ * ```json
+ * { "name": "...", "version": "...", "description": "...", "dist": { ... } }
+ * ```
+ */
+export type SearchResultWebFlat = {
   name: string;
   version: string;
-  description: string;
+  description?: string;
+  main?: string;
+  readmeFilename?: string;
+  dependencies?: Record<string, string>;
+  dist?: {
+    shasum?: string;
+    tarball?: string;
+  };
+  contributors?: unknown[];
 };
+
+/**
+ * npm-style "search objects" response where each entry is wrapped in a
+ * `package` envelope and carries verdaccio-specific metadata flags.
+ */
+export type SearchResultWebWrapped = {
+  package: {
+    name: string;
+    version: string;
+    description?: string;
+    scope?: string;
+    keywords?: string[];
+    date?: string;
+    author?: PublisherMaintainer | { name?: string; email?: string };
+    publisher?: any;
+    maintainers?: Array<{ name?: string; email?: string }>;
+    links?: {
+      npm?: string;
+      homepage?: string;
+      repository?: any;
+      bugs?: any;
+    };
+  };
+  score?: {
+    final?: number;
+    detail?: {
+      maintenance?: number;
+      popularity?: number;
+      quality?: number;
+    };
+  };
+  searchScore?: number;
+  verdaccioPkgCached?: boolean;
+  verdaccioPrivate?: boolean;
+};
+
+/**
+ * Union of the two search response shapes the web UI can consume.
+ * The Search component auto-detects the shape at render time — no feature
+ * flag is required to switch between them.
+ */
+export type SearchResultWeb = SearchResultWebFlat | SearchResultWebWrapped;

--- a/packages/plugins/ui-theme/tools/_verdaccio.config.yaml
+++ b/packages/plugins/ui-theme/tools/_verdaccio.config.yaml
@@ -11,7 +11,6 @@ web:
     - pnpm
 
 flags:
-  searchRemote: true
   webLogin: true
   createUser: true
   changePassword: true

--- a/packages/ui-components/.storybook/preview-head.html
+++ b/packages/ui-components/.storybook/preview-head.html
@@ -5,7 +5,7 @@
     primary_color: null,
     pkgManagers: ['npm', 'yarn', 'pnpm'],
     version: '1.0.0',
-    flags: { searchRemote: false },
+    flags: {},
     filename: 'index.html',
     base: 'https://my-registry.org',
   };

--- a/packages/ui-components/src/components/Search/Search.test.tsx
+++ b/packages/ui-components/src/components/Search/Search.test.tsx
@@ -46,11 +46,6 @@ describe('<Search /> component', () => {
     expect(screen.getByPlaceholderText('search.packages')).toBeInTheDocument();
   });
 
-  test('should load the component in default state with remote search', () => {
-    renderWithRouteDetail(<ComponentToBeRendered />, 'jquery', { flags: { searchRemote: true } });
-    expect(screen.getByPlaceholderText('search.packages')).toBeInTheDocument();
-  });
-
   test('handleSearch: when user type package name in search component, show suggestions', async () => {
     renderWithRouteDetail(<ComponentToBeRendered />);
 

--- a/packages/ui-components/src/components/Search/Search.tsx
+++ b/packages/ui-components/src/components/Search/Search.tsx
@@ -4,13 +4,12 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
-import type { SearchResultWeb } from '@verdaccio/types';
-
-import { useConfig, useSearch } from '../../';
+import { useSearch } from '../../';
 import { Route } from '../../utils';
 import AutoComplete from './AutoComplete';
 import SearchItem from './SearchItem';
 import { StyledInputAdornment, StyledTextField } from './styles';
+import { normalizeSearchOption } from './utils';
 
 const CONSTANTS = {
   API_DELAY: 300,
@@ -21,10 +20,6 @@ const Search: React.FC = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { searchResults, isLoading, doSearch } = useSearch();
-  const {
-    configOptions: { flags },
-  } = useConfig();
-  const searchRemote = flags?.searchRemote ?? false;
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -44,14 +39,16 @@ const Search: React.FC = () => {
   );
 
   const handleClickSearch = useCallback(
-    (event: React.SyntheticEvent, value: SearchResultWeb, reason: string): void => {
+    (event: React.SyntheticEvent, value: any, reason: string): void => {
       event.stopPropagation();
       if (reason === 'selectOption') {
-        const pkgName = value['package']?.name ?? value.name;
-        navigate(`${Route.DETAIL}${pkgName}`);
+        const { name } = normalizeSearchOption(value);
+        if (name) {
+          navigate(`${Route.DETAIL}${name}`);
+        }
       }
     },
-    [navigate, searchRemote]
+    [navigate]
   );
 
   // Use a ref to always access the latest doSearch without re-creating the debounced function
@@ -105,36 +102,20 @@ const Search: React.FC = () => {
 
   const renderOption = (props, option) => {
     const { key, ...otherProps } = props;
-
-    if (searchRemote) {
-      const item: SearchResultWeb = option.package;
-      const isPrivate = option?.verdaccioPrivate;
-      const isCached = option?.verdaccioPkgCached;
-      const isRemote = !isCached && !isPrivate;
-      return (
-        <SearchItem
-          key={key}
-          {...otherProps}
-          description={item?.description}
-          isCached={isCached}
-          isPrivate={isPrivate}
-          isRemote={isRemote}
-          name={item?.name}
-          version={item?.version}
-        />
-      );
-    } else {
-      const item: SearchResultWeb = option.package;
-      return (
-        <SearchItem
-          key={key}
-          {...otherProps}
-          description={item?.description}
-          name={item?.name}
-          version={item?.version}
-        />
-      );
-    }
+    const { name, version, description, isPrivate, isCached, isRemote } =
+      normalizeSearchOption(option);
+    return (
+      <SearchItem
+        key={key}
+        {...otherProps}
+        description={description}
+        isCached={isCached}
+        isPrivate={isPrivate}
+        isRemote={isRemote}
+        name={name}
+        version={version}
+      />
+    );
   };
 
   const renderInput = (params) => {
@@ -157,7 +138,7 @@ const Search: React.FC = () => {
   };
 
   const getOptionLabel = (option) => {
-    return option?.package?.name;
+    return normalizeSearchOption(option).name;
   };
 
   return (

--- a/packages/ui-components/src/components/Search/utils.test.ts
+++ b/packages/ui-components/src/components/Search/utils.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from 'vitest';
+
+import { normalizeSearchOption } from './utils';
+
+describe('normalizeSearchOption', () => {
+  describe('wrapped (npm search-objects) shape', () => {
+    test('extracts name, version and description from the package envelope', () => {
+      const result = normalizeSearchOption({
+        package: {
+          name: '@starbase/auth',
+          scope: '@starbase',
+          version: '3.0.0',
+          description: 'Authentication module with JWT, OAuth2, API keys, and session support.',
+          keywords: ['auth', 'jwt'],
+          date: '2026-04-06T16:51:06.944Z',
+          publisher: {},
+          links: { npm: '' },
+        },
+        score: {
+          final: 1,
+          detail: { maintenance: 0, popularity: 1, quality: 1 },
+        },
+        searchScore: 1,
+        verdaccioPkgCached: false,
+        verdaccioPrivate: true,
+      });
+
+      expect(result).toEqual({
+        name: '@starbase/auth',
+        version: '3.0.0',
+        description: 'Authentication module with JWT, OAuth2, API keys, and session support.',
+        isPrivate: true,
+        isCached: false,
+        isRemote: false,
+      });
+    });
+
+    test('marks the option as cached when verdaccioPkgCached is true', () => {
+      const result = normalizeSearchOption({
+        package: { name: '@eslint/config-array', version: '0.23.3' },
+        verdaccioPkgCached: true,
+        verdaccioPrivate: false,
+      });
+
+      expect(result.isCached).toBe(true);
+      expect(result.isPrivate).toBe(false);
+      expect(result.isRemote).toBe(false);
+    });
+
+    test('marks the option as private when verdaccioPrivate is true', () => {
+      const result = normalizeSearchOption({
+        package: { name: '@starbase/admin-api', version: '2.0.0' },
+        verdaccioPkgCached: false,
+        verdaccioPrivate: true,
+      });
+
+      expect(result.isPrivate).toBe(true);
+      expect(result.isCached).toBe(false);
+      expect(result.isRemote).toBe(false);
+    });
+
+    test('infers remote when neither cached nor private', () => {
+      const result = normalizeSearchOption({
+        package: { name: '@angular/cli', version: '21.2.2' },
+        verdaccioPkgCached: false,
+        verdaccioPrivate: false,
+      });
+
+      expect(result.isRemote).toBe(true);
+      expect(result.isCached).toBe(false);
+      expect(result.isPrivate).toBe(false);
+    });
+
+    test('private takes precedence: a private package is never flagged as remote', () => {
+      const result = normalizeSearchOption({
+        package: { name: '@starbase/cache', version: '2.5.0' },
+        verdaccioPkgCached: false,
+        verdaccioPrivate: true,
+      });
+
+      expect(result.isRemote).toBe(false);
+    });
+
+    test('treats missing verdaccio metadata as falsy (not undefined)', () => {
+      const result = normalizeSearchOption({
+        package: { name: '@nodelib/fs.stat', version: '4.0.0' },
+      });
+
+      expect(result.isPrivate).toBe(false);
+      expect(result.isCached).toBe(false);
+      // With both flags absent, the UI should treat it as a remote suggestion.
+      expect(result.isRemote).toBe(true);
+    });
+
+    test('returns undefined fields when the package envelope is empty', () => {
+      const result = normalizeSearchOption({ package: {} });
+
+      expect(result.name).toBeUndefined();
+      expect(result.version).toBeUndefined();
+      expect(result.description).toBeUndefined();
+    });
+  });
+
+  describe('flat (packument-style) shape', () => {
+    test('extracts name, version and description from top-level fields', () => {
+      const result = normalizeSearchOption({
+        name: 'aurora-logger',
+        version: '1.2.0',
+        description:
+          'A lightweight, colorful logging library for Node.js applications. Supports multiple transports, log levels, and structured JSON output.',
+        main: 'index.js',
+        readmeFilename: 'README.md',
+        dist: {
+          shasum: '3150795ba15a52399fd68b262cb5dca9d6a1bb48',
+          tarball: 'http://localhost:4873/aurora-logger/-/aurora-logger-1.2.0.tgz',
+        },
+        contributors: [],
+      });
+
+      expect(result).toEqual({
+        name: 'aurora-logger',
+        version: '1.2.0',
+        description:
+          'A lightweight, colorful logging library for Node.js applications. Supports multiple transports, log levels, and structured JSON output.',
+        isPrivate: false,
+        isCached: false,
+        isRemote: false,
+      });
+    });
+
+    test('handles a scoped flat entry', () => {
+      const result = normalizeSearchOption({
+        name: '@starbase/assert',
+        version: '0.5.0',
+        description: 'Lightweight assertion library with descriptive failure messages.',
+        main: 'index.js',
+        dist: { tarball: 'http://localhost:4873/@starbase/assert/-/@starbase/assert-0.5.0.tgz' },
+      });
+
+      expect(result.name).toBe('@starbase/assert');
+      expect(result.version).toBe('0.5.0');
+    });
+
+    test('leaves all metadata flags false because the flat shape carries no uplink info', () => {
+      const result = normalizeSearchOption({
+        name: 'api-doc-gen',
+        version: '2.0.0',
+        description: 'Generate OpenAPI 3.1 specs from route definitions and TypeScript types.',
+      });
+
+      expect(result.isPrivate).toBe(false);
+      expect(result.isCached).toBe(false);
+      expect(result.isRemote).toBe(false);
+    });
+
+    test('preserves missing description as undefined', () => {
+      const result = normalizeSearchOption({
+        name: 'k8s-manifest-gen',
+        version: '1.2.0',
+      });
+
+      expect(result.description).toBeUndefined();
+    });
+  });
+
+  describe('nullish and malformed input', () => {
+    test('returns a safe default when given undefined', () => {
+      expect(normalizeSearchOption(undefined as any)).toEqual({
+        name: undefined,
+        version: undefined,
+        description: undefined,
+        isPrivate: false,
+        isCached: false,
+        isRemote: false,
+      });
+    });
+
+    test('returns a safe default when given null', () => {
+      expect(normalizeSearchOption(null as any)).toEqual({
+        name: undefined,
+        version: undefined,
+        description: undefined,
+        isPrivate: false,
+        isCached: false,
+        isRemote: false,
+      });
+    });
+
+    test('returns a safe default for an empty object', () => {
+      expect(normalizeSearchOption({} as any)).toEqual({
+        name: undefined,
+        version: undefined,
+        description: undefined,
+        isPrivate: false,
+        isCached: false,
+        isRemote: false,
+      });
+    });
+
+    test('a `package: null` envelope falls back to the flat branch', () => {
+      // Not strictly one of the documented shapes, but we want the helper
+      // to be defensive rather than throw.
+      const result = normalizeSearchOption({ package: null, name: 'fallback', version: '0.0.1' });
+
+      expect(result.name).toBe('fallback');
+      expect(result.version).toBe('0.0.1');
+      expect(result.isRemote).toBe(false);
+    });
+  });
+});

--- a/packages/ui-components/src/components/Search/utils.ts
+++ b/packages/ui-components/src/components/Search/utils.ts
@@ -1,3 +1,50 @@
+export type NormalizedSearchOption = {
+  name: string;
+  version?: string;
+  description?: string;
+  isPrivate: boolean;
+  isCached: boolean;
+  isRemote: boolean;
+};
+
+/**
+ * Normalize a raw search result into a unified shape the UI can render,
+ * regardless of which backend response format was returned:
+ *
+ * 1) npm-style "search objects" response where each entry is wrapped in
+ *    `{ package: { name, version, description, ... }, verdaccioPrivate, verdaccioPkgCached }`.
+ * 2) Flat packument-style response where each entry exposes `name`, `version`,
+ *    `description`, `dist`, etc. directly at the top level.
+ *
+ * The second shape carries no uplink metadata, so private/remote/cached flags
+ * default to `false` and the UI simply omits the corresponding badges.
+ */
+export function normalizeSearchOption(option: any): NormalizedSearchOption {
+  if (option && typeof option === 'object' && option.package) {
+    const pkg = option.package ?? {};
+    const isPrivate = Boolean(option.verdaccioPrivate);
+    const isCached = Boolean(option.verdaccioPkgCached);
+    return {
+      name: pkg.name,
+      version: pkg.version,
+      description: pkg.description,
+      isPrivate,
+      isCached,
+      isRemote: !isCached && !isPrivate,
+    };
+  }
+
+  const flat = option ?? {};
+  return {
+    name: flat.name,
+    version: flat.version,
+    description: flat.description,
+    isPrivate: false,
+    isCached: false,
+    isRemote: false,
+  };
+}
+
 function removeHtmlTags(input: string): string {
   let previous;
   do {

--- a/packages/ui-components/src/sections/Header/Header.stories.tsx
+++ b/packages/ui-components/src/sections/Header/Header.stories.tsx
@@ -52,7 +52,6 @@ export const HeaderAll: Story = {
     </MemoryRouter>
   ),
   parameters: {
-    searchRemote: false,
     msw: {
       handlers: [
         http.get('https://my-registry.org/-/verdaccio/data/sidebar/storybook', () => {


### PR DESCRIPTION
## Breaking Changes

(Internal usage only anyway)

### Removed the `searchRemote` feature flag (intended for 6.x support, not exposed to users) 

The `flags.searchRemote` configuration option has been removed. The Web UI now
auto-detects the shape of the `/-/verdaccio/data/search/*` response at render
time, so no flag is required to toggle between local-only and remote-augmented
results.

**What changed:**

- `FlagsConfig.searchRemote` has been removed from `@verdaccio/types`.
- `@verdaccio/config` no longer reads or defaults `flags.searchRemote`.
- The sample `# searchRemote: true` lines in `default.yaml` / `docker.yaml`
  have been removed.
- The search UI (`@verdaccio/ui-components`) no longer consults the flag.