### PR TITLE
fix(core): password regex validation

### DIFF
--- a/.changeset/rotten-kings-cry.md
+++ b/.changeset/rotten-kings-cry.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/types': patch
+'@verdaccio/core': patch
+---
+
+fix(core): password regex validation

--- a/packages/core/core/src/validation-utils.ts
+++ b/packages/core/core/src/validation-utils.ts
@@ -112,11 +112,28 @@ export function isObject(obj: any): boolean {
 
 export function validatePassword(
   password: string,
-  validation: RegExp = DEFAULT_PASSWORD_VALIDATION
+  validation: RegExp | string = DEFAULT_PASSWORD_VALIDATION
 ): boolean {
-  return typeof password === 'string' && validation instanceof RegExp
-    ? password.match(validation) !== null
-    : false;
+  if (typeof password !== 'string') {
+    return false;
+  }
+
+  let regex: RegExp;
+  if (validation instanceof RegExp) {
+    regex = validation;
+  } else if (typeof validation === 'string') {
+    // YAML config loads `passwordValidationRegex` as a plain string,
+    // so coerce it into a RegExp here. Invalid patterns fall back to false.
+    try {
+      regex = new RegExp(validation);
+    } catch {
+      return false;
+    }
+  } else {
+    return false;
+  }
+
+  return password.match(regex) !== null;
 }
 
 export function validateUserName(userName: any, expectedName: string): boolean {

--- a/packages/core/core/test/validation-utilts.spec.ts
+++ b/packages/core/core/test/validation-utilts.spec.ts
@@ -165,6 +165,36 @@ describe('validatePassword', () => {
   test('should validate password according the length and default config', () => {
     expect(validatePassword('1235678910')).toBeTruthy();
   });
+
+  test('should accept regex provided as string (YAML config case)', () => {
+    expect(validatePassword('12345', '.{3}$')).toBeTruthy();
+  });
+
+  test('should fail when password does not match string regex', () => {
+    expect(validatePassword('12', '.{3}$')).toBeFalsy();
+  });
+
+  test('should handle complex password validation provided as string', () => {
+    expect(
+      validatePassword(
+        'XYabc67test!',
+        '^(?=.{8,64}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9\\s])(?=\\S+$).+$'
+      )
+    ).toBeTruthy();
+  });
+
+  test('should fail complex password validation provided as string', () => {
+    expect(
+      validatePassword(
+        'weakpass',
+        '^(?=.{8,64}$)(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9\\s])(?=\\S+$).+$'
+      )
+    ).toBeFalsy();
+  });
+
+  test('should fail safely when string regex is invalid', () => {
+    expect(validatePassword('whatever', '[invalid(regex')).toBeFalsy();
+  });
 });
 
 describe('validateUserName', () => {

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -273,7 +273,7 @@ export type ServerSettingsConf = {
    * acme-XXXXXX
    */
   pluginPrefix?: string;
-  passwordValidationRegex?: RegExp;
+  passwordValidationRegex?: RegExp | string;
   // docs on `trustProxy` can be found at: https://expressjs.com/en/guide/behind-proxies.html
   trustProxy?: string;
   // Controls how requests with dotfile path segments (e.g. /.env, /.well-known/) are handled.


### PR DESCRIPTION
Ref #3384 

Passing a regex with `{x,y}`, `\d`, or `\s` escapes from config yaml is fragile. This change allows wrapping it in single quotes ('…') which is safer against future edits or stricter parsers.