### PR TITLE
feat: docker file refactor deploy

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,60 @@
+name: Docker build test
+
+on:
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+      - 'docker-bin/**'
+      - 'packages/config/src/conf/docker.yaml'
+      - '.github/workflows/docker-build-test.yml'
+
+concurrency:
+  group: docker-build-test-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Build image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: verdaccio/verdaccio:pr-${{ github.event.pull_request.number }}
+
+      - name: Run container
+        run: |
+          docker run -d --rm --name verdaccio \
+            verdaccio/verdaccio:pr-${{ github.event.pull_request.number }}
+
+      - name: Ping registry with verdaccioctl (inside container)
+        run: |
+          for i in $(seq 1 30); do
+            if docker exec -u 0 verdaccio npx -y @verdaccio/registry-cli ping -r http://localhost:4873; then
+              echo "Verdaccio responded after ${i} attempt(s)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Verdaccio did not respond within 30 attempts"
+          docker logs verdaccio
+          exit 1
+
+      - name: Stop container
+        if: always()
+        run: docker stop verdaccio || true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,3 +54,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm -g i corepack && \
     pnpm --filter verdaccio --prod --legacy deploy /opt/verdaccio-deploy
 
 FROM node:24-alpine
-LABEL maintainer="https://github.com/verdaccio/verdaccio"
+LABEL maintainer="https://github.com/verdaccio"
 
 ENV VERDACCIO_APPDIR=/opt/verdaccio \
     VERDACCIO_USER_NAME=verdaccio \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,23 +3,17 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} node:24-alpine AS builder
 ENV NODE_ENV=development \
     VERDACCIO_BUILD_REGISTRY=https://registry.npmjs.org
 
-RUN apk --no-cache add openssl ca-certificates wget && \
-    apk --no-cache add g++ gcc libgcc libstdc++ linux-headers make python3 && \
-    wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub && \
-    wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.35-r0/glibc-2.35-r0.apk && \
-    apk add --force-overwrite glibc-2.35-r0.apk
+RUN apk --no-cache add ca-certificates g++ gcc libgcc libstdc++ linux-headers make python3
 
 WORKDIR /opt/verdaccio-build
 COPY . .
+
 RUN npm -g i corepack && \
     corepack install && \
     pnpm config set registry $VERDACCIO_BUILD_REGISTRY && \
     pnpm install --frozen-lockfile --ignore-scripts && \
-    rm -Rf test && \
-    pnpm run build
-# FIXME: need to remove devDependencies from the build
-# NODE_ENV=production pnpm install --frozen-lockfile --ignore-scripts
-# RUN pnpm install --prod --ignore-scripts
+    pnpm run build && \
+    pnpm --filter verdaccio --prod --legacy deploy /opt/verdaccio-deploy
 
 FROM node:24-alpine
 LABEL maintainer="https://github.com/verdaccio/verdaccio"
@@ -35,17 +29,15 @@ ENV PATH=$VERDACCIO_APPDIR/docker-bin:$PATH \
 
 WORKDIR $VERDACCIO_APPDIR
 
-RUN apk --no-cache add openssl dumb-init
+RUN apk --no-cache add openssl dumb-init && \
+    mkdir -p /verdaccio/storage /verdaccio/plugins /verdaccio/conf
 
-RUN mkdir -p /verdaccio/storage /verdaccio/plugins /verdaccio/conf
-
-COPY --from=builder /opt/verdaccio-build .
-
-RUN ls packages/config/src/conf
-ADD packages/config/src/conf/docker.yaml /verdaccio/conf/config.yaml
+COPY --from=builder /opt/verdaccio-deploy ./
+COPY docker-bin ./docker-bin
+COPY packages/config/src/conf/docker.yaml /verdaccio/conf/config.yaml
 
 RUN adduser -u $VERDACCIO_USER_UID -S -D -h $VERDACCIO_APPDIR -g "$VERDACCIO_USER_NAME user" -s /sbin/nologin $VERDACCIO_USER_NAME && \
-    chmod -R +x $VERDACCIO_APPDIR/packages/verdaccio/bin $VERDACCIO_APPDIR/docker-bin && \
+    chmod -R +x $VERDACCIO_APPDIR/bin $VERDACCIO_APPDIR/docker-bin && \
     chown -R $VERDACCIO_USER_UID:root /verdaccio/storage /verdaccio/conf && \
     chmod -R g=u /verdaccio/storage /verdaccio/conf /etc/passwd
 
@@ -57,4 +49,4 @@ VOLUME /verdaccio/storage
 
 ENTRYPOINT ["uid_entrypoint"]
 
-CMD $VERDACCIO_APPDIR/packages/verdaccio/bin/verdaccio --config /verdaccio/conf/config.yaml --listen $VERDACCIO_PROTOCOL://$VERDACCIO_ADDRESS:$VERDACCIO_PORT
+CMD $VERDACCIO_APPDIR/bin/verdaccio --config /verdaccio/conf/config.yaml --listen $VERDACCIO_PROTOCOL://$VERDACCIO_ADDRESS:$VERDACCIO_PORT


### PR DESCRIPTION
## Summary

Refactor of the `Dockerfile` to produce a leaner, more deterministic image by leveraging `pnpm deploy` instead of copying the full monorepo into the runtime stage.

### Builder stage
- Dropped the `glibc-2.35-r0` install (sgerrand keys + `wget` + `openssl` no longer pulled in); only the toolchain actually needed for native deps is installed (`ca-certificates`, `g++`, `gcc`, `libgcc`, `libstdc++`, `linux-headers`, `make`, `python3`).
- Removed the `rm -Rf test` step and the stale `FIXME` block about pruning devDependencies.
- Added `pnpm --filter verdaccio --prod --legacy deploy /opt/verdaccio-deploy` so the builder emits a self-contained production deployment of the `verdaccio` package.

### Runtime stage
- Now copies the pre-pruned `/opt/verdaccio-deploy` output (production deps only) instead of the entire `verdaccio-build` workspace, plus `docker-bin` and the docker `config.yaml` directly.
- Collapsed the two `apk add` + `mkdir` steps into a single `RUN` to reduce layers.
- Removed the leftover debug `RUN ls packages/config/src/conf` line.
- Updated `chmod` target and `CMD` entrypoint to use the new flat layout (`$VERDACCIO_APPDIR/bin/verdaccio`) instead of the monorepo path (`$VERDACCIO_APPDIR/packages/verdaccio/bin/verdaccio`).
