### PR TITLE
fix: add debug dependency to ui-theme

### DIFF
--- a/.changeset/add-debug-dep-ui-theme.md
+++ b/.changeset/add-debug-dep-ui-theme.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-theme': patch
+---
+
+Add debug dependency to ui-theme

--- a/packages/plugins/ui-theme/package.json
+++ b/packages/plugins/ui-theme/package.json
@@ -16,6 +16,9 @@
   },
   "homepage": "https://verdaccio.org",
   "main": "index.js",
+  "dependencies": {
+    "debug": "4.4.3"
+  },
   "devDependencies": {
     "@mui/material": "7.3.9",
     "@testing-library/dom": "10.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -895,6 +895,10 @@ importers:
         version: link:../../core/types
 
   packages/plugins/ui-theme:
+    dependencies:
+      debug:
+        specifier: 4.4.3
+        version: 4.4.3(supports-color@5.5.0)
     devDependencies:
       '@mui/material':
         specifier: 7.3.9


### PR DESCRIPTION
Context: https://github.com/verdaccio/verdaccio/pull/5608/changes#diff-4165d575000d6716c1bc676b1ac0c2177697a048d27770bbef18fd435f8b2637