### PR TITLE
fix: avoid sharing default security object across configs

### DIFF
--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -5,8 +5,8 @@ import { Config, Security } from '@verdaccio/types';
 
 export function getSecurity(config: Config): Security {
   if (_.isNil(config.security) === false) {
-    return _.merge(defaultSecurity, config.security);
+    return _.merge({}, defaultSecurity, config.security);
   }
 
-  return defaultSecurity;
+  return _.merge({}, defaultSecurity);
 }

--- a/test/unit/modules/auth/auth-utils.spec.ts
+++ b/test/unit/modules/auth/auth-utils.spec.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, test } from 'vitest';
+
+import { defaultSecurity } from '@verdaccio/config';
+
+import { getSecurity } from '../../../../src/lib/auth-utils';
+
+describe('getSecurity', () => {
+  const originalExpires = defaultSecurity.web.sign.expiresIn;
+  const originalLegacy = defaultSecurity.api.legacy;
+  afterEach(() => {
+    defaultSecurity.web.sign.expiresIn = originalExpires;
+    defaultSecurity.api.legacy = originalLegacy;
+  });
+
+  test('returns defaults when config.security is nil', () => {
+    const security = getSecurity({} as any);
+    expect(security.web.sign.expiresIn).toBe(originalExpires);
+    expect(security.api.legacy).toBe(originalLegacy);
+  });
+
+  test('merges config.security on top of defaults', () => {
+    const security = getSecurity({
+      security: { web: { sign: { expiresIn: '24h' } } },
+    } as any);
+    expect(security.web.sign.expiresIn).toBe('24h');
+    expect(security.api.legacy).toBe(originalLegacy);
+  });
+
+  test('does not mutate the shared defaultSecurity', () => {
+    getSecurity({
+      security: { web: { sign: { expiresIn: '24h' } } },
+    } as any);
+    expect(defaultSecurity.web.sign.expiresIn).toBe(originalExpires);
+  });
+
+  test('returned object does not alias defaultSecurity', () => {
+    const withConfig = getSecurity({
+      security: { web: { sign: { expiresIn: '24h' } } },
+    } as any);
+    const withoutConfig = getSecurity({} as any);
+
+    expect(withConfig).not.toBe(defaultSecurity);
+    expect(withConfig.web).not.toBe(defaultSecurity.web);
+    expect(withConfig.web.sign).not.toBe(defaultSecurity.web.sign);
+
+    expect(withoutConfig).not.toBe(defaultSecurity);
+    expect(withoutConfig.web).not.toBe(defaultSecurity.web);
+  });
+
+  test('successive calls do not leak state between configs', () => {
+    getSecurity({
+      security: { web: { sign: { expiresIn: '7d' } } },
+    } as any);
+    const laterCall = getSecurity({} as any);
+    expect(laterCall.web.sign.expiresIn).toBe(originalExpires);
+  });
+});


### PR DESCRIPTION
This pull request improves the handling of the `defaultSecurity` configuration in the `getSecurity` utility and adds comprehensive unit tests to ensure its correctness. The changes ensure that the `defaultSecurity` object is not mutated or aliased, preventing unintended side effects across different parts of the application.

**Security configuration handling:**

* Updated the `getSecurity` function in `auth-utils.ts` to always return a deep-merged copy of `defaultSecurity` rather than modifying or referencing the original object, ensuring immutability and preventing accidental mutations.

**Testing improvements:**

* Added a new test suite in `auth-utils.spec.ts` to verify that `getSecurity` merges configuration correctly, does not mutate or alias `defaultSecurity`, and does not leak state between calls.