### PR TITLE
fix(middleware): assets test

### DIFF
--- a/.changeset/shaggy-crabs-glow.md
+++ b/.changeset/shaggy-crabs-glow.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/middleware': patch
+---
+
+fix(middleware): assets test

--- a/packages/middleware/src/middlewares/web/render-web.ts
+++ b/packages/middleware/src/middlewares/web/render-web.ts
@@ -121,6 +121,11 @@ export function renderWebMiddleware(config, tokenMiddleware, pluginOptions) {
       WebUrlsNamespace.assets,
       function (req: express.Request<{ all: string | string[] }>, res, next) {
         const filename = Array.isArray(req.params.all) ? req.params.all.join('/') : req.params.all;
+        // Express normalizes `.`/`%2E` segments out of the URL, leaving the
+        // wildcard param undefined; treat that as a 404.
+        if (!filename) {
+          return next();
+        }
         sendFileSafe(config.web.assetFolder, filename, res, next);
       }
     );


### PR DESCRIPTION
Ref #5653 

Fixes middleware test for assets feature and now returns 404 for assets folder itself.

```
FAIL  test/render.spec.ts > test web server > render > assetFolder > should not serve the asset folder 
itself as a file
AssertionError: expected 500 to be 404 // Object.is equality
```