### PR TITLE
chore: export functions to reuse

### DIFF
--- a/.changeset/cozy-aliens-return.md
+++ b/.changeset/cozy-aliens-return.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/server': patch
+'@verdaccio/cli': patch
+---
+
+export functions to reuse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
             packages/*/*/build
             packages/*/*/dist
             packages/plugins/ui-theme/static
-          key: ci-build-${{ github.sha }}-node-${{ matrix.node_version }}
+          key: ci-build-${{ github.run_id }}-${{ github.run_attempt }}-node-${{ matrix.node_version }}
   test-docker:
     needs: [build]
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == false && !failure() && !cancelled() }}
@@ -133,7 +133,7 @@ jobs:
             packages/*/*/build
             packages/*/*/dist
             packages/plugins/ui-theme/static
-          key: ci-build-${{ github.sha }}-node-${{ matrix.node_version }}
+          key: ci-build-${{ github.run_id }}-${{ github.run_attempt }}-node-${{ matrix.node_version }}
           fail-on-cache-miss: true
       - name: Test (Node 26)
         if: matrix.node_version == 26
@@ -184,7 +184,7 @@ jobs:
             packages/*/*/build
             packages/*/*/dist
             packages/plugins/ui-theme/static
-          key: ci-build-${{ github.sha }}-node-24
+          key: ci-build-${{ github.run_id }}-${{ github.run_attempt }}-node-24
           fail-on-cache-miss: true
       - name: Start Verdaccio
         run: |
@@ -216,7 +216,7 @@ jobs:
             packages/*/*/build
             packages/*/*/dist
             packages/plugins/ui-theme/static
-          key: ci-build-${{ github.sha }}-node-24
+          key: ci-build-${{ github.run_id }}-${{ github.run_attempt }}-node-24
           fail-on-cache-miss: true
       # The shared install-app action runs `pnpm install --ignore-scripts`,
       # so cypress's postinstall (which downloads the test runner binary) is
@@ -341,5 +341,5 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh cache delete "ci-build-${{ github.sha }}-node-24" --repo ${{ github.repository }} || true
-          gh cache delete "ci-build-${{ github.sha }}-node-26" --repo ${{ github.repository }} || true
+          gh cache delete "ci-build-${{ github.run_id }}-${{ github.run_attempt }}-node-24" --repo ${{ github.repository }} || true
+          gh cache delete "ci-build-${{ github.run_id }}-${{ github.run_attempt }}-node-26" --repo ${{ github.repository }} || true

--- a/packages/cli/bin/verdaccio
+++ b/packages/cli/bin/verdaccio
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../build');
+require('../build').runCli();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -5,38 +5,57 @@ import { pkgUtils, warningUtils } from '@verdaccio/core';
 import { InfoCommand } from './commands/info';
 import { InitCommand } from './commands/init';
 import { VersionCommand } from './commands/version';
+import type { CliRuntimeOptions } from './runtime';
+import { configureCli } from './runtime';
 import { MIN_NODE_VERSION, isVersionValid } from './utils';
 
-if (process.getuid && process.getuid() === 0) {
-  warningUtils.emit(warningUtils.Codes.VERWAR001);
-}
+/**
+ * Build and run the Verdaccio CLI.
+ *
+ * Called with no arguments it behaves exactly like the standalone `verdaccio`
+ * binary. Downstream distributions can inject a custom server factory (and
+ * version/name) via {@link CliRuntimeOptions} — e.g. a registry that needs to
+ * boot with a custom Storage — without re-implementing the command set.
+ */
+export function runCli(options: CliRuntimeOptions = {}): Promise<number> {
+  configureCli(options);
 
-if (!isVersionValid(process.version)) {
-  throw new Error(
-    `Verdaccio requires at least Node.js v${MIN_NODE_VERSION} or higher and you have installed ${process.version}, 
+  if (process.getuid && process.getuid() === 0) {
+    warningUtils.emit(warningUtils.Codes.VERWAR001);
+  }
+
+  if (!isVersionValid(process.version)) {
+    throw new Error(
+      `Verdaccio requires at least Node.js v${MIN_NODE_VERSION} or higher and you have installed ${process.version},
     please upgrade your Node.js distribution`
-  );
+    );
+  }
+
+  const [node, app, ...args] = process.argv;
+
+  const version =
+    options.version ??
+    (pkgUtils.getPackageJson(
+      typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname,
+      '..'
+    ).version as string);
+
+  const cli = new Cli({
+    binaryLabel: `verdaccio`,
+    binaryName: `${node} ${app}`,
+    binaryVersion: version,
+  });
+
+  cli.register(InfoCommand);
+  cli.register(InitCommand);
+  cli.register(VersionCommand);
+
+  process.on('uncaughtException', function (err) {
+    console.error(
+      `uncaught exception, please report (https://github.com/verdaccio/verdaccio/issues) this: \n${err.stack}`
+    );
+    process.exit(1);
+  });
+
+  return cli.runExit(args, Cli.defaultContext);
 }
-
-const [node, app, ...args] = process.argv;
-
-const cli = new Cli({
-  binaryLabel: `verdaccio`,
-  binaryName: `${node} ${app}`,
-  binaryVersion: pkgUtils.getPackageJson(
-    typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname,
-    '..'
-  ).version as string,
-});
-
-cli.register(InfoCommand);
-cli.register(InitCommand);
-cli.register(VersionCommand);
-cli.runExit(args, Cli.defaultContext);
-
-process.on('uncaughtException', function (err) {
-  console.error(
-    `uncaught exception, please report (https://github.com/verdaccio/verdaccio/issues) this: \n${err.stack}`
-  );
-  process.exit(1);
-});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,8 +4,9 @@ import { findConfigFile, parseConfigFile } from '@verdaccio/config';
 import { pkgUtils, warningUtils } from '@verdaccio/core';
 import { logger, setup } from '@verdaccio/logger';
 import { initServer } from '@verdaccio/node-api';
-import startServer from '@verdaccio/server';
 import type { ConfigYaml, LoggerConfigItem } from '@verdaccio/types';
+
+import { getPkgNameOverride, getStartServer, getVersionOverride } from '../runtime';
 
 export const DEFAULT_PROCESS_NAME: string = 'verdaccio';
 
@@ -64,14 +65,16 @@ export class InitCommand extends Command {
       process.title = web?.title || DEFAULT_PROCESS_NAME;
 
       const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-      const { version, name } = pkgUtils.getPackageJson(currentDir, '../..');
+      const pkg = pkgUtils.getPackageJson(currentDir, '../..');
+      const version = getVersionOverride() ?? (pkg.version as string);
+      const name = getPkgNameOverride() ?? (pkg.name as string);
 
       await initServer(
         configParsed,
         this.port as string,
         version as string,
         name as string,
-        startServer
+        getStartServer()
       );
 
       const logLevel = configParsed.log?.level || 'default';

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -2,12 +2,14 @@ import { Command } from 'clipanion';
 
 import { pkgUtils } from '@verdaccio/core';
 
+import { getVersionOverride } from '../runtime';
+
 export class VersionCommand extends Command {
   static paths = [[`--version`], [`-v`]];
 
   async execute() {
     const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-    const { version } = pkgUtils.getPackageJson(currentDir, '../..');
+    const version = getVersionOverride() ?? pkgUtils.getPackageJson(currentDir, '../..').version;
     this.context.stdout.write(`v${version}\n`);
     process.exit(0);
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,1 +1,7 @@
-import './cli';
+export { runCli } from './cli';
+export { configureCli } from './runtime';
+export type { CliRuntimeOptions, ServerFactory } from './runtime';
+export { InfoCommand } from './commands/info';
+export { InitCommand } from './commands/init';
+export { VersionCommand } from './commands/version';
+export { MIN_NODE_VERSION, isVersionValid } from './utils';

--- a/packages/cli/src/runtime.ts
+++ b/packages/cli/src/runtime.ts
@@ -1,0 +1,45 @@
+import defaultStartServer from '@verdaccio/server';
+import type { ConfigYaml } from '@verdaccio/types';
+
+export type ServerFactory = (config: ConfigYaml) => Promise<any>;
+
+export interface CliRuntimeOptions {
+  /**
+   * The server factory used by the default (start) command. Defaults to
+   * `@verdaccio/server`. Downstream distributions (e.g. a registry that needs a
+   * custom Storage) can inject their own factory here.
+   */
+  startServer?: ServerFactory;
+  /** Version string reported by `--version` and the startup banner. */
+  version?: string;
+  /** Process/package name reported on startup. */
+  pkgName?: string;
+}
+
+let _startServer: ServerFactory = defaultStartServer;
+let _version: string | undefined;
+let _pkgName: string | undefined;
+
+export function configureCli(options: CliRuntimeOptions = {}): void {
+  if (options.startServer) {
+    _startServer = options.startServer;
+  }
+  if (options.version) {
+    _version = options.version;
+  }
+  if (options.pkgName) {
+    _pkgName = options.pkgName;
+  }
+}
+
+export function getStartServer(): ServerFactory {
+  return _startServer;
+}
+
+export function getVersionOverride(): string | undefined {
+  return _version;
+}
+
+export function getPkgNameOverride(): string | undefined {
+  return _pkgName;
+}

--- a/packages/server/express/src/index.ts
+++ b/packages/server/express/src/index.ts
@@ -1,1 +1,1 @@
-export { default, startServer } from './server';
+export { default, startServer, defineAPI } from './server';

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -41,7 +41,7 @@ const debug = buildDebug('verdaccio:server');
 const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
 const { version } = pkgUtils.getPackageJson(currentDir, '..');
 
-const defineAPI = async function (config: IConfig, storage: Storage): Promise<Express> {
+export const defineAPI = async function (config: IConfig, storage: Storage): Promise<Express> {
   const auth = new Auth(config, logger);
   await auth.init();
   const app = express();

--- a/packages/verdaccio/debug/bootstrap.js
+++ b/packages/verdaccio/debug/bootstrap.js
@@ -1,4 +1,4 @@
 // this file aims to help local debugging with hot transpilation
 // uses tsx for fast TypeScript execution (replaces @babel/register)
 require('tsx/cjs');
-require('@verdaccio/cli');
+require('@verdaccio/cli').runCli();

--- a/packages/verdaccio/src/start.ts
+++ b/packages/verdaccio/src/start.ts
@@ -1,1 +1,3 @@
-import '@verdaccio/cli';
+import { runCli } from '@verdaccio/cli';
+
+runCli();


### PR DESCRIPTION
Export the server composition and CLI so downstream distributions can reuse them with a **custom `Storage`** instead of forking.

- `@verdaccio/server`: export `defineAPI(config, storage)` — build the app with a caller-provided `Storage`.
- `@verdaccio/cli`: export `runCli`/`configureCli` (+ command classes); inject the server factory / version via a small `runtime`. `bin` now calls `runCli()`.

Additive and backward compatible — the standalone `verdaccio` binary calls `runCli()` and behaves exactly as before.