### PR TITLE
fix(proxy): vite:dts build error

### DIFF
--- a/.changeset/twelve-lizards-lay.md
+++ b/.changeset/twelve-lizards-lay.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/proxy': patch
+---
+
+fix(proxy): vite:dts build error

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -495,13 +495,13 @@ class ProxyStorage implements IProxy {
       );
       debug('searching on %o', uri);
       const response = got(uri, {
-        signal: abort ? abort.signal : {},
+        signal: abort ? abort.signal : undefined,
         agent: this.agent,
         timeout: this.timeout,
         retry: retry ?? this.retry,
       });
 
-      const res = await response.text();
+      const res = await (response.text() as unknown as Promise<string>);
       const total = JSON.parse(res).total;
       debug('number of packages found: %o', total);
       const streamSearch = new PassThrough({ objectMode: true });


### PR DESCRIPTION
Fixed errors during vite:dts build due to changed abort signal:

For example, see "build & push" in [verdaccio/verdaccio/actions/runs/25077192007/job/73472856325](https://github.com/verdaccio/verdaccio/actions/runs/25077192007/job/73472856325)

<img width="816" height="269" alt="image" src="https://github.com/user-attachments/assets/26666264-3fa9-436e-bb9f-8aad16441586" />

Also fixed casting got’s .text() cancelable request result, so JSON.parse() and Readable.from() receive a real string type.

