### PR TITLE
fix: remove basic header on 401 #5814

### DIFF
--- a/.changeset/fix-web-login-auth-popup.md
+++ b/.changeset/fix-web-login-auth-popup.md
@@ -1,0 +1,11 @@
+---
+'@verdaccio/web': patch
+---
+
+fix: prevent browser basic auth popup on WebUI login failure
+
+Set WWW-Authenticate header to Bearer only (excluding Basic) on 401 responses
+from the WebUI login endpoint, so browsers do not show a native authentication
+popup when credentials are invalid.
+
+Closes #5814

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
           path: cypress/videos
           if-no-files-found: ignore
   changeset-validation:
-    needs: prepare
+    needs: [build]
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     name: Changeset validation
@@ -307,7 +307,7 @@ jobs:
       - name: Run changeset version
         run: pnpm ci:version:changeset
   codeql:
-    needs: prepare
+    needs: [build]
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     name: CodeQL Analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
           path: cypress/videos
           if-no-files-found: ignore
   changeset-validation:
-    needs: [test, e2e-cli, e2e-ui]
+    needs: prepare
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     name: Changeset validation
@@ -307,7 +307,7 @@ jobs:
       - name: Run changeset version
         run: pnpm ci:version:changeset
   codeql:
-    needs: [test, e2e-cli, e2e-ui]
+    needs: prepare
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && always() && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     name: CodeQL Analysis
@@ -360,7 +360,7 @@ jobs:
           CONTEXT: production
         run: pnpm crowdin:sync
   cleanup:
-    needs: [test, e2e-cli, e2e-ui, codeql, changeset-validation]
+    needs: [test, e2e-cli, e2e-ui]
     if: always()
     runs-on: ubuntu-latest
     name: Cleanup caches

--- a/packages/web/src/api/user.ts
+++ b/packages/web/src/api/user.ts
@@ -10,6 +10,7 @@ import {
   APP_ERROR,
   HEADERS,
   HTTP_STATUS,
+  TOKEN_BEARER,
   cryptoUtils,
   errorUtils,
   validationUtils,
@@ -38,12 +39,18 @@ function addUserAuthApi(auth: Auth, config: Config, storage: Storage): Router {
           if (err) {
             const errorCode = err.message ? HTTP_STATUS.UNAUTHORIZED : HTTP_STATUS.INTERNAL_ERROR;
             debug('error authenticate %o', errorCode);
-            next(errorUtils.getCode(errorCode, err.message));
+            // Prevent the final middleware from adding WWW-Authenticate header,
+            // which triggers the browser's native basic auth popup instead of
+            // letting the WebUI handle the error in JavaScript.
+            if (errorCode === HTTP_STATUS.UNAUTHORIZED) {
+              res.set(HEADERS.WWW_AUTH, TOKEN_BEARER);
+            }
+            return next(errorUtils.getCode(errorCode, err.message));
           } else {
             req.remote_user = user as RemoteUser;
             const jWTSignOptions: JWTSignOptions = config.security.web.sign;
             res.set(HEADERS.CACHE_CONTROL, HEADERS.NO_CACHE);
-            next({
+            return next({
               token: await auth.jwtEncrypt(user as RemoteUser, jWTSignOptions),
               username: req.remote_user.name,
             });

--- a/packages/web/test/api.user.test.ts
+++ b/packages/web/test/api.user.test.ts
@@ -46,6 +46,9 @@ describe('test web server', () => {
       .expect(HTTP_STATUS.UNAUTHORIZED)
       .then((response) => {
         expect(response.body.error).toEqual(API_ERROR.BAD_USERNAME_PASSWORD);
+        // WWW-Authenticate must not include Basic, otherwise browsers
+        // show a native auth popup instead of letting the WebUI handle the error
+        expect(response.headers['www-authenticate']).toBe('Bearer');
       });
   });
 


### PR DESCRIPTION
## Summary

Fixes #5814

The `final` middleware adds `WWW-Authenticate: Basic, Bearer` to all 401 responses. When the WebUI login fails behind a reverse proxy (e.g. K3s Traefik ingress), the proxy intercepts the `Basic` challenge and triggers the browser's native auth popup instead of letting the WebUI show the error inline.

Fix: set `WWW-Authenticate: Bearer` on the web login 401, preventing `Basic` from being added. Browsers don't prompt for `Bearer`.

**Note:** Not reproducible with Chrome alone (Chrome ignores `Basic` on fetch/XHR). Requires a reverse proxy that intercepts 401 + `Basic` challenges.