### PR TITLE
feat: remove deprecated `self_path` config property in favor of `conf…

### DIFF
--- a/.changeset/remove-self-path.md
+++ b/.changeset/remove-self-path.md
@@ -1,6 +1,6 @@
 ---
-'@verdaccio/config': patch
-'@verdaccio/types': patch
+'@verdaccio/config': major
+'@verdaccio/types': major
 ---
 
-chore: remove deprecated `self_path` config property in favor of `configPath`
+chore!: remove deprecated `self_path` config property in favor of `configPath`

--- a/.changeset/remove-self-path.md
+++ b/.changeset/remove-self-path.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/config': patch
+'@verdaccio/types': patch
+---
+
+chore: remove deprecated `self_path` config property in favor of `configPath`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,12 @@ jobs:
         uses: ./.github/actions/install-app-node
         with:
           node-version: ${{ steps.nvmrc.outputs.node-version }}
+      - name: Setup Bun
+        if: startsWith(matrix.pm, 'bun')
+        uses: oven-sh/setup-bun@v2
+      - name: Setup Deno
+        if: startsWith(matrix.pm, 'deno')
+        uses: denoland/setup-deno@v2
       - name: Restore build artifacts
         uses: actions/cache/restore@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: pnpm format:check
   build:
     needs: [lint-and-format]
-    if: ${{ always() && !failure() && !cancelled() }}
+    if: ${{ always() && !failure() && !cancelled() && github.event.pull_request.draft == false }}
     strategy:
       fail-fast: true
       matrix:
@@ -86,7 +86,7 @@ jobs:
           key: ci-build-${{ github.sha }}-node-${{ matrix.node_version }}
   test-docker:
     needs: [build]
-    if: ${{ github.event_name == 'pull_request' && !failure() && !cancelled() }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     name: Test Docker Build
     steps:
@@ -111,7 +111,7 @@ jobs:
         run: docker stop verdaccio-test
   test:
     needs: [build]
-    if: ${{ github.event_name == 'pull_request' && !failure() && !cancelled() }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && !failure() && !cancelled() }}
     strategy:
       fail-fast: true
       matrix:
@@ -146,7 +146,7 @@ jobs:
         run: pnpm test
   e2e-cli:
     needs: [build]
-    if: ${{ github.event_name == 'pull_request' && !failure() && !cancelled() }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     name: E2E CLI (${{ matrix.pm }})
     strategy:
@@ -206,7 +206,7 @@ jobs:
         run: cat ~/.config/verdaccio/verdaccio.log 2>/dev/null || echo "No log file found"
   e2e-ui:
     needs: [build]
-    if: ${{ github.event_name == 'pull_request' && !failure() && !cancelled() }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     name: E2E UI
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        node_version: [24, 25]
+        node_version: [24, 26]
     name: Test / ${{ matrix.os }} / Node ${{ matrix.node_version }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -136,13 +136,13 @@ jobs:
             packages/plugins/ui-theme/static
           key: ci-build-${{ github.sha }}-node-${{ matrix.node_version }}
           fail-on-cache-miss: true
-      - name: Test (Node 25)
-        if: matrix.node_version == 25
+      - name: Test (Node 26)
+        if: matrix.node_version == 26
         run: pnpm test
         env:
           NODE_OPTIONS: --no-webstorage
       - name: Test (Other Node)
-        if: matrix.node_version != 25
+        if: matrix.node_version != 26
         run: pnpm test
   e2e-cli:
     needs: [build]
@@ -352,4 +352,4 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh cache delete "ci-build-${{ github.sha }}-node-24" --repo ${{ github.repository }} || true
-          gh cache delete "ci-build-${{ github.sha }}-node-25" --repo ${{ github.repository }} || true
+          gh cache delete "ci-build-${{ github.sha }}-node-26" --repo ${{ github.repository }} || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,8 @@ jobs:
           - pnpm@9
           - pnpm@10
           - pnpm@11
+          - bun
+          - deno
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Read Node version from .nvmrc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        node_version: [24, 25]
+        node_version: [24, 26]
     name: Build / ${{ matrix.os }} / Node ${{ matrix.node_version }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/superagent": "8.1.9",
     "@types/supertest": "7.2.0",
     "@types/validator": "13.15.10",
-    "@verdaccio/e2e-cli": "2.7.0",
+    "@verdaccio/e2e-cli": "2.8.0",
     "@verdaccio/e2e-ui": "2.4.1",
     "@verdaccio/eslint-config": "13.0.0",
     "@verdaccio/package-filter": "workspace:*",

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -48,10 +48,6 @@ class Config implements AppConfig {
   public store: any;
   public server_id: string;
   public configPath: string;
-  /**
-   * @deprecated use configPath or config.getConfigPath();
-   */
-  public self_path: string;
   public storage: string | void;
 
   public plugins: string | void | null;
@@ -65,15 +61,12 @@ class Config implements AppConfig {
     const self = this;
     this.storage = process.env.VERDACCIO_STORAGE_PATH || config.storage;
     if (!config.configPath) {
-      // backport self_path for previous to version 6
-      // @ts-expect-error
-      config.configPath = config.config_path ?? config.self_path;
+      config.configPath = config.config_path;
       if (!config.configPath) {
         throw new Error('configPath property is required');
       }
     }
     this.configPath = config.configPath;
-    this.self_path = this.configPath;
     debug('config path: %s', this.configPath);
     this.plugins = config.plugins;
     this.security = merge(defaultSecurity, config.security);

--- a/packages/config/src/parse.ts
+++ b/packages/config/src/parse.ts
@@ -2,7 +2,6 @@ import buildDebug from 'debug';
 import YAML from 'js-yaml';
 import { isObject } from 'lodash-es';
 import fs from 'node:fs';
-import path from 'node:path';
 
 import { API_ERROR, APP_ERROR } from '@verdaccio/core';
 import type { ConfigYaml } from '@verdaccio/types';
@@ -70,12 +69,10 @@ export function fromJStoYAML(config: Partial<ConfigYaml>): string | null {
  * If a string or `undefined` is provided, it is interpreted as a path to a config file
  * (or uses a default location). The config file is then loaded and parsed.
  * If an object is provided, it is assumed to be a pre-parsed configuration.
- * Backward compability: ensures the returned configuration object has a `self_path` property set,
- * either to the config file path or to a property within the object.
  *
  * @param {string | ConfigYaml} [config] - Optional. A path to the configuration file (string),
  *                                         a pre-parsed config object, or `undefined`.
- * @returns {ConfigYaml} The parsed configuration object with a guaranteed `self_path` property.
+ * @returns {ConfigYaml} The parsed configuration object.
  * @throws {Error} If the provided config is neither a string, undefined, nor an object.
  */
 export function getConfigParsed(config?: string | ConfigYaml): ConfigYaml {
@@ -85,14 +82,6 @@ export function getConfigParsed(config?: string | ConfigYaml): ConfigYaml {
     debug('using default configuration');
     const configPathLocation = findConfigFile(config);
     configurationParsed = parseConfigFile(configPathLocation);
-
-    // @ts-expect-error
-    if (!configurationParsed.self_path) {
-      debug('self_path not defined, using config path location');
-
-      // @ts-expect-error
-      configurationParsed.self_path = path.resolve(configPathLocation);
-    }
   } else if (typeof config === 'object' && config !== null) {
     configurationParsed = config;
 
@@ -100,14 +89,6 @@ export function getConfigParsed(config?: string | ConfigYaml): ConfigYaml {
     // is set so the Config constructor does not throw.
     if (!configurationParsed.configPath) {
       configurationParsed.configPath = process.cwd();
-    }
-
-    // @ts-expect-error
-    if (!configurationParsed.self_path) {
-      debug('self_path not defined, using config path location');
-
-      // @ts-expect-error
-      configurationParsed.self_path = configurationParsed.configPath;
     }
   } else {
     throw new Error(API_ERROR.CONFIG_BAD_FORMAT);

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -334,8 +334,6 @@ export interface Config extends Omit<ConfigYaml, 'packages' | 'security' | 'conf
   secret: string;
   // save the configuration file path, it's fails without thi configPath
   configPath: string;
-  // @deprecated use configPath
-  self_path?: string;
   // packages from yaml file looks different from packages inside the config file
   packages: PackageList;
   // security object defaults is added by the config file but optional in the yaml file

--- a/packages/loaders/test/plugin_loader_async.spec.ts
+++ b/packages/loaders/test/plugin_loader_async.spec.ts
@@ -214,7 +214,7 @@ describe('plugin loader', () => {
       expect(plugins).toHaveLength(1);
       const plugin = plugins[0];
       // just check if the plugin has the main config
-      expect(plugin.config).toHaveProperty('self_path');
+      expect(plugin.config).toHaveProperty('configPath');
       expect(plugin.config).toHaveProperty('storage');
       // assume all config props are merged
       // check if the plugin has the auth config

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,8 +123,8 @@ importers:
         specifier: 13.15.10
         version: 13.15.10
       '@verdaccio/e2e-cli':
-        specifier: 2.7.0
-        version: 2.7.0
+        specifier: 2.8.0
+        version: 2.8.0
       '@verdaccio/e2e-ui':
         specifier: 2.4.1
         version: 2.4.1(cypress@15.10.0)
@@ -3536,8 +3536,8 @@ packages:
     resolution: {integrity: sha512-F/YZANu4DmpcEV0jronzI7v2fGVWkQ5Mwi+bVmV+ACJ+EzR0c9Jbhtbe5QyLUuzR97t8R5E/Xe53O0cc2LukdQ==}
     engines: {node: '>=8'}
 
-  '@verdaccio/e2e-cli@2.7.0':
-    resolution: {integrity: sha512-YsBEIW6h4rPa1GImkc01aCbKE1Sc1SWGoVh7M1RBmp8WmkMFN9VuJXOOZMzGQWJbTmNkW5hrnpMqX2syQ2r+zA==}
+  '@verdaccio/e2e-cli@2.8.0':
+    resolution: {integrity: sha512-wbd4VzFY6Uf7Cs294Ee/MNFpEujbv5J+GVNxcJ8KUOIDRjPvRN3kTS6OjOqxxeU5qtz5/o5nWREFKZqIWW9q9w==}
     hasBin: true
 
   '@verdaccio/e2e-ui@2.4.1':
@@ -10451,7 +10451,7 @@ snapshots:
       http-errors: 2.0.0
       http-status-codes: 2.2.0
 
-  '@verdaccio/e2e-cli@2.7.0':
+  '@verdaccio/e2e-cli@2.8.0':
     dependencies:
       '@verdaccio/registry-cli': 1.1.0
       debug: 4.4.0


### PR DESCRIPTION
## Summary

- Removes the deprecated `self_path` runtime property from the `Config` object (deprecated since v6, scheduled for removal per `docs/migrations-guide.md`).
- Drops the `self_path` field from the `@verdaccio/types` `Config` interface.
- Removes the `self_path` fallback in the `Config` constructor and the auto-population in `getConfigParsed`.
- Updates the legacy plugin-loader test to assert `configPath` instead.

## Breaking changes

Plugins or programmatic consumers reading `config.self_path` will now get `undefined`. Use `config.configPath` (or `config.getConfigPath()`) instead — same value, available since v6.

The `config_path` snake_case fallback in the `Config` constructor is preserved for old programmatic callers. The YAML config format is unaffected (`self_path` was never a user-facing key, only a runtime-injected property).