### PR TITLE
fix: enforce generated npm token metadata

### DIFF
--- a/.changeset/enforce-generated-token-metadata.md
+++ b/.changeset/enforce-generated-token-metadata.md
@@ -1,0 +1,25 @@
+---
+'@verdaccio/middleware': patch
+'@verdaccio/signature': patch
+'@verdaccio/auth': patch
+'@verdaccio/core': patch
+'@verdaccio/types': patch
+---
+
+fix: enforce generated npm token metadata
+
+Generated npm tokens (`POST /-/npm/v1/tokens`) stored their `readonly` and
+`cidr_whitelist` restrictions but never enforced them, and deleting a token did
+not revoke it for the package APIs. A token marked read-only or pinned to a CIDR
+range could still publish packages and change dist-tags, and a deleted token
+remained usable.
+
+Generated tokens now embed a server-issued key (in the JWT claim, or in the
+encrypted legacy AES payload), and a new `enforceGeneratedTokenMetadata`
+middleware looks that key up on each request and rejects the token when it is
+missing/revoked, used outside its CIDR whitelist, or used for a write while
+read-only. Enforcement applies to both AES and JWT API-token modes.
+
+Note: tokens issued before upgrading carry no key and are not retroactively
+constrained — regenerate them to apply the restrictions. Web UI enforcement of
+generated-token metadata is tracked as a follow-up.

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -510,12 +510,12 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
         next(errorUtils.getBadRequest(API_ERROR.BAD_USERNAME_PASSWORD));
         return;
       }
-      const { user, password } = parsedCredentials as AESPayload;
+      const { user, password, tokenKey } = parsedCredentials as AESPayload;
       debug('authenticating %o', user);
       this.authenticate(user, password, (err: VerdaccioError | null, user): void => {
         if (!err) {
           debug('generating a remote user');
-          req.remote_user = user;
+          req.remote_user = tokenKey ? { ...user, token: { key: tokenKey } } : user;
           next();
         } else {
           debug('generating anonymous user');
@@ -552,11 +552,11 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     const credentials: any = getMiddlewareCredentials(security, secret, authorization);
     debug('api middleware credentials %o', credentials?.name);
     if (credentials) {
-      const { user, password } = credentials;
+      const { user, password, tokenKey } = credentials;
       debug('authenticating %o', user);
       this.authenticate(user, password, (err, user): void => {
         if (!err) {
-          req.remote_user = user;
+          req.remote_user = tokenKey ? { ...user, token: { key: tokenKey } } : user;
           debug('generating a remote user');
           next();
         } else {
@@ -629,7 +629,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
   }
 
   public async jwtEncrypt(user: RemoteUser, signOptions: JWTSignOptions): Promise<string> {
-    const { real_groups, name, groups } = user;
+    const { real_groups, name, groups, token: tokenMetadata } = user;
     debug('jwt encrypt %o', name);
     const realGroupsValidated = _.isNil(real_groups) ? [] : real_groups;
     const groupedGroups = _.isNil(groups)
@@ -640,9 +640,12 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
       name,
       groups: groupedGroups,
     };
-    const token: string = await signPayload(payload, this.secret, signOptions);
+    if (tokenMetadata?.key) {
+      payload.token = { key: tokenMetadata.key };
+    }
+    const signedToken: string = await signPayload(payload, this.secret, signOptions);
 
-    return token;
+    return signedToken;
   }
 
   /**

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -6,6 +6,7 @@ import type { AuthPackageAllow, JWTSignOptions, Logger, RemoteUser } from '@verd
 export interface AESPayload {
   user: string;
   password: string;
+  tokenKey?: string;
 }
 
 export type BasicPayload = AESPayload | void;

--- a/packages/auth/src/utils.ts
+++ b/packages/auth/src/utils.ts
@@ -101,25 +101,29 @@ export async function getApiToken(
   auth: TokenEncryption,
   config: Config,
   remoteUser: RemoteUser,
-  aesPassword: string
+  aesPassword: string,
+  options: { tokenKey?: string } = {}
 ): Promise<string | void> {
   debug('get api token');
   const { security } = config;
+  const tokenUser: RemoteUser = options.tokenKey
+    ? { ...remoteUser, token: { key: options.tokenKey } }
+    : remoteUser;
 
   if (isAESLegacy(security)) {
     debug('security legacy enabled');
     // fallback all goes to AES encryption
     return await new Promise((resolve): void => {
-      resolve(auth.aesEncrypt(buildUser(remoteUser.name as string, aesPassword)));
+      resolve(auth.aesEncrypt(buildUser(remoteUser.name as string, aesPassword, options.tokenKey)));
     });
   }
   const { jwt } = security.api;
 
   if (jwt?.sign) {
-    return await auth.jwtEncrypt(remoteUser, jwt.sign);
+    return await auth.jwtEncrypt(tokenUser, jwt.sign);
   }
   return await new Promise((resolve): void => {
-    resolve(auth.aesEncrypt(buildUser(remoteUser.name as string, aesPassword)));
+    resolve(auth.aesEncrypt(buildUser(remoteUser.name as string, aesPassword, options.tokenKey)));
   });
 }
 
@@ -237,7 +241,11 @@ export function handleSpecialUnpublish(logger: Logger): any {
   };
 }
 
-export function buildUser(name: string, password: string): string {
+export function buildUser(name: string, password: string, tokenKey?: string): string {
+  if (tokenKey) {
+    return JSON.stringify({ user: name, password, tokenKey });
+  }
+
   return String(`${name}:${password}`);
 }
 

--- a/packages/core/core/src/index.ts
+++ b/packages/core/core/src/index.ts
@@ -3,6 +3,7 @@ import * as constants from './constants';
 import * as cryptoUtils from './crypto-utils';
 import * as errorUtils from './error-utils';
 import * as fileUtils from './file-utils';
+import * as ipUtils from './ip-utils';
 import * as pkgUtils from './pkg-utils';
 import * as pluginUtils from './plugin-utils';
 import * as searchUtils from './search-utils';
@@ -40,6 +41,7 @@ export {
   authUtils,
   cryptoUtils,
   fileUtils,
+  ipUtils,
   pkgUtils,
   searchUtils,
   streamUtils,

--- a/packages/core/core/src/ip-utils.ts
+++ b/packages/core/core/src/ip-utils.ts
@@ -1,0 +1,94 @@
+import net from 'node:net';
+
+const IPV4_MAPPED_PREFIX = '::ffff:';
+
+/**
+ * Trim an address and strip the IPv4-mapped IPv6 prefix (`::ffff:`) so that
+ * mapped addresses are compared as plain IPv4.
+ */
+export function normalizeAddress(address?: string): string | undefined {
+  if (!address) {
+    return;
+  }
+
+  const trimmedAddress = address.trim();
+
+  if (trimmedAddress.startsWith(IPV4_MAPPED_PREFIX)) {
+    return trimmedAddress.slice(IPV4_MAPPED_PREFIX.length);
+  }
+
+  return trimmedAddress;
+}
+
+/**
+ * Convert a dotted-quad IPv4 address into its unsigned 32-bit integer value.
+ */
+export function parseIPv4(address: string): number | undefined {
+  if (net.isIP(address) !== 4) {
+    return;
+  }
+
+  return (
+    address
+      .split('.')
+      .map(Number)
+      .reduce((accumulator, octet) => (accumulator << 8) + octet, 0) >>> 0
+  );
+}
+
+/**
+ * Whether an IPv4 `address` falls inside the `range`/`prefix` CIDR block.
+ */
+export function isIPv4InCIDR(address: string, range: string, prefix: number): boolean {
+  const addressNumber = parseIPv4(address);
+  const rangeNumber = parseIPv4(range);
+
+  if (addressNumber === undefined || rangeNumber === undefined || prefix < 0 || prefix > 32) {
+    return false;
+  }
+
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+
+  return (addressNumber & mask) === (rangeNumber & mask);
+}
+
+/**
+ * Whether `address` is allowed by the provided `cidr` whitelist. An empty or
+ * missing whitelist allows every address; an unparseable address is rejected.
+ */
+export function isAddressAllowed(address: string | undefined, cidr: string[] | undefined): boolean {
+  if (!cidr || cidr.length === 0) {
+    return true;
+  }
+
+  const normalizedAddress = normalizeAddress(address);
+
+  if (!normalizedAddress) {
+    return false;
+  }
+
+  return cidr.some((entry) => {
+    const [range, prefixValue] = entry.split('/');
+    const normalizedRange = normalizeAddress(range);
+
+    if (!normalizedRange) {
+      return false;
+    }
+
+    if (typeof prefixValue === 'undefined') {
+      return normalizedAddress === normalizedRange;
+    }
+
+    const prefix = Number(prefixValue);
+
+    if (Number.isInteger(prefix) === false) {
+      return false;
+    }
+
+    if (net.isIP(normalizedAddress) === 4 && net.isIP(normalizedRange) === 4) {
+      return isIPv4InCIDR(normalizedAddress, normalizedRange, prefix);
+    }
+
+    return prefix === 128 && normalizedAddress === normalizedRange;
+  });
+}

--- a/packages/core/core/test/ip-utils.spec.ts
+++ b/packages/core/core/test/ip-utils.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest';
+
+import { ipUtils } from '../src';
+
+describe('ip-utils', () => {
+  describe('normalizeAddress', () => {
+    test('returns undefined for empty input', () => {
+      expect(ipUtils.normalizeAddress(undefined)).toBeUndefined();
+      expect(ipUtils.normalizeAddress('')).toBeUndefined();
+    });
+
+    test('trims surrounding whitespace', () => {
+      expect(ipUtils.normalizeAddress('  10.0.0.1  ')).toEqual('10.0.0.1');
+    });
+
+    test('strips the IPv4-mapped IPv6 prefix', () => {
+      expect(ipUtils.normalizeAddress('::ffff:127.0.0.1')).toEqual('127.0.0.1');
+    });
+
+    test('leaves plain IPv6 untouched', () => {
+      expect(ipUtils.normalizeAddress('2001:db8::1')).toEqual('2001:db8::1');
+    });
+  });
+
+  describe('parseIPv4', () => {
+    test('converts a dotted-quad to its unsigned 32-bit value', () => {
+      expect(ipUtils.parseIPv4('0.0.0.0')).toEqual(0);
+      expect(ipUtils.parseIPv4('255.255.255.255')).toEqual(0xffffffff);
+      expect(ipUtils.parseIPv4('192.168.0.1')).toEqual(0xc0a80001);
+    });
+
+    test('returns undefined for non-IPv4 input', () => {
+      expect(ipUtils.parseIPv4('2001:db8::1')).toBeUndefined();
+      expect(ipUtils.parseIPv4('not-an-ip')).toBeUndefined();
+    });
+  });
+
+  describe('isIPv4InCIDR', () => {
+    test('matches addresses inside the range', () => {
+      expect(ipUtils.isIPv4InCIDR('203.0.113.5', '203.0.113.0', 24)).toBe(true);
+      expect(ipUtils.isIPv4InCIDR('10.1.2.3', '10.0.0.0', 8)).toBe(true);
+    });
+
+    test('rejects addresses outside the range', () => {
+      expect(ipUtils.isIPv4InCIDR('203.0.114.5', '203.0.113.0', 24)).toBe(false);
+    });
+
+    test('treats /0 as matching everything', () => {
+      expect(ipUtils.isIPv4InCIDR('8.8.8.8', '0.0.0.0', 0)).toBe(true);
+    });
+
+    test('rejects invalid prefixes or addresses', () => {
+      expect(ipUtils.isIPv4InCIDR('10.0.0.1', '10.0.0.0', -1)).toBe(false);
+      expect(ipUtils.isIPv4InCIDR('10.0.0.1', '10.0.0.0', 33)).toBe(false);
+      expect(ipUtils.isIPv4InCIDR('not-an-ip', '10.0.0.0', 8)).toBe(false);
+    });
+  });
+
+  describe('isAddressAllowed', () => {
+    test('allows any address when the whitelist is empty or missing', () => {
+      expect(ipUtils.isAddressAllowed('203.0.113.5', undefined)).toBe(true);
+      expect(ipUtils.isAddressAllowed('203.0.113.5', [])).toBe(true);
+    });
+
+    test('rejects a missing address against a non-empty whitelist', () => {
+      expect(ipUtils.isAddressAllowed(undefined, ['203.0.113.0/24'])).toBe(false);
+    });
+
+    test('honors an IPv4 CIDR whitelist', () => {
+      expect(ipUtils.isAddressAllowed('203.0.113.5', ['203.0.113.0/24'])).toBe(true);
+      expect(ipUtils.isAddressAllowed('198.51.100.5', ['203.0.113.0/24'])).toBe(false);
+    });
+
+    test('matches IPv4-mapped IPv6 addresses against IPv4 ranges', () => {
+      expect(ipUtils.isAddressAllowed('::ffff:203.0.113.5', ['203.0.113.0/24'])).toBe(true);
+    });
+
+    test('supports bare addresses without a prefix', () => {
+      expect(ipUtils.isAddressAllowed('203.0.113.5', ['203.0.113.5'])).toBe(true);
+      expect(ipUtils.isAddressAllowed('203.0.113.6', ['203.0.113.5'])).toBe(false);
+    });
+
+    test('rejects entries with a non-integer prefix', () => {
+      expect(ipUtils.isAddressAllowed('203.0.113.5', ['203.0.113.0/abc'])).toBe(false);
+    });
+
+    test('only matches IPv6 ranges on an exact /128', () => {
+      expect(ipUtils.isAddressAllowed('2001:db8::1', ['2001:db8::1/128'])).toBe(true);
+      expect(ipUtils.isAddressAllowed('2001:db8::2', ['2001:db8::1/128'])).toBe(false);
+    });
+  });
+});

--- a/packages/core/types/src/commons.ts
+++ b/packages/core/types/src/commons.ts
@@ -10,6 +10,9 @@ export interface RemoteUser {
   groups: string[];
   name: string | void;
   error?: string;
+  token?: {
+    key: string;
+  };
 }
 
 export type StringValue = string | void | null;

--- a/packages/middleware/src/index.ts
+++ b/packages/middleware/src/index.ts
@@ -7,6 +7,8 @@ export { expectJson } from './middlewares/json';
 export { antiLoop } from './middlewares/antiLoop';
 export { final } from './middlewares/final';
 export { allow } from './middlewares/allow';
+export { enforceGeneratedTokenMetadata } from './middlewares/token-auth';
+export type { TokenReadableStorage } from './middlewares/token-auth';
 export { rateLimit } from './middlewares/rate-limit';
 export { registerBodyParser } from './middlewares/body-parser';
 export { userAgent } from './middlewares/user-agent';

--- a/packages/middleware/src/middlewares/token-auth.ts
+++ b/packages/middleware/src/middlewares/token-auth.ts
@@ -1,0 +1,128 @@
+import type { NextFunction, Request, RequestHandler, Response } from 'express';
+
+import { API_ERROR, errorUtils, ipUtils } from '@verdaccio/core';
+import type { Logger, Token } from '@verdaccio/types';
+
+import type { $RequestExtend } from '../types';
+
+const WRITE_METHODS = new Set(['DELETE', 'PATCH', 'POST', 'PUT']);
+
+/**
+ * Minimal storage surface required to enforce generated token metadata. Typed
+ * structurally so this package does not need to depend on `@verdaccio/store`.
+ */
+export interface TokenReadableStorage {
+  /**
+   * Load the generated tokens stored for a user.
+   *
+   * @param filter narrows the lookup to a single `user`
+   * @returns the user's persisted tokens
+   */
+  readTokens(filter: { user: string }): Promise<Token[]>;
+}
+
+/**
+ * Resolve the client address of an incoming request for CIDR matching.
+ *
+ * Prefers the `x-forwarded-for` header (taking the first, client-most entry of
+ * the comma-separated list) and falls back to `req.ip` and then the raw socket
+ * address. The result is normalized (trimmed and IPv4-mapped IPv6 prefixes
+ * stripped) via {@link ipUtils.normalizeAddress}.
+ *
+ * @param req the incoming Express request
+ * @returns the normalized client address, or `undefined` when none can be determined
+ */
+function getClientAddress(req: Request): string | undefined {
+  const forwardedFor = req.headers['x-forwarded-for'];
+
+  if (Array.isArray(forwardedFor)) {
+    return ipUtils.normalizeAddress(forwardedFor[0]?.split(',')[0]);
+  }
+
+  if (typeof forwardedFor === 'string') {
+    return ipUtils.normalizeAddress(forwardedFor.split(',')[0]);
+  }
+
+  return ipUtils.normalizeAddress(req.ip || req.socket.remoteAddress);
+}
+
+/**
+ * Find the stored token whose `key` matches the key carried by the request.
+ *
+ * @param tokens the tokens persisted for the authenticated user
+ * @param tokenKey the key extracted from the presented generated token
+ * @returns the matching {@link Token}, or `undefined` when it has been revoked / never existed
+ */
+function findToken(tokens: Token[], tokenKey: string): Token | undefined {
+  return tokens.find(({ key }) => key === tokenKey);
+}
+
+/**
+ * Express middleware that enforces the metadata of npm-style generated tokens
+ * (created via `POST /-/npm/v1/tokens`).
+ *
+ * A generated token embeds a server-issued `key` that is recovered from the
+ * verified credentials as `remote_user.token.key`. This middleware looks that
+ * key up in storage and rejects the request when the token:
+ * - is missing from storage (revoked or never issued);
+ * - is used from a client address outside its `cidr` whitelist;
+ * - is `readonly` and the request uses a write method (`DELETE`/`PATCH`/`POST`/`PUT`).
+ *
+ * Requests that do not carry a generated token key (e.g. interactive logins)
+ * pass through untouched. It must run after the JWT/auth middleware has
+ * populated `remote_user`. Failures fail closed: a storage lookup error yields
+ * an internal error rather than allowing the request.
+ *
+ * @param storage storage exposing {@link TokenReadableStorage.readTokens} to load the user's tokens
+ * @param logger logger used to record rejected attempts and lookup failures
+ * @returns an Express {@link RequestHandler} that calls `next()` to allow or `next(error)` to reject
+ */
+export function enforceGeneratedTokenMetadata(
+  storage: TokenReadableStorage,
+  logger: Logger
+): RequestHandler {
+  return async function (req: Request, _res: Response, next: NextFunction): Promise<void> {
+    const remoteUser = (req as $RequestExtend).remote_user;
+    const tokenKey = remoteUser?.token?.key;
+
+    if (!tokenKey) {
+      return next();
+    }
+
+    const user = remoteUser?.name;
+
+    if (typeof user !== 'string') {
+      return next(errorUtils.getForbidden(API_ERROR.UNAUTHORIZED_ACCESS));
+    }
+
+    try {
+      const token = findToken(await storage.readTokens({ user }), tokenKey);
+
+      if (!token) {
+        logger.warn({ tokenKey, user }, 'generated token @{tokenKey} for user @{user} is missing');
+        return next(errorUtils.getForbidden(API_ERROR.UNAUTHORIZED_ACCESS));
+      }
+
+      if (!ipUtils.isAddressAllowed(getClientAddress(req), token.cidr)) {
+        logger.warn(
+          { tokenKey, user },
+          'generated token @{tokenKey} for user @{user} was used outside its CIDR whitelist'
+        );
+        return next(errorUtils.getForbidden(API_ERROR.UNAUTHORIZED_ACCESS));
+      }
+
+      if (token.readonly && WRITE_METHODS.has(req.method)) {
+        logger.warn(
+          { tokenKey, user },
+          'readonly generated token @{tokenKey} for user @{user} was used for a write request'
+        );
+        return next(errorUtils.getForbidden(API_ERROR.UNAUTHORIZED_ACCESS));
+      }
+
+      return next();
+    } catch (error: any) {
+      logger.error({ error: error.msg }, 'generated token metadata lookup failed: @{error}');
+      return next(errorUtils.getInternalError(error.message));
+    }
+  };
+}

--- a/packages/middleware/test/token-auth.spec.ts
+++ b/packages/middleware/test/token-auth.spec.ts
@@ -1,0 +1,184 @@
+import express, { type Application, type NextFunction, type Request, type Response } from 'express';
+import request from 'supertest';
+import { type Mock, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { HTTP_STATUS } from '@verdaccio/core';
+import type { Logger, Token } from '@verdaccio/types';
+
+import { type TokenReadableStorage, enforceGeneratedTokenMetadata } from '../src';
+
+type RemoteUser = { name?: unknown; token?: { key: string } };
+
+function buildRemoteUser(options: { tokenKey?: string; user?: unknown } = {}): RemoteUser {
+  const user = 'user' in options ? options.user : 'jota';
+
+  if (typeof options.tokenKey === 'undefined') {
+    return { name: user };
+  }
+
+  return { name: user, token: { key: options.tokenKey } };
+}
+
+function buildToken(overrides: Partial<Token> = {}): Token {
+  return {
+    user: 'jota',
+    token: 'masked',
+    key: 'abc123',
+    readonly: false,
+    created: 1,
+    ...overrides,
+  } as Token;
+}
+
+function buildApp(
+  storage: TokenReadableStorage,
+  logger: Logger,
+  remoteUser: RemoteUser,
+  clientIp?: string
+): Application {
+  const app = express();
+  app.use((req: Request, _res: Response, next: NextFunction) => {
+    (req as any).remote_user = remoteUser;
+    // `req.ip` is a read-only accessor derived from the socket; shadow it so the
+    // no-x-forwarded-for fallback can be exercised with a deterministic address
+    if (typeof clientIp !== 'undefined') {
+      Object.defineProperty(req, 'ip', { value: clientIp, configurable: true });
+    }
+    next();
+  });
+  app.use(enforceGeneratedTokenMetadata(storage, logger));
+  app.use((_req: Request, res: Response) => {
+    res.status(HTTP_STATUS.OK).json({ ok: true });
+  });
+   
+  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+    res.status(err.statusCode || HTTP_STATUS.INTERNAL_ERROR).json({ error: err.message });
+  });
+  return app;
+}
+
+describe('enforceGeneratedTokenMetadata', () => {
+  let readTokens: Mock;
+  let storage: TokenReadableStorage;
+  let logger: Logger;
+
+  beforeEach(() => {
+    readTokens = vi.fn();
+    storage = { readTokens } as unknown as TokenReadableStorage;
+    logger = { warn: vi.fn(), error: vi.fn() } as unknown as Logger;
+  });
+
+  test('passes through when the request carries no generated token key', async () => {
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: undefined }));
+
+    await request(app).put('/').expect(HTTP_STATUS.OK);
+
+    expect(readTokens).not.toHaveBeenCalled();
+  });
+
+  test('rejects when a token key is present but the user is not a string', async () => {
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123', user: undefined }));
+
+    await request(app).put('/').expect(HTTP_STATUS.FORBIDDEN);
+
+    expect(readTokens).not.toHaveBeenCalled();
+  });
+
+  test('looks the token up scoped to the authenticated user', async () => {
+    readTokens.mockResolvedValue([buildToken()]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123', user: 'jota' }));
+
+    await request(app).get('/').expect(HTTP_STATUS.OK);
+
+    expect(readTokens).toHaveBeenCalledWith({ user: 'jota' });
+  });
+
+  test('rejects when the generated token is missing (revoked)', async () => {
+    readTokens.mockResolvedValue([buildToken({ key: 'another-key' })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+
+    await request(app).put('/').expect(HTTP_STATUS.FORBIDDEN);
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('rejects when the client address is outside the token CIDR whitelist', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+
+    await request(app)
+      .put('/')
+      .set('x-forwarded-for', '198.51.100.5')
+      .expect(HTTP_STATUS.FORBIDDEN);
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('allows when the client address is inside the token CIDR whitelist', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+
+    await request(app).get('/').set('x-forwarded-for', '203.0.113.5').expect(HTTP_STATUS.OK);
+  });
+
+  test('falls back to req.ip for the CIDR check when no x-forwarded-for is present', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), '203.0.113.5');
+
+    await request(app).get('/').expect(HTTP_STATUS.OK);
+  });
+
+  test('rejects via the req.ip fallback when the address is outside the CIDR whitelist', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), '198.51.100.5');
+
+    await request(app).get('/').expect(HTTP_STATUS.FORBIDDEN);
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('uses the first x-forwarded-for entry for the CIDR check', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+
+    await request(app)
+      .get('/')
+      .set('x-forwarded-for', '203.0.113.5, 70.41.3.18')
+      .expect(HTTP_STATUS.OK);
+  });
+
+  test.each(['delete', 'patch', 'post', 'put'])(
+    'rejects a readonly token on write method %s',
+    async (method) => {
+      readTokens.mockResolvedValue([buildToken({ readonly: true })]);
+      const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+
+      await request(app)[method]('/').expect(HTTP_STATUS.FORBIDDEN);
+
+      expect(logger.warn).toHaveBeenCalled();
+    }
+  );
+
+  test('allows a readonly token on a read request', async () => {
+    readTokens.mockResolvedValue([buildToken({ readonly: true })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+
+    await request(app).get('/').expect(HTTP_STATUS.OK);
+  });
+
+  test('allows a write request made with a non-readonly token', async () => {
+    readTokens.mockResolvedValue([buildToken({ readonly: false })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+
+    await request(app).put('/').expect(HTTP_STATUS.OK);
+  });
+
+  test('fails closed with an internal error when the token lookup throws', async () => {
+    readTokens.mockRejectedValue(new Error('storage down'));
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+
+    await request(app).put('/').expect(HTTP_STATUS.INTERNAL_ERROR);
+
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/packages/middleware/test/token-auth.spec.ts
+++ b/packages/middleware/test/token-auth.spec.ts
@@ -50,7 +50,7 @@ function buildApp(
   app.use((_req: Request, res: Response) => {
     res.status(HTTP_STATUS.OK).json({ ok: true });
   });
-   
+
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     res.status(err.statusCode || HTTP_STATUS.INTERNAL_ERROR).json({ error: err.message });
   });

--- a/packages/signature/src/token.ts
+++ b/packages/signature/src/token.ts
@@ -6,6 +6,22 @@ import type { BasicPayload } from './types';
  * @returns
  */
 export function parseBasicPayload(credentials: string): BasicPayload {
+  if (credentials.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(credentials);
+
+      if (typeof parsed.user === 'string' && typeof parsed.password === 'string') {
+        return {
+          user: parsed.user,
+          password: parsed.password,
+          tokenKey: typeof parsed.tokenKey === 'string' ? parsed.tokenKey : undefined,
+        };
+      }
+    } catch {
+      // not a JSON payload, fall through to the legacy "user:password" parsing
+    }
+  }
+
   const index = credentials.indexOf(':');
   if (index < 0) {
     return;

--- a/packages/signature/src/types.ts
+++ b/packages/signature/src/types.ts
@@ -1,6 +1,7 @@
 export interface AESPayload {
   user: string;
   password: string;
+  tokenKey?: string;
 }
 
 export type BasicPayload = AESPayload | void;

--- a/packages/signature/test/parse-basic-payload.spec.ts
+++ b/packages/signature/test/parse-basic-payload.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'vitest';
+
+import { parseBasicPayload } from '../src';
+
+describe('parseBasicPayload', () => {
+  describe('legacy "user:password" format', () => {
+    test('parses user and password', () => {
+      expect(parseBasicPayload('dummy:password')).toEqual({
+        user: 'dummy',
+        password: 'password',
+      });
+    });
+
+    test('keeps colons that belong to the password', () => {
+      expect(parseBasicPayload('dummy:pass:word')).toEqual({
+        user: 'dummy',
+        password: 'pass:word',
+      });
+    });
+
+    test('returns undefined when there is no colon separator', () => {
+      expect(parseBasicPayload('dummy')).toBeUndefined();
+    });
+  });
+
+  describe('JSON payload format', () => {
+    test('parses user, password and tokenKey', () => {
+      const payload = JSON.stringify({
+        user: 'dummy',
+        password: 'password',
+        tokenKey: 'abc123',
+      });
+
+      expect(parseBasicPayload(payload)).toEqual({
+        user: 'dummy',
+        password: 'password',
+        tokenKey: 'abc123',
+      });
+    });
+
+    test('leaves tokenKey undefined when it is absent', () => {
+      const payload = JSON.stringify({ user: 'dummy', password: 'password' });
+
+      expect(parseBasicPayload(payload)).toEqual({
+        user: 'dummy',
+        password: 'password',
+        tokenKey: undefined,
+      });
+    });
+
+    test('leaves tokenKey undefined when it is not a string', () => {
+      const payload = JSON.stringify({ user: 'dummy', password: 'password', tokenKey: 42 });
+
+      expect(parseBasicPayload(payload)).toEqual({
+        user: 'dummy',
+        password: 'password',
+        tokenKey: undefined,
+      });
+    });
+  });
+
+  describe('ambiguous "{"-prefixed input', () => {
+    test('falls back to legacy parsing when the JSON lacks user/password', () => {
+      // valid JSON, but not a credentials object: should not short-circuit
+      expect(parseBasicPayload('{}:password')).toEqual({
+        user: '{}',
+        password: 'password',
+      });
+    });
+
+    test('falls back to legacy parsing when the JSON is malformed', () => {
+      // starts with "{" but is not valid JSON; must still honor the colon format
+      expect(parseBasicPayload('{user:password')).toEqual({
+        user: '{user',
+        password: 'password',
+      });
+    });
+
+    test('returns undefined for malformed JSON with no colon separator', () => {
+      expect(parseBasicPayload('{user')).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Enforces the metadata of generated npm tokens (`POST /-/npm/v1/tokens`) across `@verdaccio/core`, `@verdaccio/signature`, `@verdaccio/auth`, `@verdaccio/middleware`, and `@verdaccio/types`. Generated tokens now embed a server-issued key — in the JWT claim or in the encrypted legacy AES payload — that is recovered on each request, and a new `enforceGeneratedTokenMetadata` middleware looks it up so a token's `readonly` flag, its `cidr_whitelist`, and its revocation are honored consistently in both AES and JWT API-token modes. Adds `ipUtils` CIDR helpers and unit coverage; tokens issued before upgrading carry no key and should be regenerated to pick up these restrictions.

ref https://github.com/verdaccio/verdaccio/commit/62ebd31c19e566469414271399c32bdaa2a6277d