### PR TITLE
fix: login refresh, SWR polling, and auto-generate github-markdown CSS

### DIFF
--- a/.changeset/fix-login-refresh-and-swr-polling.md
+++ b/.changeset/fix-login-refresh-and-swr-polling.md
@@ -1,0 +1,9 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+fix: save auth token synchronously before navigation on login to ensure package list refreshes with authenticated access
+
+Disable SWR revalidateOnFocus and revalidateOnReconnect to prevent unnecessary repeated API calls
+
+Closes #5813

--- a/.github/actions/build-app/action.yml
+++ b/.github/actions/build-app/action.yml
@@ -5,7 +5,7 @@ inputs:
   registry-url:
     description: 'Registry URL for pnpm'
     required: false
-    default: 'http://localhost:4873'
+    default: 'https://registry.npmjs.org'
   node-version:
     description: 'Node.js version to use'
     required: true

--- a/.github/actions/install-app-node/action.yml
+++ b/.github/actions/install-app-node/action.yml
@@ -5,7 +5,7 @@ inputs:
   registry-url:
     description: 'Registry URL for pnpm'
     required: false
-    default: 'http://localhost:4873'
+    default: 'https://registry.npmjs.org'
   reporter:
     description: 'Reporter for pnpm'
     required: false
@@ -21,31 +21,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Use Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: ${{ inputs.node-version }}
     - name: Install pnpm
       run: |
         npm install --global corepack@latest
         corepack enable
         corepack prepare
       shell: bash
-    - name: set store
-      run: |
-        if [ ! -d "$HOME/.pnpm-store" ]; then
-          mkdir -p $HOME/.pnpm-store
-          pnpm config set store-dir $HOME/.pnpm-store
-        else
-          echo "Store directory already exists. Skipping configuration."
-        fi
-      shell: bash
-    - name: Restore cache pnpm store
-      uses: ./.github/actions/cache-store
+    - name: Use Node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'pnpm'
     - name: Install
       run: pnpm install --reporter=${{inputs.reporter}} --ignore-scripts --registry ${{ inputs.registry-url }} --loglevel=${{ inputs.loglevel }}
       shell: bash
-    - name: Save cache pnpm store
-      if: steps.cache-npm.outputs.cache-hit == 'false'
-      uses: ./.github/actions/cache-store
-

--- a/.github/actions/install-app/action.yml
+++ b/.github/actions/install-app/action.yml
@@ -5,7 +5,7 @@ inputs:
   registry-url:
     description: 'Registry URL for pnpm'
     required: false
-    default: 'http://localhost:4873'
+    default: 'https://registry.npmjs.org'
   reporter:
     description: 'Reporter for pnpm'
     required: false
@@ -14,27 +14,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Use Node
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version-file: '.nvmrc'
     - name: Install pnpm
       run: |
         npm install --global corepack@latest
         corepack enable
         corepack prepare
       shell: bash
-    - name: set store
-      run: |
-        mkdir ~/.pnpm-store
-        pnpm config set store-dir ~/.pnpm-store
-      shell: bash
-    - name: Restore cache pnpm store
-      uses: ./.github/actions/cache-store
+    - name: Use Node
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'pnpm'
     - name: Install
       run: pnpm install --reporter=${{inputs.reporter}} --ignore-scripts --registry ${{ inputs.registry-url }}
       shell: bash
-    - name: Save cache pnpm store
-      if: steps.cache-npm.outputs.cache-hit == 'false'
-      uses: ./.github/actions/cache-store
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,33 +43,11 @@ jobs:
           fetch-depth: 0
       - name: Check changeset
         uses: ./.github/actions/changeset-check        
-  prepare:
-    needs: [changeset-check]
-    # Avoid running on draft PRs; always() allows this to proceed when changeset-check is skipped (Renovate)
-    if: ${{ always() && !failure() && !cancelled() && github.event.pull_request.draft == false }}
-    runs-on: ubuntu-latest
-    name: setup
-    services:
-      verdaccio:
-        image: verdaccio/verdaccio:6
-        ports:
-          - 4873:4873
-        env:
-          NODE_ENV: production
-          options: >-
-            --health-cmd="curl -f http://0.0.0.0:4873/-/ping || exit 1"
-            --health-interval=10s
-            --health-timeout=20s
-            --health-retries=6
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install dependencies via Verdaccio registry
-        uses: ./.github/actions/install-app
   lint-and-format:
     runs-on: ubuntu-latest
     name: Lint & Format
-    needs: prepare
-    if: ${{ always() && !failure() && !cancelled() }}
+    needs: [changeset-check]
+    if: ${{ always() && !failure() && !cancelled() && github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install dependencies
@@ -351,7 +329,7 @@ jobs:
           pnpm config set store-dir ~/.pnpm-store
       - name: Install
         ## we need scripts, pupetter downloads aditional content
-        run: pnpm install --registry http://localhost:4873
+        run: pnpm install --registry https://registry.npmjs.org
       - name: build
         run: pnpm build
       - name: sync

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ packages/standalone/dist/
 
 ## ui
 packages/plugins/ui-theme/static
+packages/ui-components/src/components/Readme/github-markdown.css
 /packages/plugins/ui-theme/src/i18n/download_translations/
 !/packages/plugins/ui-theme/src/i18n/crowdin/ui.json
 /packages/core/**/download_translations/

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -26,9 +26,10 @@
     "clean": "rimraf ./build",
     "type-check": "tsc --noEmit -p tsconfig.build.json",
     "watch": "vite build --watch",
-    "build": "vite build",
+    "build": "node tools/generate-github-markdown.mjs && vite build",
     "start": "cross-env BROWSER=none storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "generate:github-markdown-css": "node tools/generate-github-markdown.mjs"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",
@@ -76,6 +77,7 @@
     "@vitejs/plugin-react": "6.0.1",
     "eslint-plugin-storybook": "10.2.17",
     "eslint-plugin-verdaccio": "10.0.0",
+    "generate-github-markdown-css": "^6.6.0",
     "jsdom": "28.1.0",
     "mockdate": "3.0.5",
     "msw": "2.12.10",

--- a/packages/ui-components/src/components/AppRoute/AppRoute.tsx
+++ b/packages/ui-components/src/components/AppRoute/AppRoute.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Outlet, Route as RouterRoute, Routes } from 'react-router';
+import { SWRConfig } from 'swr';
 
 import { ManifestsProvider, VersionProvider } from '../../providers';
 import { useConfig } from '../../providers/AppConfigurationProvider/AppConfigurationProvider';
@@ -25,29 +26,31 @@ const AppRoute: React.FC = () => {
   const createUserEnabled = configOptions?.flags?.createUser;
   const changePasswordEnabled = configOptions?.flags?.changePassword;
   return (
-    <Routes>
-      <RouterRoute
-        element={
-          <ManifestsProvider>
-            <Front />
-          </ManifestsProvider>
-        }
-        path={Route.ROOT}
-      />
-      <RouterRoute element={versionElement} path={Route.SCOPE_PACKAGE_VERSION} />
-      <RouterRoute element={versionElement} path={Route.SCOPE_PACKAGE} />
-      <RouterRoute element={versionElement} path={Route.PACKAGE_VERSION} />
-      <RouterRoute element={versionElement} path={Route.PACKAGE} />
-      <RouterRoute element={<Outlet />}>
-        <RouterRoute element={<Login />} path={Route.LOGIN} />
-        <RouterRoute element={<Success />} path={Route.SUCCESS} />
-        {createUserEnabled && <RouterRoute element={<AddUser />} path={Route.ADD_USER} />}
-        {changePasswordEnabled && (
-          <RouterRoute element={<ChangePassword />} path={Route.CHANGE_PASSWORD} />
-        )}
-      </RouterRoute>
-      <RouterRoute element={<NotFound />} path="*" />
-    </Routes>
+    <SWRConfig value={{ revalidateOnFocus: false, revalidateOnReconnect: false }}>
+      <Routes>
+        <RouterRoute
+          element={
+            <ManifestsProvider>
+              <Front />
+            </ManifestsProvider>
+          }
+          path={Route.ROOT}
+        />
+        <RouterRoute element={versionElement} path={Route.SCOPE_PACKAGE_VERSION} />
+        <RouterRoute element={versionElement} path={Route.SCOPE_PACKAGE} />
+        <RouterRoute element={versionElement} path={Route.PACKAGE_VERSION} />
+        <RouterRoute element={versionElement} path={Route.PACKAGE} />
+        <RouterRoute element={<Outlet />}>
+          <RouterRoute element={<Login />} path={Route.LOGIN} />
+          <RouterRoute element={<Success />} path={Route.SUCCESS} />
+          {createUserEnabled && <RouterRoute element={<AddUser />} path={Route.ADD_USER} />}
+          {changePasswordEnabled && (
+            <RouterRoute element={<ChangePassword />} path={Route.CHANGE_PASSWORD} />
+          )}
+        </RouterRoute>
+        <RouterRoute element={<NotFound />} path="*" />
+      </Routes>
+    </SWRConfig>
   );
 };
 

--- a/packages/ui-components/src/components/LoginDialog/LoginDialog.test.tsx
+++ b/packages/ui-components/src/components/LoginDialog/LoginDialog.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { vi } from 'vitest';
 
+import storage from '../../store/storage';
 import {
   act,
   cleanup,
@@ -16,6 +17,8 @@ describe('<LoginDialog /> component', () => {
     vi.resetModules();
     vi.resetAllMocks();
     cleanup();
+    storage.removeItem('token');
+    storage.removeItem('username');
   });
 
   test('should render the component in default state', () => {
@@ -100,6 +103,37 @@ describe('<LoginDialog /> component', () => {
       fireEvent.click(signInButton);
     });
     expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('should save auth token after successful login', async () => {
+    const props = {
+      open: true,
+      onClose: vi.fn(),
+    };
+
+    await act(async () => {
+      renderWithRouter(<LoginDialog onClose={props.onClose} open={props.open} />, '/login', [
+        '/login',
+      ]);
+    });
+
+    const usernameInput = screen.getByPlaceholderText('form-placeholder.username');
+    const passwordInput = screen.getByPlaceholderText('form-placeholder.password');
+
+    await act(async () => {
+      fireEvent.change(usernameInput, { target: { value: 'testuser' } });
+      fireEvent.change(passwordInput, { target: { value: 'testpass' } });
+    });
+
+    const signInButton = screen.getByTestId('login-dialog-form-login-button');
+    await act(async () => {
+      fireEvent.click(signInButton);
+    });
+
+    await waitFor(() => {
+      expect(storage.getItem('token')).toBe('valid-mock-token');
+      expect(storage.getItem('username')).toBe('testuser');
+    });
   });
 
   test.todo('validateCredentials: should validate credentials');

--- a/packages/ui-components/src/components/Readme/github-markdown.css
+++ b/packages/ui-components/src/components/Readme/github-markdown.css
@@ -1,40 +1,119 @@
-/* Ensure monospace for combination with highlight.js */
+/* Auto-generated — do not edit. Run: node tools/generate-github-markdown.mjs */
 
+/* Ensure monospace for combination with highlight.js */
 .markdown-body pre code span {
   font-family: monospace;
 }
 
-/* Output from https://github.com/sindresorhus/generate-github-markdown-css without media selectors and transparent background */
-
-.markdown-body {
+/* Light theme variables */
+[data-theme='light'].markdown-body {
   --base-size-16: 1rem;
   --base-size-24: 1.5rem;
-  --base-size-4: 0.25rem;
+  --base-size-4: .25rem;
   --base-size-40: 2.5rem;
-  --base-size-8: 0.5rem;
+  --base-size-8: .5rem;
   --base-text-weight-medium: 500;
   --base-text-weight-normal: 400;
   --base-text-weight-semibold: 600;
-  --borderWidth-thin: 0.0625rem;
+  --borderWidth-thin: .0625rem;
   --borderRadius-full: 624.938rem;
-  --borderRadius-medium: 0.375rem;
-  --stack-padding-condensed: 0.5rem;
+  --borderRadius-medium: .375rem;
+  --stack-padding-condensed: .5rem;
   --stack-padding-normal: 1rem;
-  --fontStack-monospace: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono,
-    monospace;
-  --fontStack-sansSerif: 'Mona Sans VF', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans',
-    Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
+  --fontStack-monospace: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+  --fontStack-sansSerif: "Mona Sans VF",-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
   --text-body-size-small: var(--base-text-size-xs);
-  --h6-size: 0.75rem;
+  --h6-size: .75rem;
   --fgColor-accent: Highlight;
 }
+
+[data-theme='light'].markdown-body {
+  /* light */
+  color-scheme: light;
+  --fgColor-danger: #d1242f;
+  --bgColor-attention-muted: #fff8c5;
+  --bgColor-muted: #f6f8fa;
+  --bgColor-neutral-muted: #818b981f;
+  --borderColor-accent-emphasis: #0969da;
+  --borderColor-attention-emphasis: #9a6700;
+  --borderColor-attention-muted: #d4a72c66;
+  --borderColor-danger-emphasis: #cf222e;
+  --borderColor-default: #d1d9e0;
+  --borderColor-done-emphasis: #8250df;
+  --borderColor-success-emphasis: #1a7f37;
+  --color-prettylights-syntax-brackethighlighter-angle: #59636e;
+  --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
+  --color-prettylights-syntax-carriage-return-bg: #cf222e;
+  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
+  --color-prettylights-syntax-comment: #59636e;
+  --color-prettylights-syntax-constant: #0550ae;
+  --color-prettylights-syntax-constant-other-reference-link: #0a3069;
+  --color-prettylights-syntax-entity: #6639ba;
+  --color-prettylights-syntax-entity-tag: #0550ae;
+  --color-prettylights-syntax-invalid-illegal-text: var(--fgColor-danger);
+  --color-prettylights-syntax-keyword: #cf222e;
+  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
+  --color-prettylights-syntax-markup-changed-text: #953800;
+  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
+  --color-prettylights-syntax-markup-deleted-text: #82071e;
+  --color-prettylights-syntax-markup-heading: #0550ae;
+  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
+  --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
+  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
+  --color-prettylights-syntax-markup-inserted-text: #116329;
+  --color-prettylights-syntax-markup-list: #3b2300;
+  --color-prettylights-syntax-meta-diff-range: #8250df;
+  --color-prettylights-syntax-string: #0a3069;
+  --color-prettylights-syntax-string-regexp: #116329;
+  --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
+  --color-prettylights-syntax-variable: #953800;
+  --fgColor-accent: #0969da;
+  --fgColor-attention: #9a6700;
+  --fgColor-done: #8250df;
+  --fgColor-muted: #59636e;
+  --fgColor-success: #1a7f37;
+  --bgColor-default: transparent;
+  --borderColor-muted: #d1d9e0b3;
+  --color-prettylights-syntax-invalid-illegal-bg: var(--bgColor-danger-muted);
+  --color-prettylights-syntax-markup-bold: #1f2328;
+  --color-prettylights-syntax-markup-italic: #1f2328;
+  --color-prettylights-syntax-storage-modifier-import: #1f2328;
+  --fgColor-default: #1f2328;
+  --selection-bgColor: #0969da33;
+  --borderColor-neutral-muted: var(--borderColor-muted);
+  --focus-outlineColor: var(--focus-outline-color);
+}
+
+
+/* Dark theme variables */
 [data-theme='dark'].markdown-body {
-  /* dark — bg tokens align with Theme/modes.ts (paper #2d3748, default #1a202c) */
+  --base-size-16: 1rem;
+  --base-size-24: 1.5rem;
+  --base-size-4: .25rem;
+  --base-size-40: 2.5rem;
+  --base-size-8: .5rem;
+  --base-text-weight-medium: 500;
+  --base-text-weight-normal: 400;
+  --base-text-weight-semibold: 600;
+  --borderWidth-thin: .0625rem;
+  --borderRadius-full: 624.938rem;
+  --borderRadius-medium: .375rem;
+  --stack-padding-condensed: .5rem;
+  --stack-padding-normal: 1rem;
+  --fontStack-monospace: ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace;
+  --fontStack-sansSerif: "Mona Sans VF",-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  --text-body-size-small: var(--base-text-size-xs);
+  --h6-size: .75rem;
+  --fgColor-accent: Highlight;
+}
+
+[data-theme='dark'].markdown-body {
+  /* dark */
   color-scheme: dark;
   --fgColor-accent: #4493f8;
   --bgColor-attention-muted: #bb800926;
-  --bgColor-default: #2d3748;
-  --bgColor-muted: #1a202c;
+  --bgColor-default: transparent;
+  --bgColor-muted: #151b23;
   --bgColor-neutral-muted: #656c7633;
   --borderColor-accent-emphasis: #1f6feb;
   --borderColor-attention-emphasis: #9e6a03;
@@ -80,87 +159,21 @@
   --borderColor-muted: #3d444db3;
   --color-prettylights-syntax-invalid-illegal-bg: var(--bgColor-danger-muted);
   --color-prettylights-syntax-invalid-illegal-text: var(--fgColor-danger);
-  --focus-outlineColor: var(--borderColor-accent-emphasis);
   --selection-bgColor: #1f6febb3;
   --borderColor-neutral-muted: var(--borderColor-muted);
+  --focus-outlineColor: var(--focus-outline-color);
 }
 
-[data-theme='light'].markdown-body {
-  /* light */
-  color-scheme: light;
-  --fgColor-danger: #d1242f;
-  --bgColor-attention-muted: #fff8c5;
-  --bgColor-muted: darkgray;
-  --bgColor-neutral-muted: #818b981f;
-  --borderColor-accent-emphasis: #0969da;
-  --borderColor-attention-emphasis: #9a6700;
-  --borderColor-attention-muted: #d4a72c66;
-  --borderColor-danger-emphasis: #cf222e;
-  --borderColor-default: #d1d9e0;
-  --borderColor-done-emphasis: #8250df;
-  --borderColor-success-emphasis: #1a7f37;
-  --color-prettylights-syntax-brackethighlighter-angle: #59636e;
-  --color-prettylights-syntax-brackethighlighter-unmatched: #82071e;
-  --color-prettylights-syntax-carriage-return-bg: #cf222e;
-  --color-prettylights-syntax-carriage-return-text: #f6f8fa;
-  --color-prettylights-syntax-comment: #59636e;
-  --color-prettylights-syntax-constant: #0550ae;
-  --color-prettylights-syntax-constant-other-reference-link: #0a3069;
-  --color-prettylights-syntax-entity: #6639ba;
-  --color-prettylights-syntax-entity-tag: #0550ae;
-  --color-prettylights-syntax-invalid-illegal-text: var(--fgColor-danger);
-  --color-prettylights-syntax-keyword: #cf222e;
-  --color-prettylights-syntax-markup-changed-bg: #ffd8b5;
-  --color-prettylights-syntax-markup-changed-text: #953800;
-  --color-prettylights-syntax-markup-deleted-bg: #ffebe9;
-  --color-prettylights-syntax-markup-deleted-text: #82071e;
-  --color-prettylights-syntax-markup-heading: #0550ae;
-  --color-prettylights-syntax-markup-ignored-bg: #0550ae;
-  --color-prettylights-syntax-markup-ignored-text: #d1d9e0;
-  --color-prettylights-syntax-markup-inserted-bg: #dafbe1;
-  --color-prettylights-syntax-markup-inserted-text: #116329;
-  --color-prettylights-syntax-markup-list: #3b2300;
-  --color-prettylights-syntax-meta-diff-range: #8250df;
-  --color-prettylights-syntax-string: #0a3069;
-  --color-prettylights-syntax-string-regexp: #116329;
-  --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
-  --color-prettylights-syntax-variable: #953800;
-  --fgColor-accent: #0969da;
-  --fgColor-attention: #9a6700;
-  --fgColor-done: #8250df;
-  --fgColor-muted: #59636e;
-  --fgColor-success: #1a7f37;
-  --bgColor-default: #fff;
-  --borderColor-muted: #d1d9e0b3;
-  --color-prettylights-syntax-invalid-illegal-bg: var(--bgColor-danger-muted);
-  --color-prettylights-syntax-markup-bold: #1f2328;
-  --color-prettylights-syntax-markup-italic: #1f2328;
-  --color-prettylights-syntax-storage-modifier-import: #1f2328;
-  --fgColor-default: #1f2328;
-  --focus-outlineColor: var(--borderColor-accent-emphasis);
-  --selection-bgColor: #0969da33;
-  --borderColor-neutral-muted: var(--borderColor-muted);
-}
 
+/* Base styles */
 .markdown-body {
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
   margin: 0;
-  font-weight: var(--base-text-weight-normal, 400);
+  font-weight: var(--base-text-weight-normal,400);
   color: var(--fgColor-default);
   background-color: var(--bgColor-default);
-  font-family: var(
-    --fontStack-sansSerif,
-    -apple-system,
-    BlinkMacSystemFont,
-    'Segoe UI',
-    'Noto Sans',
-    Helvetica,
-    Arial,
-    sans-serif,
-    'Apple Color Emoji',
-    'Segoe UI Emoji'
-  );
+  font-family: var(--fontStack-sansSerif,-apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji");
   overflow-wrap: break-word;
   font-size: 16px;
   line-height: 1.5;
@@ -168,7 +181,7 @@
 
 .markdown-body a {
   text-decoration: underline;
-  text-underline-offset: 0.2rem;
+  text-underline-offset: .2rem;
 }
 
 .markdown-body .octicon {
@@ -203,7 +216,7 @@
 }
 
 .markdown-body [hidden] {
-  display: none !important;
+  display: none!important;
 }
 
 .markdown-body a {
@@ -220,7 +233,7 @@
 
 .markdown-body b,
 .markdown-body strong {
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
 }
 
 .markdown-body dfn {
@@ -228,10 +241,10 @@
 }
 
 .markdown-body h1 {
-  margin: 0.67em 0;
-  font-weight: var(--base-text-weight-semibold, 600);
+  margin: .67em 0;
+  font-weight: var(--base-text-weight-semibold,600);
   border-bottom: 1px solid var(--borderColor-muted);
-  padding-bottom: 0.3em;
+  padding-bottom: .3em;
   font-size: 2em;
 }
 
@@ -249,11 +262,11 @@
 }
 
 .markdown-body sub {
-  bottom: -0.25em;
+  bottom: -.25em;
 }
 
 .markdown-body sup {
-  top: -0.5em;
+  top: -.5em;
 }
 
 .markdown-body img {
@@ -279,8 +292,8 @@
   border-bottom: 1px solid var(--borderColor-muted);
   background: 0 0;
   overflow: hidden;
-  height: 0.25em;
-  margin: var(--base-size-24) 0;
+  height: .25em;
+  margin: var(--base-size-24)0;
   background-color: var(--borderColor-default);
   border: 0;
   padding: 0;
@@ -295,40 +308,40 @@
   line-height: inherit;
 }
 
-.markdown-body [type='button'],
-.markdown-body [type='reset'],
-.markdown-body [type='submit'] {
+.markdown-body [type=button],
+.markdown-body [type=reset],
+.markdown-body [type=submit] {
   -webkit-appearance: button;
   appearance: button;
 }
 
-.markdown-body [type='checkbox'],
-.markdown-body [type='radio'] {
+.markdown-body [type=checkbox],
+.markdown-body [type=radio] {
   box-sizing: border-box;
   padding: 0;
 }
 
-.markdown-body [type='number']::-webkit-inner-spin-button {
+.markdown-body [type=number]::-webkit-inner-spin-button {
   height: auto;
 }
 
-.markdown-body [type='number']::-webkit-outer-spin-button {
+.markdown-body [type=number]::-webkit-outer-spin-button {
   height: auto;
 }
 
-.markdown-body [type='search']::-webkit-search-cancel-button {
+.markdown-body [type=search]::-webkit-search-cancel-button {
   -webkit-appearance: none;
   appearance: none;
 }
 
-.markdown-body [type='search']::-webkit-search-decoration {
+.markdown-body [type=search]::-webkit-search-decoration {
   -webkit-appearance: none;
   appearance: none;
 }
 
 .markdown-body ::-webkit-input-placeholder {
   color: inherit;
-  opacity: 0.54;
+  opacity: .54;
 }
 
 .markdown-body ::-webkit-file-upload-button {
@@ -347,13 +360,13 @@
 }
 
 .markdown-body hr:before {
-  content: '';
+  content: "";
   display: table;
 }
 
 .markdown-body hr:after {
   clear: both;
-  content: '';
+  content: "";
   display: table;
 }
 
@@ -377,25 +390,25 @@
 }
 
 .markdown-body a:focus,
-.markdown-body [role='button']:focus,
-.markdown-body input[type='radio']:focus,
-.markdown-body input[type='checkbox']:focus {
+.markdown-body [role=button]:focus,
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=checkbox]:focus {
   outline: 2px solid var(--focus-outlineColor);
   outline-offset: -2px;
   box-shadow: none;
 }
 
 .markdown-body a:focus:not(:focus-visible),
-.markdown-body [role='button']:focus:not(:focus-visible),
-.markdown-body input[type='radio']:focus:not(:focus-visible),
-.markdown-body input[type='checkbox']:focus:not(:focus-visible) {
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body input[type=radio]:focus:not(:focus-visible),
+.markdown-body input[type=checkbox]:focus:not(:focus-visible) {
   outline: 1px solid #0000;
 }
 
 .markdown-body a:focus-visible,
-.markdown-body [role='button']:focus-visible,
-.markdown-body input[type='radio']:focus-visible,
-.markdown-body input[type='checkbox']:focus-visible {
+.markdown-body [role=button]:focus-visible,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus-visible {
   outline: 2px solid var(--focus-outlineColor);
   outline-offset: -2px;
   box-shadow: none;
@@ -403,26 +416,16 @@
 
 .markdown-body a:not([class]):focus,
 .markdown-body a:not([class]):focus-visible,
-.markdown-body input[type='radio']:focus,
-.markdown-body input[type='radio']:focus-visible,
-.markdown-body input[type='checkbox']:focus,
-.markdown-body input[type='checkbox']:focus-visible {
+.markdown-body input[type=radio]:focus,
+.markdown-body input[type=radio]:focus-visible,
+.markdown-body input[type=checkbox]:focus,
+.markdown-body input[type=checkbox]:focus-visible {
   outline-offset: 0;
 }
 
 .markdown-body kbd {
   padding: var(--base-size-4);
-  font: 11px
-    var(
-      --fontStack-monospace,
-      ui-monospace,
-      SFMono-Regular,
-      SF Mono,
-      Menlo,
-      Consolas,
-      Liberation Mono,
-      monospace
-    );
+  font: 11px var(--fontStack-monospace,ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace);
   color: var(--fgColor-default);
   vertical-align: middle;
   background-color: var(--bgColor-muted);
@@ -443,36 +446,36 @@
 .markdown-body h6 {
   margin-top: var(--base-size-24);
   margin-bottom: var(--base-size-16);
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
   line-height: 1.25;
 }
 
 .markdown-body h2 {
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
   border-bottom: 1px solid var(--borderColor-muted);
-  padding-bottom: 0.3em;
+  padding-bottom: .3em;
   font-size: 1.5em;
 }
 
 .markdown-body h3 {
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
   font-size: 1.25em;
 }
 
 .markdown-body h4 {
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
   font-size: 1em;
 }
 
 .markdown-body h5 {
-  font-weight: var(--base-text-weight-semibold, 600);
-  font-size: 0.875em;
+  font-weight: var(--base-text-weight-semibold,600);
+  font-size: .875em;
 }
 
 .markdown-body h6 {
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
   color: var(--fgColor-muted);
-  font-size: 0.85em;
+  font-size: .85em;
 }
 
 .markdown-body p {
@@ -487,7 +490,7 @@
 .markdown-body blockquote {
   margin: 0;
   color: var(--fgColor-muted);
-  border-left: 0.25em solid var(--borderColor-default);
+  border-left: .25em solid var(--borderColor-default);
   padding: 0 1em;
 }
 
@@ -517,30 +520,12 @@
 .markdown-body tt,
 .markdown-body code,
 .markdown-body samp {
-  font-family: var(
-    --fontStack-monospace,
-    ui-monospace,
-    SFMono-Regular,
-    SF Mono,
-    Menlo,
-    Consolas,
-    Liberation Mono,
-    monospace
-  );
+  font-family: var(--fontStack-monospace,ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace);
   font-size: 12px;
 }
 
 .markdown-body pre {
-  font-family: var(
-    --fontStack-monospace,
-    ui-monospace,
-    SFMono-Regular,
-    SF Mono,
-    Menlo,
-    Consolas,
-    Liberation Mono,
-    monospace
-  );
+  font-family: var(--fontStack-monospace,ui-monospace,SFMono-Regular,SF Mono,Menlo,Consolas,Liberation Mono,monospace);
   margin-top: 0;
   margin-bottom: 0;
   font-size: 12px;
@@ -551,7 +536,7 @@
   vertical-align: text-bottom;
   fill: currentColor;
   display: inline-block;
-  overflow: visible !important;
+  overflow: visible!important;
 }
 
 .markdown-body .Box-body.scrollable-overlay {
@@ -577,65 +562,65 @@
 }
 
 .markdown-body .border {
-  border: var(--borderWidth-thin, 1px) solid var(--borderColor-default) !important;
+  border: var(--borderWidth-thin,1px)solid var(--borderColor-default)!important;
 }
 
 .markdown-body .border-0 {
-  border: 0 !important;
+  border: 0!important;
 }
 
 .markdown-body .circle {
-  border-radius: var(--borderRadius-full, 50%) !important;
+  border-radius: var(--borderRadius-full,50%)!important;
 }
 
 .markdown-body .color-fg-muted {
-  color: var(--fgColor-muted) !important;
+  color: var(--fgColor-muted)!important;
 }
 
 .markdown-body .color-bg-default {
-  background-color: var(--bgColor-default) !important;
+  background-color: var(--bgColor-default)!important;
 }
 
 .markdown-body .color-border-subtle {
-  border-color: var(--borderColor-muted) !important;
+  border-color: var(--borderColor-muted)!important;
 }
 
 .markdown-body .mb-0 {
-  margin-bottom: 0 !important;
+  margin-bottom: 0!important;
 }
 
 .markdown-body .ml-1 {
-  margin-left: var(--base-size-4, 4px) !important;
+  margin-left: var(--base-size-4,4px)!important;
 }
 
 .markdown-body .mr-2 {
-  margin-right: var(--base-size-8, 8px) !important;
+  margin-right: var(--base-size-8,8px)!important;
 }
 
 .markdown-body .my-2 {
-  margin-top: var(--base-size-8, 8px) !important;
-  margin-bottom: var(--base-size-8, 8px) !important;
+  margin-top: var(--base-size-8,8px)!important;
+  margin-bottom: var(--base-size-8,8px)!important;
 }
 
 .markdown-body .p-0 {
-  padding: 0 !important;
+  padding: 0!important;
 }
 
 .markdown-body .py-0 {
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
+  padding-top: 0!important;
+  padding-bottom: 0!important;
 }
 
 .markdown-body .f6 {
-  font-size: var(--h6-size, 12px) !important;
+  font-size: var(--h6-size,12px)!important;
 }
 
 .markdown-body .text-bold {
-  font-weight: var(--base-text-weight-semibold, 600) !important;
+  font-weight: var(--base-text-weight-semibold,600)!important;
 }
 
 .markdown-body .d-inline-block {
-  display: inline-block !important;
+  display: inline-block!important;
 }
 
 .markdown-body .sr-only {
@@ -650,22 +635,22 @@
 }
 
 .markdown-body:before {
-  content: '';
+  content: "";
   display: table;
 }
 
 .markdown-body:after {
   clear: both;
-  content: '';
+  content: "";
   display: table;
 }
 
-.markdown-body > :first-child {
-  margin-top: 0 !important;
+.markdown-body>:first-child {
+  margin-top: 0!important;
 }
 
-.markdown-body > :last-child {
-  margin-bottom: 0 !important;
+.markdown-body>:last-child {
+  margin-bottom: 0!important;
 }
 
 .markdown-body a:not([href]) {
@@ -700,11 +685,11 @@
   margin-bottom: var(--base-size-16);
 }
 
-.markdown-body blockquote > :first-child {
+.markdown-body blockquote>:first-child {
   margin-top: 0;
 }
 
-.markdown-body blockquote > :last-child {
+.markdown-body blockquote>:last-child {
   margin-bottom: 0;
 }
 
@@ -750,7 +735,7 @@
 .markdown-body h6 tt,
 .markdown-body h6 code {
   font-size: inherit;
-  padding: 0 0.2em;
+  padding: 0 .2em;
 }
 
 .markdown-body summary h1,
@@ -783,24 +768,24 @@
   list-style-type: none;
 }
 
-.markdown-body ol[type='a\ s'] {
+.markdown-body ol[type=a\ s] {
   list-style-type: lower-alpha;
 }
 
-.markdown-body ol[type='A\ s'] {
+.markdown-body ol[type=A\ s] {
   list-style-type: upper-alpha;
 }
 
-.markdown-body ol[type='i\ s'] {
+.markdown-body ol[type=i\ s] {
   list-style-type: lower-roman;
 }
 
-.markdown-body ol[type='I\ s'] {
+.markdown-body ol[type=I\ s] {
   list-style-type: upper-roman;
 }
 
-.markdown-body ol[type='1'],
-.markdown-body div > ol:not([type]) {
+.markdown-body ol[type="1"],
+.markdown-body div>ol:not([type]) {
   list-style-type: decimal;
 }
 
@@ -812,12 +797,12 @@
   margin-bottom: 0;
 }
 
-.markdown-body li > p {
+.markdown-body li>p {
   margin-top: var(--base-size-16);
 }
 
-.markdown-body li + li {
-  margin-top: 0.25em;
+.markdown-body li+li {
+  margin-top: .25em;
 }
 
 .markdown-body dl {
@@ -828,11 +813,11 @@
   margin-top: var(--base-size-16);
   font-size: 1em;
   font-style: italic;
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
   padding: 0;
 }
 
-.markdown-body dl dt + dt {
+.markdown-body dl dt+dt {
   margin-top: 0;
 }
 
@@ -842,7 +827,7 @@
 }
 
 .markdown-body table th {
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
 }
 
 .markdown-body table th,
@@ -851,7 +836,7 @@
   padding: 6px 13px;
 }
 
-.markdown-body table td > :last-child {
+.markdown-body table td>:last-child {
   margin-bottom: 0;
 }
 
@@ -868,11 +853,11 @@
   background-color: #0000;
 }
 
-.markdown-body img[align='right'] {
+.markdown-body img[align=right] {
   padding-left: 20px;
 }
 
-.markdown-body img[align='left'] {
+.markdown-body img[align=left] {
   padding-right: 20px;
 }
 
@@ -887,7 +872,7 @@
   overflow: hidden;
 }
 
-.markdown-body span.frame > span {
+.markdown-body span.frame>span {
   float: left;
   border: 1px solid var(--borderColor-default);
   width: auto;
@@ -915,7 +900,7 @@
   overflow: hidden;
 }
 
-.markdown-body span.align-center > span {
+.markdown-body span.align-center>span {
   text-align: center;
   margin: 13px auto 0;
   display: block;
@@ -933,7 +918,7 @@
   overflow: hidden;
 }
 
-.markdown-body span.align-right > span {
+.markdown-body span.align-right>span {
   text-align: right;
   margin: 13px 0 0;
   display: block;
@@ -963,7 +948,7 @@
   overflow: hidden;
 }
 
-.markdown-body span.float-right > span {
+.markdown-body span.float-right>span {
   text-align: right;
   margin: 13px auto 0;
   display: block;
@@ -976,7 +961,7 @@
   background-color: var(--bgColor-neutral-muted);
   border-radius: 6px;
   margin: 0;
-  padding: 0.2em 0.4em;
+  padding: .2em .4em;
   font-size: 85%;
 }
 
@@ -998,7 +983,7 @@
   font-size: 100%;
 }
 
-.markdown-body pre > code {
+.markdown-body pre>code {
   word-break: normal;
   white-space: pre;
   background: 0 0;
@@ -1050,7 +1035,7 @@
 }
 
 .markdown-body .csv-data .blob-num {
-  padding: 10px var(--base-size-8) 9px;
+  padding: 10px var(--base-size-8)9px;
   text-align: right;
   background: var(--bgColor-default);
   border: 0;
@@ -1061,17 +1046,17 @@
 }
 
 .markdown-body .csv-data th {
-  font-weight: var(--base-text-weight-semibold, 600);
+  font-weight: var(--base-text-weight-semibold,600);
   background: var(--bgColor-muted);
   border-top: 0;
 }
 
 .markdown-body [data-footnote-ref]:before {
-  content: '[';
+  content: "[";
 }
 
 .markdown-body [data-footnote-ref]:after {
-  content: ']';
+  content: "]";
 }
 
 .markdown-body .footnotes {
@@ -1095,12 +1080,12 @@
 }
 
 .markdown-body .footnotes li:target:before {
-  top: calc(var(--base-size-8) * -1);
-  right: calc(var(--base-size-8) * -1);
-  bottom: calc(var(--base-size-8) * -1);
-  left: calc(var(--base-size-24) * -1);
+  top: calc(var(--base-size-8)*-1);
+  right: calc(var(--base-size-8)*-1);
+  bottom: calc(var(--base-size-8)*-1);
+  left: calc(var(--base-size-24)*-1);
   pointer-events: none;
-  content: '';
+  content: "";
   border: 2px solid var(--borderColor-accent-emphasis);
   border-radius: 6px;
   position: absolute;
@@ -1115,14 +1100,14 @@
 }
 
 .markdown-body :is() {
-  content: '';
+  content: "";
   width: 100%;
   height: 100%;
   min-height: 48px;
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%) translateY(-50%);
+  transform: translate(-50%)translateY(-50%);
 }
 
 .markdown-body .Box {
@@ -1140,11 +1125,11 @@
 .markdown-body .Box--condensed .Box-body,
 .markdown-body .Box--condensed .Box-footer,
 .markdown-body .Box--condensed .Box-header {
-  padding: var(--stack-padding-condensed) var(--stack-padding-normal);
+  padding: var(--stack-padding-condensed)var(--stack-padding-normal);
 }
 
 .markdown-body .Box--condensed .Box-row {
-  padding: var(--stack-padding-condensed) var(--stack-padding-normal);
+  padding: var(--stack-padding-condensed)var(--stack-padding-normal);
 }
 
 .markdown-body .Box-header {
@@ -1154,24 +1139,24 @@
   border-top-right-radius: var(--borderRadius-medium);
   border-style: solid;
   border-width: var(--borderWidth-thin);
-  margin: calc(var(--borderWidth-thin) * -1) calc(var(--borderWidth-thin) * -1) 0;
+  margin: calc(var(--borderWidth-thin)*-1)calc(var(--borderWidth-thin)*-1)0;
   padding: var(--stack-padding-normal);
 }
 
 .markdown-body .Box-body {
-  border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
+  border-bottom: var(--borderWidth-thin)solid var(--borderColor-default);
   padding: var(--stack-padding-normal);
 }
 
 .markdown-body .Box-body:last-of-type {
   border-bottom-left-radius: var(--borderRadius-medium);
   border-bottom-right-radius: var(--borderRadius-medium);
-  margin-bottom: calc(var(--borderWidth-thin) * -1);
+  margin-bottom: calc(var(--borderWidth-thin)*-1);
 }
 
 .markdown-body .tmp-px-3 {
-  padding-right: var(--base-size-16, 16px) !important;
-  padding-left: var(--base-size-16, 16px) !important;
+  padding-right: var(--base-size-16,16px)!important;
+  padding-left: var(--base-size-16,16px)!important;
 }
 
 .markdown-body .pl-c {
@@ -1294,8 +1279,8 @@
   text-decoration: underline;
 }
 
-.markdown-body [role='button']:focus:not(:focus-visible),
-.markdown-body [role='tabpanel'][tabindex='0']:focus:not(:focus-visible),
+.markdown-body [role=button]:focus:not(:focus-visible),
+.markdown-body [role=tabpanel][tabindex="0"]:focus:not(:focus-visible),
 .markdown-body button:focus:not(:focus-visible),
 .markdown-body summary:focus:not(:focus-visible),
 .markdown-body a:focus:not(:focus-visible) {
@@ -1303,22 +1288,19 @@
   outline: none;
 }
 
-.markdown-body [tabindex='0']:focus:not(:focus-visible),
+.markdown-body [tabindex="0"]:focus:not(:focus-visible),
 .markdown-body details-dialog:focus:not(:focus-visible) {
   outline: none;
 }
 
 .markdown-body g-emoji {
   min-width: 1ch;
-  font-family:
-    Apple Color Emoji,
-    Segoe UI Emoji,
-    Segoe UI Symbol;
+  font-family: Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
   font-weight: var(--base-text-weight-normal);
-  vertical-align: -0.075em;
+  vertical-align: -.075em;
   line-height: 1;
   display: inline-block;
-  font-style: normal !important;
+  font-style: normal!important;
   font-size: 1.25em;
 }
 
@@ -1400,13 +1382,13 @@
 }
 
 .markdown-body .blob-code-inner .x-first {
-  border-top-left-radius: 0.2em;
-  border-bottom-left-radius: 0.2em;
+  border-top-left-radius: .2em;
+  border-bottom-left-radius: .2em;
 }
 
 .markdown-body .blob-code-inner .x-last {
-  border-top-right-radius: 0.2em;
-  border-bottom-right-radius: 0.2em;
+  border-top-right-radius: .2em;
+  border-bottom-right-radius: .2em;
 }
 
 .markdown-body .blob-code-inner.highlighted,
@@ -1423,19 +1405,18 @@
 .markdown-body .blob-code-inner.blob-code-addition,
 .markdown-body .blob-code-inner.blob-code-deletion {
   position: relative;
-  padding-left: 22px !important;
+  padding-left: 22px!important;
 }
 
-.markdown-body a:has(> p, > div, > pre, > blockquote) {
+.markdown-body a:has(>p,>div,>pre,>blockquote) {
   display: block;
 }
 
-.markdown-body a:has(> p, > div, > pre, > blockquote):not(:has(.snippet-clipboard-content, > pre)) {
+.markdown-body a:has(>p,>div,>pre,>blockquote):not(:has(.snippet-clipboard-content,>pre)) {
   width: fit-content;
 }
 
-.markdown-body
-  a:has(> p, > div, > pre, > blockquote):has(.snippet-clipboard-content, > pre):focus-visible {
+.markdown-body a:has(>p,>div,>pre,>blockquote):has(.snippet-clipboard-content,>pre):focus-visible {
   outline: 2px solid var(--focus-outlineColor);
   outline-offset: 2px;
 }
@@ -1452,7 +1433,7 @@
   cursor: pointer;
 }
 
-.markdown-body .task-list-item + .task-list-item {
+.markdown-body .task-list-item+.task-list-item {
   margin-top: var(--base-size-4);
 }
 
@@ -1462,56 +1443,12 @@
 
 .markdown-body .task-list-item-checkbox {
   vertical-align: middle;
-  margin: 0 0.2em 0.25em -1.4em;
+  margin: 0 .2em .25em -1.4em;
 }
 
-.markdown-body
-  ul:is(
-    :lang(ae),
-    :lang(ar),
-    :lang(arc),
-    :lang(bcc),
-    :lang(bqi),
-    :lang(ckb),
-    :lang(dv),
-    :lang(fa),
-    :lang(glk),
-    :lang(he),
-    :lang(ku),
-    :lang(mzn),
-    :lang(nqo),
-    :lang(pnb),
-    :lang(ps),
-    :lang(sd),
-    :lang(ug),
-    :lang(ur),
-    :lang(yi)
-  )
-  .task-list-item-checkbox,
-.markdown-body
-  ol:is(
-    :lang(ae),
-    :lang(ar),
-    :lang(arc),
-    :lang(bcc),
-    :lang(bqi),
-    :lang(ckb),
-    :lang(dv),
-    :lang(fa),
-    :lang(glk),
-    :lang(he),
-    :lang(ku),
-    :lang(mzn),
-    :lang(nqo),
-    :lang(pnb),
-    :lang(ps),
-    :lang(sd),
-    :lang(ug),
-    :lang(ur),
-    :lang(yi)
-  )
-  .task-list-item-checkbox {
-  margin: 0 -1.6em 0.25em 0.2em;
+.markdown-body ul:is(:lang(ae),:lang(ar),:lang(arc),:lang(bcc),:lang(bqi),:lang(ckb),:lang(dv),:lang(fa),:lang(glk),:lang(he),:lang(ku),:lang(mzn),:lang(nqo),:lang(pnb),:lang(ps),:lang(sd),:lang(ug),:lang(ur),:lang(yi)) .task-list-item-checkbox,
+.markdown-body ol:is(:lang(ae),:lang(ar),:lang(arc),:lang(bcc),:lang(bqi),:lang(ckb),:lang(dv),:lang(fa),:lang(glk),:lang(he),:lang(ku),:lang(mzn),:lang(nqo),:lang(pnb),:lang(ps),:lang(sd),:lang(ug),:lang(ur),:lang(yi)) .task-list-item-checkbox {
+  margin: 0 -1.6em .25em .2em;
 }
 
 .markdown-body .contains-task-list:hover .task-list-item-convert-container,
@@ -1528,22 +1465,22 @@
 }
 
 .markdown-body .markdown-alert {
-  padding: var(--base-size-8) var(--base-size-16);
+  padding: var(--base-size-8)var(--base-size-16);
   margin-bottom: var(--base-size-16);
   color: inherit;
-  border-left: 0.25em solid var(--borderColor-default);
+  border-left: .25em solid var(--borderColor-default);
 }
 
-.markdown-body .markdown-alert > :first-child {
+.markdown-body .markdown-alert>:first-child {
   margin-top: 0;
 }
 
-.markdown-body .markdown-alert > :last-child {
+.markdown-body .markdown-alert>:last-child {
   margin-bottom: 0;
 }
 
 .markdown-body .markdown-alert .markdown-alert-title {
-  font-weight: var(--base-text-weight-medium, 500);
+  font-weight: var(--base-text-weight-medium,500);
   align-items: center;
   line-height: 1;
   display: flex;
@@ -1589,55 +1526,55 @@
   color: var(--fgColor-danger);
 }
 
-.markdown-body > :first-child > .heading-element:first-child {
-  margin-top: 0 !important;
+.markdown-body>:first-child>.heading-element:first-child {
+  margin-top: 0!important;
 }
 
-.markdown-body .tab-size[data-tab-size='1'] {
+.markdown-body .tab-size[data-tab-size="1"] {
   tab-size: 1;
 }
 
-.markdown-body .tab-size[data-tab-size='2'] {
+.markdown-body .tab-size[data-tab-size="2"] {
   tab-size: 2;
 }
 
-.markdown-body .tab-size[data-tab-size='3'] {
+.markdown-body .tab-size[data-tab-size="3"] {
   tab-size: 3;
 }
 
-.markdown-body .tab-size[data-tab-size='4'] {
+.markdown-body .tab-size[data-tab-size="4"] {
   tab-size: 4;
 }
 
-.markdown-body .tab-size[data-tab-size='5'] {
+.markdown-body .tab-size[data-tab-size="5"] {
   tab-size: 5;
 }
 
-.markdown-body .tab-size[data-tab-size='6'] {
+.markdown-body .tab-size[data-tab-size="6"] {
   tab-size: 6;
 }
 
-.markdown-body .tab-size[data-tab-size='7'] {
+.markdown-body .tab-size[data-tab-size="7"] {
   tab-size: 7;
 }
 
-.markdown-body .tab-size[data-tab-size='8'] {
+.markdown-body .tab-size[data-tab-size="8"] {
   tab-size: 8;
 }
 
-.markdown-body .tab-size[data-tab-size='9'] {
+.markdown-body .tab-size[data-tab-size="9"] {
   tab-size: 9;
 }
 
-.markdown-body .tab-size[data-tab-size='10'] {
+.markdown-body .tab-size[data-tab-size="10"] {
   tab-size: 10;
 }
 
-.markdown-body .tab-size[data-tab-size='11'] {
+.markdown-body .tab-size[data-tab-size="11"] {
   tab-size: 11;
 }
 
-.markdown-body .tab-size[data-tab-size='12'] {
+.markdown-body .tab-size[data-tab-size="12"] {
   tab-size: 12;
 }
 
@@ -1649,6 +1586,7 @@
   display: block;
 }
 
-.markdown-body .highlight pre:has(+ .zeroclipboard-container) {
+.markdown-body .highlight pre:has(+.zeroclipboard-container) {
   min-height: 52px;
 }
+

--- a/packages/ui-components/src/providers/AuthProvider/AuthProvider.tsx
+++ b/packages/ui-components/src/providers/AuthProvider/AuthProvider.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
-import React, { createContext, useContext, useEffect } from 'react';
+import React, { createContext, use } from 'react';
+import { useSWRConfig } from 'swr';
 
 import { useDataMutation } from '../../api/use-data-mutation';
 import { getConfiguration } from '../../configuration';
@@ -28,14 +29,17 @@ const basePath = stripTrailingSlash(configuration.base);
 
 const AuthProvider: React.FC<{ children: ReactElement }> = ({ children }) => {
   const [userState, setUserState] = React.useState<LoginBody>(getDefaultUserState());
-  const { data, isMutating, trigger } = useDataMutation<LoginBody>(
-    basePath,
-    APIRoute.LOGIN,
-    'POST'
-  );
+  const { trigger } = useDataMutation<LoginBody>(basePath, APIRoute.LOGIN, 'POST');
+  const { mutate } = useSWRConfig();
 
   const handleLogin = async (body: { username: string; password: string }) => {
-    await trigger(body);
+    const result = await trigger(body);
+    if (result && result.username && result.token) {
+      saveAuth(result.username, result.token);
+      setUserState(result as LoginBody);
+      // Revalidate the packages list so it reflects authenticated access
+      mutate(`${basePath}${APIRoute.PACKAGES}`);
+    }
   };
 
   const logOutUser = () => {
@@ -44,17 +48,8 @@ const AuthProvider: React.FC<{ children: ReactElement }> = ({ children }) => {
     window.location?.reload();
   };
 
-  useEffect(() => {
-    if (data && !isMutating) {
-      setUserState(data as LoginBody);
-      if (data.username && data.token) {
-        saveAuth(data.username, data.token);
-      }
-    }
-  }, [data, isMutating]);
-
   return (
-    <AuthContext.Provider
+    <AuthContext
       value={{
         handleLogin,
         userState,
@@ -63,10 +58,10 @@ const AuthProvider: React.FC<{ children: ReactElement }> = ({ children }) => {
       }}
     >
       {children}
-    </AuthContext.Provider>
+    </AuthContext>
   );
 };
 
 export { AuthProvider };
 
-export const useAuth = () => useContext(AuthContext);
+export const useAuth = () => use(AuthContext);

--- a/packages/ui-components/src/sections/Security/Login.test.tsx
+++ b/packages/ui-components/src/sections/Security/Login.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { vi } from 'vitest';
 
+import storage from '../../store/storage';
 import {
   act,
   cleanup,
@@ -21,6 +22,8 @@ describe('<Login /> component', () => {
     vi.resetModules();
     vi.resetAllMocks();
     cleanup();
+    storage.removeItem('token');
+    storage.removeItem('username');
   });
 
   afterEach(() => {
@@ -92,6 +95,34 @@ describe('<Login /> component', () => {
     });
 
     expect(screen.queryByText('security.login.createUser')).not.toBeInTheDocument();
+  });
+
+  test('should save auth token before navigating on successful login', async () => {
+    await act(async () => {
+      renderWithRouter(<Login />, Route.LOGIN, [LOGIN_URL_WITH_NEXT]);
+    });
+
+    const usernameInput = screen.getByPlaceholderText('form-placeholder.username');
+    const passwordInput = screen.getByPlaceholderText('form-placeholder.password');
+
+    await act(async () => {
+      fireEvent.change(usernameInput, { target: { value: 'testuser' } });
+      fireEvent.change(passwordInput, { target: { value: 'testpass' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('login-dialog-form-login-button')).not.toBeDisabled();
+    });
+
+    const submitButton = screen.getByTestId('login-dialog-form-login-button');
+    await act(async () => {
+      fireEvent.click(submitButton);
+    });
+
+    await waitFor(() => {
+      expect(storage.getItem('token')).toBe('valid-mock-token');
+      expect(storage.getItem('username')).toBe('testuser');
+    });
   });
 
   test('should show error message on failed login', async () => {

--- a/packages/ui-components/src/sections/Security/Login.tsx
+++ b/packages/ui-components/src/sections/Security/Login.tsx
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Link, Typography } from '@mui/material';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
@@ -33,7 +33,7 @@ const Login: React.FC = () => {
   const createUserEnabled = configuration?.flags?.createUser;
   const addUserLink = Route.ADD_USER + (next ? '?next=' + next : '');
 
-  const { data, isMutating, trigger } = useDataMutation<LoginBody>(basePath, next, 'POST');
+  const { trigger } = useDataMutation<LoginBody>(basePath, next, 'POST');
 
   const form = useForm<LoginFormValues>({
     mode: 'onChange',
@@ -49,7 +49,7 @@ const Login: React.FC = () => {
 
   const handleLogin = async (body: { username: string; password: string }) => {
     try {
-      await trigger(body);
+      return await trigger(body);
     } catch (err) {
       throw normalizeAuthError(err);
     }
@@ -62,7 +62,10 @@ const Login: React.FC = () => {
   const onSubmit = useCallback(
     async (data: LoginFormValues) => {
       try {
-        await handleLogin?.(data);
+        const result = await handleLogin?.(data);
+        if (result && result.username && result.token) {
+          saveAuth(result.username, result.token);
+        }
         onSuccess();
       } catch {
         setError('root', {
@@ -74,12 +77,6 @@ const Login: React.FC = () => {
     },
     [handleLogin, setError, onSuccess]
   );
-
-  useEffect(() => {
-    if (data && !isMutating && data.username && data.token) {
-      saveAuth(data.username, data.token);
-    }
-  }, [data, isMutating]);
 
   return !next ? (
     <NotFound />

--- a/packages/ui-components/tools/generate-github-markdown.mjs
+++ b/packages/ui-components/tools/generate-github-markdown.mjs
@@ -1,0 +1,66 @@
+import { writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import githubMarkdownCss from 'generate-github-markdown-css';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const OUTPUT = resolve(__dirname, '../src/components/Readme/github-markdown.css');
+
+async function generate() {
+  const baseStyles = await githubMarkdownCss({
+    onlyStyles: true,
+    useFixture: true,
+    rootSelector: '.markdown-body',
+  });
+
+  const lightVars = await githubMarkdownCss({
+    light: 'light',
+    dark: 'light',
+    onlyVariables: true,
+    rootSelector: "[data-theme='light'].markdown-body",
+    transparentBackground: true,
+  });
+
+  const darkVars = await githubMarkdownCss({
+    light: 'dark',
+    dark: 'dark',
+    onlyVariables: true,
+    rootSelector: "[data-theme='dark'].markdown-body",
+    transparentBackground: true,
+  });
+
+  // The library adds bare [data-theme="x"] selectors alongside our scoped ones.
+  // Remove them so variables don't leak outside .markdown-body.
+  const cleanVars = (css) =>
+    css
+      .replace(/,\n\[data-theme="[^"]+"\]/g, '')
+      .replace(/,\n\[data-theme='[^']+'\]/g, '');
+
+  const css = [
+    '/* Auto-generated — do not edit. Run: node tools/generate-github-markdown.mjs */',
+    '',
+    '/* Ensure monospace for combination with highlight.js */',
+    '.markdown-body pre code span {',
+    '  font-family: monospace;',
+    '}',
+    '',
+    '/* Light theme variables */',
+    cleanVars(lightVars),
+    '',
+    '/* Dark theme variables */',
+    cleanVars(darkVars),
+    '',
+    '/* Base styles */',
+    baseStyles,
+    '',
+  ].join('\n');
+
+  writeFileSync(OUTPUT, css, 'utf8');
+  console.log(`Generated ${OUTPUT}`);
+}
+
+generate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1418,6 +1418,9 @@ importers:
       eslint-plugin-verdaccio:
         specifier: 10.0.0
         version: 10.0.0
+      generate-github-markdown-css:
+        specifier: ^6.6.0
+        version: 6.6.0
       jsdom:
         specifier: 28.1.0
         version: 28.1.0(@noble/hashes@1.8.0)
@@ -5168,6 +5171,11 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  generate-github-markdown-css@6.6.0:
+    resolution: {integrity: sha512-w5mLLHA/EkcYh4flSsfPs/uFZdpEAMZK4dHXgPBFJmf8IOIv++1qPy1KiqwL8/eepB4Oomhf1CsLJS7UMheGoQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -6246,6 +6254,10 @@ packages:
   memorystream@0.3.1:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
+
+  meow@12.1.1:
+    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
+    engines: {node: '>=16.10'}
 
   merge-descriptors@1.0.1:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
@@ -12535,6 +12547,11 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  generate-github-markdown-css@6.6.0:
+    dependencies:
+      meow: 12.1.1
+      postcss: 8.5.8
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
@@ -13745,6 +13762,8 @@ snapshots:
       tslib: 2.6.3
 
   memorystream@0.3.1: {}
+
+  meow@12.1.1: {}
 
   merge-descriptors@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Fixes #5813

### Login refresh

Auth token was saved in a `useEffect` (async, after render) but navigation/dialog close happened immediately after `trigger()` resolved. The token wasn't in localStorage yet, so the package list fetched without auth.

Fix: save the token synchronously from `trigger()` return value before proceeding, in both the full-page Login and the LoginDialog (AuthProvider). After login via the dialog, call `mutate()` on the packages SWR key to force a refetch with the new auth token.

### SWR polling

SWR defaults `revalidateOnFocus` and `revalidateOnReconnect` to `true`, causing API calls on every tab switch. Added `SWRConfig` at `AppRoute` level to disable both.

### GitHub Markdown CSS

Replaced the manually copied `github-markdown.css` with auto-generation via `generate-github-markdown-css` at build time.