### PR TITLE
fix: add types to 6.x changeset publish

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -33,6 +33,8 @@ jobs:
         run: yarn install --immutable
       - name: Build
         run: yarn build
+      - name: Types
+        run: yarn code:types    
       - name: create versions or publish
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b


### PR DESCRIPTION
The types got lost between [6.6.0 and 6.6.2](https://github.com/verdaccio/verdaccio/compare/v6.6.0...v6.6.2) with the switch to changesets.

This adds the missing step which was originally included in `yarn-ci.yml@master`.

Closes #5889