### PR TITLE
feat(config): extend ConfigBuilder with methods

### DIFF
--- a/.changeset/improve-config-builder.md
+++ b/.changeset/improve-config-builder.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/config': minor
+---
+
+feat(config): extend ConfigBuilder with methods for web, listen, https, publish, flags, notify, middlewares, filters, maxBodySize, userRateLimit, urlPrefix, and i18n

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -33,41 +33,119 @@ To start using `@verdaccio/config`, import the `ConfigBuilder` class and begin c
 
 ## `ConfigBuilder` constructor
 
-The `ConfigBuilder` class is a helper configuration builder constructor used to programmatically create configuration objects for testing or other purposes.
+The `ConfigBuilder` class is a helper configuration builder constructor used to programmatically create configuration objects for testing or other purposes. All setter methods return `this` for fluent chaining.
 
 ```typescript
-
 import { ConfigBuilder } from '@verdaccio/config';
+import { constants } from '@verdaccio/core';
 
-// Create a new configuration builder instance
-const config = ConfigBuilder.build({ security: { api: { legacy: false } } });
-
-// Add package access configuration
-configBuilder.addPackageAccess('@scope/*', { access: 'read', publish: 'write' });
-
-// Add an uplink configuration
-configBuilder.addUplink('npmjs', { url: 'https://registry.npmjs.org/' });
-
-// Add security configuration
-configBuilder.addSecurity({ allow_offline: true });
+const config = ConfigBuilder.build()
+  .addStorage('./storage')
+  .addSecurity({
+    api: {
+      jwt: { sign: { expiresIn: '7d' }, verify: {} },
+      legacy: false,
+    },
+    web: {
+      sign: { expiresIn: '1h' },
+      verify: {},
+    },
+  })
+  .addAuth({
+    htpasswd: { file: '.htpasswd' },
+  })
+  .addUplink('npmjs', { url: 'https://registry.npmjs.org/' })
+  .addPackageAccess('@scope/*', {
+    access: constants.ROLES.$AUTH,
+    publish: constants.ROLES.$AUTH,
+    proxy: 'npmjs',
+  })
+  .addWeb({ title: 'My Registry', darkMode: true, primaryColor: '#4b5e40' })
+  .addLogger({ type: 'stdout', format: 'pretty', level: 'info' })
+  .addMiddlewares({ audit: { enabled: true } })
+  .addFlags({ changePassword: true })
+  .addI18n({ web: 'en-US' });
 
 // Get the configuration object
-const config = configBuilder.getConfig();
+const configObj = config.getConfig();
 
-// Get the configuration yaml text
-const config = configBuilder.getAsYaml();
+// Get the configuration as YAML text
+const configYaml = config.getAsYaml();
+```
+
+You can also pass an initial partial configuration to `ConfigBuilder.build()`:
+
+```typescript
+const config = ConfigBuilder.build({ security: { api: { legacy: false } } });
 ```
 
 ### Methods
 
-- `addPackageAccess(pattern: string, pkgAccess: PackageAccessYaml)`: Adds package access configuration.
+- `addPackageAccess(pattern: string, pkgAccess: PackageAccessYaml)`: Adds package access configuration for a pattern.
 - `addUplink(id: string, uplink: UpLinkConf)`: Adds an uplink configuration.
-- `addSecurity(security: Partial<Security>)`: Adds security configuration.
-- `addAuth(auth: Partial<AuthConf>)`: Adds authentication configuration.
-- `addLogger(log: LoggerConfItem)`: Adds logger configuration.
-- `addStorage(storage: string | object)`: Adds storage configuration.
+- `addSecurity(security: Partial<Security>)`: Merges security configuration.
+- `addAuth(auth: Partial<AuthConf>)`: Merges authentication configuration.
+- `addLogger(log: LoggerConfigItem)`: Sets logger configuration.
+- `addServer(server: Partial<ServerSettingsConf>)`: Merges server settings.
+- `addStorage(storage: string | object)`: Sets storage path (string) or store plugin configuration (object).
+- `addWeb(web: Partial<WebConf>)`: Merges web UI configuration.
+- `addListen(listen: ListenAddress)`: Sets listen address.
+- `addHttps(https: HttpsConf)`: Sets HTTPS configuration.
+- `addPublish(publish: Partial<PublishOptions>)`: Merges publish options.
+- `addFlags(flags: Partial<FlagsConfig>)`: Merges feature flags.
+- `addNotify(notify: Notifications | Notifications[])`: Sets notification hooks.
+- `addMiddlewares(middlewares: any)`: Merges middlewares configuration.
+- `addFilters(filters: any)`: Merges filters configuration.
+- `addMaxBodySize(maxBodySize: string)`: Sets the max body size (e.g., `'50mb'`).
+- `addUserRateLimit(rateLimit: RateLimit)`: Merges user rate limit settings.
+- `addUrlPrefix(urlPrefix: string)`: Sets URL prefix.
+- `addI18n(i18n: ConfigYaml['i18n'])`: Sets i18n configuration.
 - `getConfig(): ConfigYaml`: Retrieves the configuration object.
-- `getAsYaml(): string`: Retrieves the configuration object as YAML format.
+- `getAsYaml(): string`: Retrieves the configuration as YAML format.
+
+## Using `ConfigBuilder` with `runServer`
+
+The `ConfigBuilder` pairs with `runServer` from the `verdaccio` package to start a registry programmatically:
+
+```typescript
+import { runServer } from 'verdaccio';
+
+import { ConfigBuilder } from '@verdaccio/config';
+import { constants } from '@verdaccio/core';
+
+const config = ConfigBuilder.build()
+  .addStorage('./storage')
+  .addAuth({ htpasswd: { file: '.htpasswd' } })
+  .addUplink('npmjs', { url: 'https://registry.npmjs.org/' })
+  .addPackageAccess(constants.PACKAGE_ACCESS.SCOPE, {
+    access: constants.ROLES.$AUTH,
+    publish: constants.ROLES.$AUTH,
+    proxy: 'npmjs',
+  })
+  .addPackageAccess(constants.PACKAGE_ACCESS.ALL, {
+    access: constants.ROLES.$ALL,
+    publish: constants.ROLES.$AUTH,
+    proxy: 'npmjs',
+  })
+  .addWeb({ title: 'My Registry', darkMode: true })
+  .addMiddlewares({ audit: { enabled: true } })
+  .addLogger({ type: 'stdout', format: 'pretty', level: 'info' })
+  .addSecurity({
+    api: { jwt: { sign: { expiresIn: '7d' }, verify: {} }, legacy: false },
+    web: { sign: { expiresIn: '1h' }, verify: {} },
+  })
+  .addI18n({ web: 'en-US' });
+
+runServer(config.getConfig())
+  .then((app) => {
+    app.listen(4873, () => {
+      console.log('verdaccio running on port 4873');
+    });
+  })
+  .catch((err) => {
+    console.error(err);
+  });
+```
 
 ## `getDefaultConfig`
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -100,6 +100,12 @@ const config = ConfigBuilder.build({ security: { api: { legacy: false } } });
 - `addUserRateLimit(rateLimit: RateLimit)`: Merges user rate limit settings.
 - `addUrlPrefix(urlPrefix: string)`: Sets URL prefix.
 - `addI18n(i18n: ConfigYaml['i18n'])`: Sets i18n configuration.
+- `addUserAgent(userAgent: string)`: Sets the user agent string.
+- `addHttpProxy(httpProxy: string)`: Sets the HTTP proxy.
+- `addHttpsProxy(httpsProxy: string)`: Sets the HTTPS proxy.
+- `addNoProxy(noProxy: string)`: Sets the no-proxy exclusion list.
+- `addPlugins(plugins: string)`: Sets the plugins directory path.
+- `addNotifications(notifications: Notifications)`: Sets notifications configuration.
 - `getConfig(): ConfigYaml`: Retrieves the configuration object.
 - `getAsYaml(): string`: Retrieves the configuration as YAML format.
 

--- a/packages/config/src/builder.ts
+++ b/packages/config/src/builder.ts
@@ -3,11 +3,18 @@ import { merge } from 'lodash-es';
 import type {
   AuthConf,
   ConfigYaml,
+  FlagsConfig,
+  HttpsConf,
+  ListenAddress,
   LoggerConfigItem,
+  Notifications,
   PackageAccessYaml,
+  PublishOptions,
+  RateLimit,
   Security,
   ServerSettingsConf,
   UpLinkConf,
+  WebConf,
 } from '@verdaccio/types';
 
 import { fromJStoYAML } from '.';
@@ -20,7 +27,7 @@ export default class ConfigBuilder {
   private config: ConfigYaml;
 
   public constructor(config?: Partial<ConfigYaml>) {
-    this.config = merge(config, { uplinks: {}, packages: {}, security: {} });
+    this.config = merge({ uplinks: {}, packages: {}, security: {} }, config);
   }
 
   public static build(config?: Partial<ConfigYaml>): ConfigBuilder {
@@ -28,8 +35,9 @@ export default class ConfigBuilder {
   }
 
   public addPackageAccess(pattern: string, pkgAccess: PackageAccessYaml) {
-    // @ts-ignore
-    this.config.packages[pattern] = pkgAccess;
+    // PackageAccessYaml uses string for publish/access while PackageAccess uses string[]
+    // The config parser normalizes these later, so the cast is safe here
+    (this.config.packages as Record<string, PackageAccessYaml>)[pattern] = pkgAccess;
     return this;
   }
 
@@ -64,6 +72,66 @@ export default class ConfigBuilder {
     } else {
       this.config.store = storage;
     }
+    return this;
+  }
+
+  public addWeb(web: Partial<WebConf>) {
+    this.config.web = merge(this.config.web, web);
+    return this;
+  }
+
+  public addListen(listen: ListenAddress) {
+    this.config.listen = listen;
+    return this;
+  }
+
+  public addHttps(https: HttpsConf) {
+    this.config.https = https;
+    return this;
+  }
+
+  public addPublish(publish: Partial<PublishOptions>) {
+    this.config.publish = merge(this.config.publish, publish);
+    return this;
+  }
+
+  public addFlags(flags: Partial<FlagsConfig>) {
+    this.config.flags = merge(this.config.flags, flags);
+    return this;
+  }
+
+  public addNotify(notify: Notifications | Notifications[]) {
+    this.config.notify = notify;
+    return this;
+  }
+
+  public addMiddlewares(middlewares: any) {
+    this.config.middlewares = merge(this.config.middlewares, middlewares);
+    return this;
+  }
+
+  public addFilters(filters: any) {
+    this.config.filters = merge(this.config.filters, filters);
+    return this;
+  }
+
+  public addMaxBodySize(maxBodySize: string) {
+    this.config.max_body_size = maxBodySize;
+    return this;
+  }
+
+  public addUserRateLimit(rateLimit: RateLimit) {
+    this.config.userRateLimit = merge(this.config.userRateLimit, rateLimit);
+    return this;
+  }
+
+  public addUrlPrefix(urlPrefix: string) {
+    this.config.url_prefix = urlPrefix;
+    return this;
+  }
+
+  public addI18n(i18n: ConfigYaml['i18n']) {
+    this.config.i18n = i18n;
     return this;
   }
 

--- a/packages/config/src/builder.ts
+++ b/packages/config/src/builder.ts
@@ -135,6 +135,36 @@ export default class ConfigBuilder {
     return this;
   }
 
+  public addUserAgent(userAgent: string) {
+    this.config.user_agent = userAgent;
+    return this;
+  }
+
+  public addHttpProxy(httpProxy: string) {
+    this.config.http_proxy = httpProxy;
+    return this;
+  }
+
+  public addHttpsProxy(httpsProxy: string) {
+    this.config.https_proxy = httpsProxy;
+    return this;
+  }
+
+  public addNoProxy(noProxy: string) {
+    this.config.no_proxy = noProxy;
+    return this;
+  }
+
+  public addPlugins(plugins: string) {
+    this.config.plugins = plugins;
+    return this;
+  }
+
+  public addNotifications(notifications: Notifications) {
+    this.config.notifications = notifications;
+    return this;
+  }
+
   public getConfig(): ConfigYaml {
     return this.config;
   }

--- a/packages/config/test/builder.spec.ts
+++ b/packages/config/test/builder.spec.ts
@@ -123,4 +123,227 @@ describe('Config builder', () => {
       storage: '/tmp/verdaccio',
     });
   });
+
+  test('constructor should not mutate initial config values', () => {
+    // @ts-expect-error
+    const config = ConfigBuilder.build({ security: { api: { legacy: true } } });
+    expect(config.getConfig().security).toEqual({ api: { legacy: true } });
+  });
+
+  test('should add web configuration', () => {
+    const config = ConfigBuilder.build().addWeb({ title: 'My Registry', primaryColor: '#4b5e40' });
+    expect(config.getConfig().web).toEqual({
+      title: 'My Registry',
+      primaryColor: '#4b5e40',
+    });
+  });
+
+  test('should merge web configuration', () => {
+    const config = ConfigBuilder.build()
+      .addWeb({ title: 'My Registry' })
+      .addWeb({ darkMode: true });
+    expect(config.getConfig().web).toEqual({
+      title: 'My Registry',
+      darkMode: true,
+    });
+  });
+
+  test('should add listen address', () => {
+    const config = ConfigBuilder.build().addListen({ 0: 'localhost:4873' });
+    expect(config.getConfig().listen).toEqual({ 0: 'localhost:4873' });
+  });
+
+  test('should add https configuration', () => {
+    const config = ConfigBuilder.build().addHttps({
+      key: '/path/to/key.pem',
+      cert: '/path/to/cert.pem',
+    });
+    expect(config.getConfig().https).toEqual({
+      key: '/path/to/key.pem',
+      cert: '/path/to/cert.pem',
+    });
+  });
+
+  test('should add publish options', () => {
+    const config = ConfigBuilder.build().addPublish({ allow_offline: true, check_owners: false });
+    expect(config.getConfig().publish).toEqual({
+      allow_offline: true,
+      check_owners: false,
+    });
+  });
+
+  test('should add flags configuration', () => {
+    const config = ConfigBuilder.build().addFlags({ changePassword: true, createUser: true });
+    expect(config.getConfig().flags).toEqual({
+      changePassword: true,
+      createUser: true,
+    });
+  });
+
+  test('should merge flags configuration', () => {
+    const config = ConfigBuilder.build()
+      .addFlags({ changePassword: true })
+      .addFlags({ createUser: true });
+    expect(config.getConfig().flags).toEqual({
+      changePassword: true,
+      createUser: true,
+    });
+  });
+
+  test('should add notifications', () => {
+    const notification = { endpoint: 'https://hooks.example.com', content: '{"text": "{{name}}"}' };
+    const config = ConfigBuilder.build().addNotify(notification);
+    expect(config.getConfig().notify).toEqual(notification);
+  });
+
+  test('should add multiple notifications as array', () => {
+    const notifications = [
+      { endpoint: 'https://hooks.example.com/1', content: '{"text": "{{name}}"}' },
+      { endpoint: 'https://hooks.example.com/2', content: '{"text": "{{name}}"}' },
+    ];
+    const config = ConfigBuilder.build().addNotify(notifications);
+    expect(config.getConfig().notify).toEqual(notifications);
+  });
+
+  test('should add middlewares', () => {
+    const config = ConfigBuilder.build().addMiddlewares({ audit: { enabled: true } });
+    expect(config.getConfig().middlewares).toEqual({ audit: { enabled: true } });
+  });
+
+  test('should add filters', () => {
+    const config = ConfigBuilder.build().addFilters({ 'storage-filter': { enabled: true } });
+    expect(config.getConfig().filters).toEqual({ 'storage-filter': { enabled: true } });
+  });
+
+  test('should merge filters configuration', () => {
+    const config = ConfigBuilder.build()
+      .addFilters({ 'filter-a': { enabled: true } })
+      .addFilters({ 'filter-b': { enabled: false } });
+    expect(config.getConfig().filters).toEqual({
+      'filter-a': { enabled: true },
+      'filter-b': { enabled: false },
+    });
+  });
+
+  test('should add max body size', () => {
+    const config = ConfigBuilder.build().addMaxBodySize('50mb');
+    expect(config.getConfig().max_body_size).toBe('50mb');
+  });
+
+  test('should add user rate limit', () => {
+    const config = ConfigBuilder.build().addUserRateLimit({ windowMs: 60000, max: 100 });
+    expect(config.getConfig().userRateLimit).toEqual({ windowMs: 60000, max: 100 });
+  });
+
+  test('should add url prefix', () => {
+    const config = ConfigBuilder.build().addUrlPrefix('/verdaccio/');
+    expect(config.getConfig().url_prefix).toBe('/verdaccio/');
+  });
+
+  test('should add i18n configuration', () => {
+    const config = ConfigBuilder.build().addI18n({ web: 'en-US' });
+    expect(config.getConfig().i18n).toEqual({ web: 'en-US' });
+  });
+
+  test('should chain all new methods together', () => {
+    const config = ConfigBuilder.build()
+      .addStorage('/tmp/verdaccio')
+      .addAuth({ htpasswd: { file: '.htpasswd' } })
+      .addUplink('npmjs', { url: 'https://registry.npmjs.org/' })
+      .addPackageAccess('**', { access: '$all', publish: '$authenticated', proxy: 'npmjs' })
+      .addWeb({ title: 'My Registry' })
+      .addFlags({ changePassword: true })
+      .addPublish({ allow_offline: false, check_owners: true })
+      .addMaxBodySize('100mb')
+      .addUrlPrefix('/registry/')
+      .addUserRateLimit({ windowMs: 60000, max: 200 })
+      .addI18n({ web: 'en-US' })
+      .addLogger({ level: 'warn', type: 'stdout', format: 'pretty' });
+
+    const result = config.getConfig();
+    expect(result.storage).toBe('/tmp/verdaccio');
+    expect(result.web).toEqual({ title: 'My Registry' });
+    expect(result.flags).toEqual({ changePassword: true });
+    expect(result.publish).toEqual({ allow_offline: false, check_owners: true });
+    expect(result.max_body_size).toBe('100mb');
+    expect(result.url_prefix).toBe('/registry/');
+    expect(result.userRateLimit).toEqual({ windowMs: 60000, max: 200 });
+    expect(result.i18n).toEqual({ web: 'en-US' });
+  });
+
+  test('should build a full configuration using all builder methods', () => {
+    const config = ConfigBuilder.build()
+      .addStorage('./storage')
+      .addSecurity({
+        api: {
+          jwt: {
+            sign: { expiresIn: '7d' },
+            verify: {},
+          },
+          legacy: false,
+        },
+        web: {
+          sign: { expiresIn: '1h' },
+          verify: {},
+        },
+      })
+      .addWeb({
+        title: 'Test Registry',
+        darkMode: true,
+        showInfo: false,
+        primaryColor: '#000000',
+      })
+      .addAuth({
+        'custom-auth-plugin': {
+          enabled: true,
+        },
+      })
+      .addStorage({
+        'custom-storage-plugin': {
+          bucket: 'test-bucket',
+          region: 'us-east-1',
+        },
+      })
+      .addMiddlewares({
+        'custom-middleware': {
+          enabled: true,
+        },
+      })
+      .addPackageAccess('@scope/public-pkg', {
+        access: ['$all'],
+        publish: ['$authenticated'],
+        unpublish: ['$authenticated'],
+      })
+      .addPackageAccess('@scope/*', {
+        access: ['$authenticated'],
+        publish: ['$authenticated'],
+        unpublish: ['$authenticated'],
+      })
+      .addLogger({ type: 'stdout', format: 'pretty', level: 'warn' })
+      .addI18n({ web: 'en-US' });
+
+    const result = config.getConfig();
+    expect(result.store).toEqual({
+      'custom-storage-plugin': {
+        bucket: 'test-bucket',
+        region: 'us-east-1',
+      },
+    });
+    expect(result.security.api).toEqual({
+      jwt: { sign: { expiresIn: '7d' }, verify: {} },
+      legacy: false,
+    });
+    expect(result.web?.title).toBe('Test Registry');
+    expect(result.web?.primaryColor).toBe('#000000');
+    expect(result.auth).toEqual({
+      'custom-auth-plugin': { enabled: true },
+    });
+    expect(result.middlewares).toEqual({
+      'custom-middleware': { enabled: true },
+    });
+    expect(result.packages).toHaveProperty('@scope/public-pkg');
+    expect(result.packages).toHaveProperty('@scope/*');
+    expect(result.i18n).toEqual({ web: 'en-US' });
+    expect(result.log).toEqual({ type: 'stdout', format: 'pretty', level: 'warn' });
+  });
 });

--- a/packages/config/test/builder.spec.ts
+++ b/packages/config/test/builder.spec.ts
@@ -245,6 +245,42 @@ describe('Config builder', () => {
     expect(config.getConfig().i18n).toEqual({ web: 'en-US' });
   });
 
+  test('should add user agent', () => {
+    const config = ConfigBuilder.build().addUserAgent('verdaccio/6.0.0');
+    expect(config.getConfig().user_agent).toBe('verdaccio/6.0.0');
+  });
+
+  test('should add http proxy', () => {
+    const config = ConfigBuilder.build().addHttpProxy('http://proxy.example.com:8080');
+    expect(config.getConfig().http_proxy).toBe('http://proxy.example.com:8080');
+  });
+
+  test('should add https proxy', () => {
+    const config = ConfigBuilder.build().addHttpsProxy('https://proxy.example.com:8443');
+    expect(config.getConfig().https_proxy).toBe('https://proxy.example.com:8443');
+  });
+
+  test('should add no proxy', () => {
+    const config = ConfigBuilder.build().addNoProxy('localhost,127.0.0.1');
+    expect(config.getConfig().no_proxy).toBe('localhost,127.0.0.1');
+  });
+
+  test('should add plugins directory', () => {
+    const config = ConfigBuilder.build().addPlugins('/opt/verdaccio/plugins');
+    expect(config.getConfig().plugins).toBe('/opt/verdaccio/plugins');
+  });
+
+  test('should add notifications configuration', () => {
+    const config = ConfigBuilder.build().addNotifications({
+      endpoint: 'https://notify.example.com',
+      content: '{"msg": "package published"}',
+    });
+    expect(config.getConfig().notifications).toEqual({
+      endpoint: 'https://notify.example.com',
+      content: '{"msg": "package published"}',
+    });
+  });
+
   test('should chain all new methods together', () => {
     const config = ConfigBuilder.build()
       .addStorage('/tmp/verdaccio')


### PR DESCRIPTION
extend ConfigBuilder with methods for web, listen, https, publish, flags, notify, middlewares, filters, maxBodySize, userRateLimit, urlPrefix, and i18n