### PR TITLE
fix: return 401 when credentials are invalid on GET /-/user/

### DIFF
--- a/.changeset/fix-basic-auth-401.md
+++ b/.changeset/fix-basic-auth-401.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/api': patch
+---
+
+fix: return 401 when Basic Auth credentials are invalid on GET /-/user/

--- a/.changeset/fix-basic-auth-401.md
+++ b/.changeset/fix-basic-auth-401.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/api': patch
+---
+
+fix: return 401 when auth credentials are invalid on GET /-/user/

--- a/packages/api/src/user.ts
+++ b/packages/api/src/user.ts
@@ -33,6 +33,12 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
         typeof req.remote_user.name !== 'string' ||
         req.remote_user.name === ''
       ) {
+        if (req.remote_user?.error) {
+          debug('user authentication failed: %o', req.remote_user.error);
+          return next(
+            errorUtils.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.BAD_USERNAME_PASSWORD)
+          );
+        }
         debug('user not logged in');
         res.status(HTTP_STATUS.OK);
         return next({ ok: false });

--- a/packages/api/src/user.ts
+++ b/packages/api/src/user.ts
@@ -34,6 +34,25 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
         typeof req.remote_user.name !== 'string' ||
         req.remote_user.name === ''
       ) {
+        if (req.remote_user?.error) {
+          debug('user authentication failed: %o', req.remote_user.error);
+          // a malformed Authorization header is a client error, not a credential failure
+          if (req.remote_user.error === API_ERROR.BAD_AUTH_HEADER) {
+            return next(errorUtils.getBadRequest(API_ERROR.BAD_AUTH_HEADER));
+          }
+          return next(
+            errorUtils.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.BAD_USERNAME_PASSWORD)
+          );
+        }
+        // When Bearer token verification fails the auth middleware intentionally keeps an
+        // anonymous user (without recording an error) to stay compatible with npm clients.
+        // If credentials were provided but the user is still anonymous they were rejected.
+        if (req.headers.authorization) {
+          debug('credentials were provided but rejected');
+          return next(
+            errorUtils.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.BAD_USERNAME_PASSWORD)
+          );
+        }
         debug('user not logged in');
         res.status(HTTP_STATUS.OK);
         return next({ ok: false });

--- a/packages/api/src/user.ts
+++ b/packages/api/src/user.ts
@@ -40,18 +40,14 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
           if (req.remote_user.error === API_ERROR.BAD_AUTH_HEADER) {
             return next(errorUtils.getBadRequest(API_ERROR.BAD_AUTH_HEADER));
           }
-          return next(
-            errorUtils.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.BAD_USERNAME_PASSWORD)
-          );
+          return next(errorUtils.getUnauthorized(API_ERROR.BAD_USERNAME_PASSWORD));
         }
         // When Bearer token verification fails the auth middleware intentionally keeps an
         // anonymous user (without recording an error) to stay compatible with npm clients.
         // If credentials were provided but the user is still anonymous they were rejected.
         if (req.headers.authorization) {
           debug('credentials were provided but rejected');
-          return next(
-            errorUtils.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.BAD_USERNAME_PASSWORD)
-          );
+          return next(errorUtils.getUnauthorized(API_ERROR.BAD_USERNAME_PASSWORD));
         }
         debug('user not logged in');
         res.status(HTTP_STATUS.OK);
@@ -114,9 +110,7 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
                 { name, err },
                 'authenticating for user @{username} failed. Error: @{err.message}'
               );
-              return next(
-                errorUtils.getCode(HTTP_STATUS.UNAUTHORIZED, API_ERROR.BAD_USERNAME_PASSWORD)
-              );
+              return next(errorUtils.getUnauthorized(API_ERROR.BAD_USERNAME_PASSWORD));
             }
 
             const restoredRemoteUser: RemoteUser = createRemoteUser(name, user?.groups || []);

--- a/packages/api/test/integration/user.spec.ts
+++ b/packages/api/test/integration/user.spec.ts
@@ -186,6 +186,20 @@ describe('token', () => {
     });
 
     test.each([['user.yaml'], ['user.jwt.yaml']])(
+      'should return 401 when Basic Auth credentials are invalid',
+      async (conf) => {
+        const app = await initializeServer(conf);
+        const basicToken = Buffer.from('admin:admin').toString('base64');
+        const response = await supertest(app)
+          .get('/-/user/org.couchdb.user:admin')
+          .set(HEADERS.AUTHORIZATION, `Basic ${basicToken}`)
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HTTP_STATUS.UNAUTHORIZED);
+        expect(response.body.error).toBe(API_ERROR.BAD_USERNAME_PASSWORD);
+      }
+    );
+
+    test.each([['user.yaml'], ['user.jwt.yaml']])(
       'should return "false" if user is not logged in',
       async (conf) => {
         const app = await initializeServer(conf);

--- a/packages/api/test/integration/user.spec.ts
+++ b/packages/api/test/integration/user.spec.ts
@@ -186,6 +186,46 @@ describe('token', () => {
     });
 
     test.each([['user.yaml'], ['user.jwt.yaml']])(
+      'should return 401 when Basic Auth credentials are invalid',
+      async (conf) => {
+        const app = await initializeServer(conf);
+        const basicToken = Buffer.from('admin:admin').toString('base64');
+        const response = await supertest(app)
+          .get('/-/user/org.couchdb.user:admin')
+          .set(HEADERS.AUTHORIZATION, `Basic ${basicToken}`)
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HTTP_STATUS.UNAUTHORIZED);
+        expect(response.body.error).toBe(API_ERROR.BAD_USERNAME_PASSWORD);
+      }
+    );
+
+    test.each([['user.yaml'], ['user.jwt.yaml']])(
+      'should return 401 when Bearer credentials are invalid',
+      async (conf) => {
+        const app = await initializeServer(conf);
+        const response = await supertest(app)
+          .get('/-/user/org.couchdb.user:admin')
+          .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, 'invalidToken'))
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HTTP_STATUS.UNAUTHORIZED);
+        expect(response.body.error).toBe(API_ERROR.BAD_USERNAME_PASSWORD);
+      }
+    );
+
+    test.each([['user.yaml'], ['user.jwt.yaml']])(
+      'should return 400 when Authorization header is malformed',
+      async (conf) => {
+        const app = await initializeServer(conf);
+        const response = await supertest(app)
+          .get('/-/user/org.couchdb.user:admin')
+          .set(HEADERS.AUTHORIZATION, 'invalidToken')
+          .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+          .expect(HTTP_STATUS.BAD_REQUEST);
+        expect(response.body.error).toBe(API_ERROR.BAD_AUTH_HEADER);
+      }
+    );
+
+    test.each([['user.yaml'], ['user.jwt.yaml']])(
       'should return "false" if user is not logged in',
       async (conf) => {
         const app = await initializeServer(conf);


### PR DESCRIPTION
## Summary

- `GET /-/user/org.couchdb.user:<name>` with invalid Basic Auth credentials (e.g. `Authorization: Basic YWRtaW46YWRtaW4=`) was returning `200 OK { "ok": false }` instead of `401 Unauthorized`
- The auth middleware intentionally swallows auth errors (for npm client compatibility) and stores the failure in `req.remote_user.error`; the route handler guard was not checking this field
- Added a check for `req.remote_user.error` in the GET handler: when credentials were provided but rejected, the handler now returns `401` with `BAD_USERNAME_PASSWORD`
- The existing `200 { ok: false }` response for *unauthenticated* requests (no `Authorization` header) is preserved

## Test plan

- [x] New integration test `should return 401 when Basic Auth credentials are invalid` added to `packages/api/test/integration/user.spec.ts`, runs against both `user.yaml` and `user.jwt.yaml` configs
- [x] All existing tests in `packages/api/test/integration/user.spec.ts` continue to pass (`pnpm test test/integration/user.spec.ts` — 26/26 pass)
- [x] `pnpm lint` passes (0 errors, 69 pre-existing warnings, under the 90 limit)
- [x] `pnpm format:check` passes on changed files
