### PR TITLE
fix: tarball might fail #5829

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: [20, 22, 24]
+        node_version: [20, 22, 24, 26]
     uses: verdaccio/verdaccio/.github/workflows/yarn-ci.yml@master
     with:
       node_version: ${{ matrix.node_version }}

--- a/.github/workflows/smoke-test-filter-plugin.yml
+++ b/.github/workflows/smoke-test-filter-plugin.yml
@@ -1,0 +1,95 @@
+name: Filter Plugin Smoke Test
+
+on: [pull_request]
+
+permissions:
+  contents: read
+concurrency:
+  group: smoke-test-filter-plugin-${{ github.ref }}-6x
+  cancel-in-progress: true
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: [18, 20, 22, 24]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Use Node ${{ matrix.node_version }}
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: ${{ matrix.node_version }}
+      - name: Install dependencies
+        run: yarn
+      - name: Build
+        run: yarn build
+      - name: Setup verdaccio + @verdaccio/package-filter
+        run: |
+          mkdir -p /tmp/v-filter/plugins /tmp/v-filter/storage
+          cd /tmp/v-filter/plugins
+          npm init -y >/dev/null
+          npm install @verdaccio/package-filter@13 --no-audit --no-fund
+          cd /tmp/v-filter
+          cat > config.yaml <<'EOF'
+          storage: ./storage
+          plugins: ./plugins/node_modules
+          uplinks:
+            npmjs:
+              url: https://registry.npmjs.org/
+          packages:
+            '@*/*':
+              access: $all
+              publish: $authenticated
+              proxy: npmjs
+            '**':
+              access: $all
+              publish: $authenticated
+              proxy: npmjs
+          filters:
+            '@verdaccio/package-filter':
+              block:
+                - package: jquery
+                  versions: '=1.5.1'
+          log:
+            type: stdout
+            format: pretty
+            level: http
+          EOF
+      - name: Start verdaccio
+        run: |
+          nohup "$GITHUB_WORKSPACE/bin/verdaccio" --config /tmp/v-filter/config.yaml --listen 4873 > /tmp/verdaccio.log 2>&1 &
+          for i in {1..20}; do
+            if curl -fsS http://localhost:4873/-/ping >/dev/null 2>&1; then
+              echo "verdaccio is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "verdaccio failed to start"
+          cat /tmp/verdaccio.log
+          exit 1
+      - name: Regression 5829 — non-filtered tarball on cold cache must succeed
+        run: |
+          # Direct tarball request without pre-fetching metadata. Before #5829
+          # was fixed, the filter gate would 404 because the version wasn't in
+          # local metadata yet. Now it must defer to the uplink sync and serve.
+          curl -fsS -o /tmp/jquery-1.6.2.tgz http://localhost:4873/jquery/-/jquery-1.6.2.tgz
+          test -s /tmp/jquery-1.6.2.tgz
+          file /tmp/jquery-1.6.2.tgz | grep -i gzip
+      - name: Filter must block the configured version
+        run: |
+          status=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:4873/jquery/-/jquery-1.5.1.tgz)
+          echo "tarball status: $status"
+          test "$status" = "404"
+      - name: Sanity install of a non-filtered package
+        run: |
+          mkdir -p /tmp/test-install && cd /tmp/test-install
+          npm init -y >/dev/null
+          npm install lodash@4.17.21 --registry http://localhost:4873 --no-audit --no-fund --loglevel info
+          test -d node_modules/lodash
+      - name: Show verdaccio log on failure
+        if: failure()
+        run: cat /tmp/verdaccio.log

--- a/.github/workflows/smoke-test-import-module.yml
+++ b/.github/workflows/smoke-test-import-module.yml
@@ -24,14 +24,29 @@ jobs:
       - name: Docker test
         run: |
             docker run -d -it --rm --name verdaccio -p 4873:4873 -e "DEBUG=verdaccio*" verdaccio/verdaccio:6
+      - name: wait for verdaccio
+        run: |
+          for i in $(seq 1 30); do
+            if npx --yes @verdaccio/registry-cli ping -r http://localhost:4873 >/dev/null 2>&1; then
+              echo "verdaccio is up"; exit 0
+            fi
+            sleep 1
+          done
+          echo "verdaccio did not become ready"
+          docker logs verdaccio || true
+          exit 1
       - name: login
         run: |
-          token=$(curl -fsS -X PUT \
+          set -euo pipefail
+          response=$(curl -fsS -X PUT \
             -H "Content-Type: application/json" \
             -d '{"name":"test","password":"1234","email":"test@domain.test"}' \
-            http://localhost:4873/-/user/org.couchdb.user:test \
-            | jq -r .token)
-          test -n "$token" && test "$token" != "null"
+            http://localhost:4873/-/user/org.couchdb.user:test)
+          token=$(printf '%s' "$response" | jq -r .token)
+          if [ -z "$token" ] || [ "$token" = "null" ]; then
+            echo "no token in response: $response"
+            exit 1
+          fi
           echo "//localhost:4873/:_authToken=$token" >> ~/.npmrc
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/smoke-test-import-module.yml
+++ b/.github/workflows/smoke-test-import-module.yml
@@ -24,8 +24,8 @@ jobs:
       - name: Docker test
         run: |
             docker run -d -it --rm --name verdaccio -p 4873:4873 -e "DEBUG=verdaccio*" verdaccio/verdaccio:6
-      - name: login    
-        run: npx npm-cli-login -u test -p 1234 -e test@domain.test -r http://localhost:4873                 
+      - name: login
+        run: yarn dlx @verdaccio/registry-cli login -u test -p 1234 -e test@domain.test -r http://localhost:4873
       - name: Install dependencies
         run: yarn
       - name: Bump up package and save version

--- a/.github/workflows/smoke-test-import-module.yml
+++ b/.github/workflows/smoke-test-import-module.yml
@@ -25,7 +25,14 @@ jobs:
         run: |
             docker run -d -it --rm --name verdaccio -p 4873:4873 -e "DEBUG=verdaccio*" verdaccio/verdaccio:6
       - name: login
-        run: yarn dlx @verdaccio/registry-cli login -u test -p 1234 -e test@domain.test -r http://localhost:4873
+        run: |
+          token=$(curl -fsS -X PUT \
+            -H "Content-Type: application/json" \
+            -d '{"name":"test","password":"1234","email":"test@domain.test"}' \
+            http://localhost:4873/-/user/org.couchdb.user:test \
+            | jq -r .token)
+          test -n "$token" && test "$token" != "null"
+          echo "//localhost:4873/:_authToken=$token" >> ~/.npmrc
       - name: Install dependencies
         run: yarn
       - name: Bump up package and save version

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -39,7 +39,7 @@ import {
 } from './storage-utils';
 import ProxyStorage from './up-storage';
 import { setupUpLinks, updateVersionsHiddenUpLink } from './uplink-util';
-import { ErrorCode, isObject, normalizeDistTags } from './utils';
+import { ErrorCode, hasTarball, isObject, normalizeDistTags } from './utils';
 
 const debug = buildDebug('verdaccio:storage');
 
@@ -308,6 +308,11 @@ class Storage {
             (syncErr, syncInfo: Manifest): any => {
               if (_.isNil(syncErr) === false) {
                 return readStream.emit('error', syncErr);
+              }
+              // _syncUplinksMetadata returns filter-applied metadata; if the
+              // version was removed by a filter, surface a 404 like a missing tarball.
+              if (self.filters?.length && !hasTarball(syncInfo, filename)) {
+                return readStream.emit('error', err404);
               }
               if (_.isNil(syncInfo._distfiles) || _.isNil(syncInfo._distfiles[filename])) {
                 return readStream.emit('error', err404);
@@ -742,9 +747,10 @@ class Storage {
   }
 
   /**
-   * Check if a tarball should be served based on filter plugins.
-   * Looks up package metadata, applies filters, and verifies the tarball
-   * still belongs to an allowed version.
+   * Check if a tarball should be served based on filter plugins, using only
+   * local metadata. Returns true (defer) when the version isn't cached locally
+   * — the uplink-sync path in getTarball re-checks filters after sync, which
+   * avoids a redundant uplink round-trip and double filter application.
    */
   private async _isTarballAllowedByFilters(name: string, filename: string): Promise<boolean> {
     if (!this.filters?.length) {
@@ -753,20 +759,19 @@ class Storage {
 
     try {
       const pkgMetadata = await this.localStorage.getPackageMetadataAsync(name);
+      if (!hasTarball(pkgMetadata, filename)) {
+        return true;
+      }
       const { filteredPackage } = await this._applyFilters(pkgMetadata);
-      return Object.values(filteredPackage.versions || {}).some((version) =>
-        (version as Version).dist?.tarball?.endsWith('/' + filename)
-      );
+      return hasTarball(filteredPackage, filename);
     } catch (err: any) {
       if (err?.status === HTTP_STATUS.NOT_FOUND) {
-        // Package not yet cached locally — the request will fall through to uplinks.
-        debug('package %o not cached locally, skipping tarball filter check', name);
-      } else {
-        this.logger.error(
-          { package: name, fileName: filename, err },
-          'error checking filters for tarball @{fileName} of package @{package}: @{err.message}'
-        );
+        return true;
       }
+      this.logger.error(
+        { package: name, fileName: filename, err },
+        'error checking filters for tarball @{fileName} of package @{package}: @{err.message}'
+      );
       return true;
     }
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -275,4 +275,14 @@ export function hasLogin(config: Config) {
   return _.isNil(config?.web?.login) || config?.web?.login === true;
 }
 
+/**
+ * Check whether any version in a package manifest has a tarball URL
+ * that matches the given filename.
+ */
+export function hasTarball(pkg: Manifest, filename: string): boolean {
+  return Object.values(pkg.versions || {}).some((version) =>
+    (version as Version).dist?.tarball?.endsWith('/' + filename)
+  );
+}
+
 export { buildTokenUtil as buildToken, parseConfigFile };

--- a/test/unit/modules/storage/store.spec.ts
+++ b/test/unit/modules/storage/store.spec.ts
@@ -939,6 +939,21 @@ describe('StorageTest', () => {
       expect(result).toBe(true);
     });
 
+    test('should defer (return true) when version is not in local metadata', async () => {
+      const storage: any = await generateStorage();
+      const filterSpy = vi.fn(async (p: any) => p);
+      storage.filters = [{ filter_metadata: filterSpy }];
+      ensureLocalMetadata('npm_test');
+      // Version 2.0.0 isn't cached locally — defer to the uplink-sync path
+      // (handled in getTarball). The filter should not run here.
+      const result = await storage._isTarballAllowedByFilters(
+        'npm_test',
+        'npm_test-2.0.0.tgz'
+      );
+      expect(result).toBe(true);
+      expect(filterSpy).not.toHaveBeenCalled();
+    });
+
     test('should return false when tarball version is filtered out', async () => {
       const storage: any = await generateStorage();
       storage.filters = [
@@ -1104,6 +1119,49 @@ describe('StorageTest', () => {
         stream.on('error', (err: any) => {
           try {
             // Should get a 404 because version 1.0.0 is filtered out
+            expect(err.status).toBe(HTTP_STATUS.NOT_FOUND);
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        });
+        stream.on('open', () => {
+          reject(new Error('Expected tarball to be blocked but stream opened'));
+        });
+      });
+    });
+
+    test('should block tarball after uplink sync when filter rejects version', async () => {
+      const storage: any = await generateStorage();
+      storage.filters = [
+        {
+          filter_metadata: vi.fn(async (pkg: any) => {
+            const clone = { ...pkg, versions: { ...pkg.versions } };
+            delete clone.versions['1.5.1'];
+            return clone;
+          }),
+        },
+      ];
+
+      // Force the local tarball + metadata to look absent so the request flows
+      // through lookupFromUplinks. The uplink (nocked) returns jquery metadata
+      // with 1.5.1, but the filter removes it — the post-sync check must 404.
+      const notFoundErr = Object.assign(new Error('no such package'), {
+        status: HTTP_STATUS.NOT_FOUND,
+      });
+      storage.localStorage.getPackageMetadata = vi.fn((_n, cb) => cb(notFoundErr));
+      storage.localStorage.getTarball = vi.fn(() => {
+        const { ReadTarball } = require('@verdaccio/streams');
+        const stream: any = new ReadTarball({});
+        stream.abort = () => {};
+        process.nextTick(() => stream.emit('error', notFoundErr));
+        return stream;
+      });
+
+      return new Promise<void>((resolve, reject) => {
+        const stream = storage.getTarball('jquery', 'jquery-1.5.1.tgz');
+        stream.on('error', (err: any) => {
+          try {
             expect(err.status).toBe(HTTP_STATUS.NOT_FOUND);
             resolve();
           } catch (error) {

--- a/test/unit/modules/utils/utils.spec.ts
+++ b/test/unit/modules/utils/utils.spec.ts
@@ -4,7 +4,13 @@ import { GENERIC_AVATAR, generateGravatarUrl } from '@verdaccio/utils';
 
 import { DIST_TAGS } from '../../../../src/lib/constants';
 import { logger, setup } from '../../../../src/lib/logger';
-import { getVersion, normalizeDistTags, parseReadme, sortByName } from '../../../../src/lib/utils';
+import {
+  getVersion,
+  hasTarball,
+  normalizeDistTags,
+  parseReadme,
+  sortByName,
+} from '../../../../src/lib/utils';
 
 setup({});
 
@@ -154,6 +160,33 @@ describe('Utilities', () => {
         { packageName: 'testPackage' },
         '@{packageName}: No readme found'
       );
+    });
+  });
+
+  describe('hasTarball', () => {
+    test('should return true when tarball filename matches a version', () => {
+      expect(hasTarball(metadata, 'npm_test-1.0.0.tgz')).toBe(true);
+    });
+
+    test('should return false when tarball filename does not match', () => {
+      expect(hasTarball(metadata, 'npm_test-2.0.0.tgz')).toBe(false);
+    });
+
+    test('should return false for empty versions', () => {
+      expect(hasTarball({ versions: {} } as any, 'npm_test-1.0.0.tgz')).toBe(false);
+    });
+
+    test('should return false when versions is undefined', () => {
+      expect(hasTarball({} as any, 'npm_test-1.0.0.tgz')).toBe(false);
+    });
+
+    test('should return false when dist is missing', () => {
+      const pkg = { versions: { '1.0.0': {} } } as any;
+      expect(hasTarball(pkg, 'pkg-1.0.0.tgz')).toBe(false);
+    });
+
+    test('should not match partial filenames', () => {
+      expect(hasTarball(metadata, 'test-1.0.0.tgz')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Fixes the tarball filter regression described in #5829 by avoiding a false 404 when a requested tarball version is not yet present in local metadata. The filter check now defers to the uplink sync path for uncached versions and re-validates the synced manifest before serving the tarball, while adding targeted unit coverage and a smoke test for the cold-cache case.