### PR TITLE
feat!: only accept YAML config files (`.yaml` / `.yml`)

### DIFF
--- a/.changeset/yaml-only-config.md
+++ b/.changeset/yaml-only-config.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/config': major
+---
+
+chore!: only accept YAML config files (`.yaml` / `.yml`); JSON and JavaScript config files are no longer supported and will throw an error

--- a/packages/config/src/parse.ts
+++ b/packages/config/src/parse.ts
@@ -12,8 +12,8 @@ import { fileExists } from './config-utils';
 const debug = buildDebug('verdaccio:config:parse');
 
 /**
- * Parse a config file from yaml to JSON.
- * @param configPath the absolute path of the configuration file
+ * Parse a YAML config file.
+ * @param configPath the absolute path of the configuration file (must end in .yaml or .yml)
  */
 export function parseConfigFile(configPath: string): ConfigYaml & {
   // @deprecated use configPath instead
@@ -24,33 +24,21 @@ export function parseConfigFile(configPath: string): ConfigYaml & {
   if (!fileExists(configPath)) {
     throw new Error(`config file does not exist or not reachable`);
   }
+  if (!/\.ya?ml$/i.test(configPath)) {
+    throw new Error(`config file must be a YAML file (.yaml or .yml)`);
+  }
   debug('parsing config file: %o', configPath);
   try {
-    if (/\.ya?ml$/i.test(configPath)) {
-      const yamlConfig = YAML.load(fs.readFileSync(configPath, 'utf8'), {
-        strict: false,
-      }) as ConfigYaml;
+    const yamlConfig = YAML.load(fs.readFileSync(configPath, 'utf8')) as ConfigYaml;
 
-      return Object.assign({}, yamlConfig, {
-        configPath,
-        // @deprecated use configPath instead
-        config_path: configPath,
-      });
-    }
-
-    const jsonConfig = require(configPath) as ConfigYaml;
-    return Object.assign({}, jsonConfig, {
+    return Object.assign({}, yamlConfig, {
       configPath,
       // @deprecated use configPath instead
       config_path: configPath,
     });
   } catch (e: any) {
-    if (e.code !== 'MODULE_NOT_FOUND') {
-      debug('config module not found %o error: %o', configPath, e.message);
-      throw Error(APP_ERROR.CONFIG_NOT_VALID);
-    }
-
-    throw e;
+    debug('failed to parse config %o error: %o', configPath, e.message);
+    throw new Error(APP_ERROR.CONFIG_NOT_VALID, { cause: e });
   }
 }
 

--- a/packages/config/test/config-parsing.spec.ts
+++ b/packages/config/test/config-parsing.spec.ts
@@ -9,42 +9,22 @@ import { parseConfigurationFile } from './utils';
 
 describe('parse', () => {
   describe('parseConfigFile', () => {
-    describe('JSON format', () => {
-      test('parse default.json', () => {
-        const config = parseConfigFile(parseConfigurationFile('default.json'));
-
-        expect(config.storage).toBeDefined();
-      });
-
-      test('parse invalid.json', () => {
+    describe('non-YAML formats are rejected', () => {
+      test('throws for .json file', () => {
         expect(function () {
-          parseConfigFile(parseConfigurationFile('invalid.json'));
-        }).toThrow(new RegExp(/CONFIG: it does not look like a valid config file/));
+          parseConfigFile(parseConfigurationFile('default.json'));
+        }).toThrow(/config file must be a YAML file/);
       });
 
-      test('parse not-exists.json', () => {
+      test('throws for .js file', () => {
+        expect(function () {
+          parseConfigFile(parseConfigurationFile('default.js'));
+        }).toThrow(/config file must be a YAML file/);
+      });
+
+      test('throws when the file does not exist regardless of extension', () => {
         expect(function () {
           parseConfigFile(parseConfigurationFile('not-exists.json'));
-        }).toThrow(/config file does not exist or not reachable/);
-      });
-    });
-
-    describe('JavaScript format', () => {
-      test('parse default.js', () => {
-        const config = parseConfigFile(parseConfigurationFile('default.js'));
-
-        expect(config.storage).toBeDefined();
-      });
-
-      test('parse invalid.js', () => {
-        expect(function () {
-          parseConfigFile(parseConfigurationFile('invalid.js'));
-        }).toThrow(new RegExp(/CONFIG: it does not look like a valid config file/));
-      });
-
-      test('parse not-exists.js', () => {
-        expect(function () {
-          parseConfigFile(parseConfigurationFile('not-exists.js'));
         }).toThrow(/config file does not exist or not reachable/);
       });
     });


### PR DESCRIPTION
## Summary

Restrict `parseConfigFile` to YAML files (`.yaml` / `.yml`) only. Any other extension now throws `config file must be a YAML file (.yaml or .yml)`. The `require(configPath)` branch that previously loaded `.json` and `.js` config files is removed.

## Motivation

The `require()`-based loader was reported as a misuse vector and a potential security issue: an attacker who could write to the config path (or trick a user into pointing Verdaccio at one) could execute arbitrary code on startup via a `.js` config — the file is `require()`'d into the Verdaccio process. YAML parsing has no such side effect: it produces data, not code.

Restricting to YAML removes that attack surface and makes the config format predictable for tooling.

## Migration

Users with `.json` or `.js` config files have two options:

- **Convert to YAML.** Use `ConfigBuilder` from `@verdaccio/config` to programmatically build a config and serialize it to YAML, then point Verdaccio at the resulting `.yaml` file.
- **Use the programmatic API.** Pass a config object directly via `@verdaccio/node-api`'s `runServer(config)` instead of a file path.

## Breaking changes

- `parseConfigFile()` throws for any path not ending in `.yaml` or `.yml`.
- `.json` and `.js` config files are no longer loaded.

## Other changes

- Removed the no-op `strict: false` option from `YAML.load()` (not part of `js-yaml`'s API).
- Wrapped YAML parse failures with `cause` so the original error is preserved.