### PR TITLE
fix: tie generated token CIDR enforcement to trust proxy

### DIFF
--- a/.changeset/token-cidr-trust-proxy.md
+++ b/.changeset/token-cidr-trust-proxy.md
@@ -1,0 +1,16 @@
+---
+'@verdaccio/middleware': patch
+---
+
+fix: tie generated token CIDR enforcement to trust proxy
+
+The `enforceGeneratedTokenMetadata` middleware resolved the client address by
+reading the `X-Forwarded-For` header directly (and taking its left-most,
+client-most entry), regardless of the application's `trust proxy` setting. Any
+client could therefore satisfy a generated token's `cidr_whitelist` by sending a
+forged `X-Forwarded-For` header, defeating the CIDR restriction.
+
+The middleware now derives the client address from Express' `req.ip`, which
+already honors `config.server.trustProxy`: forwarded headers are trusted only
+for operator-configured proxies, otherwise the direct socket address is used and
+`X-Forwarded-For` is ignored.

--- a/packages/middleware/src/middlewares/token-auth.ts
+++ b/packages/middleware/src/middlewares/token-auth.ts
@@ -24,25 +24,22 @@ export interface TokenReadableStorage {
 /**
  * Resolve the client address of an incoming request for CIDR matching.
  *
- * Prefers the `x-forwarded-for` header (taking the first, client-most entry of
- * the comma-separated list) and falls back to `req.ip` and then the raw socket
- * address. The result is normalized (trimmed and IPv4-mapped IPv6 prefixes
- * stripped) via {@link ipUtils.normalizeAddress}.
+ * Uses Express' `req.ip`, which already honors the application's `trust proxy`
+ * setting (`config.server.trustProxy`): when the operator has declared trusted
+ * proxies, `req.ip` is the upstream-most untrusted address parsed from
+ * `X-Forwarded-For`; otherwise it is the direct socket peer and the forwarded
+ * header is ignored entirely.
+ *
+ * The middleware must NOT read `X-Forwarded-For` on its own — doing so
+ * unconditionally would let any client spoof its address (and bypass a token's
+ * CIDR whitelist) simply by sending the header. Falls back to the raw socket
+ * address and is normalized (trimmed, IPv4-mapped IPv6 prefix stripped) via
+ * {@link ipUtils.normalizeAddress}.
  *
  * @param req the incoming Express request
  * @returns the normalized client address, or `undefined` when none can be determined
  */
 function getClientAddress(req: Request): string | undefined {
-  const forwardedFor = req.headers['x-forwarded-for'];
-
-  if (Array.isArray(forwardedFor)) {
-    return ipUtils.normalizeAddress(forwardedFor[0]?.split(',')[0]);
-  }
-
-  if (typeof forwardedFor === 'string') {
-    return ipUtils.normalizeAddress(forwardedFor.split(',')[0]);
-  }
-
   return ipUtils.normalizeAddress(req.ip || req.socket.remoteAddress);
 }
 

--- a/packages/middleware/test/token-auth.spec.ts
+++ b/packages/middleware/test/token-auth.spec.ts
@@ -34,13 +34,18 @@ function buildApp(
   storage: TokenReadableStorage,
   logger: Logger,
   remoteUser: RemoteUser,
-  clientIp?: string
+  clientIp?: string,
+  trustProxy?: boolean | string | number
 ): Application {
   const app = express();
+  // mirrors Verdaccio wiring `config.server.trustProxy` -> app.set('trust proxy')
+  if (typeof trustProxy !== 'undefined') {
+    app.set('trust proxy', trustProxy);
+  }
   app.use((req: Request, _res: Response, next: NextFunction) => {
     (req as any).remote_user = remoteUser;
     // `req.ip` is a read-only accessor derived from the socket; shadow it so the
-    // no-x-forwarded-for fallback can be exercised with a deterministic address
+    // socket-address path can be exercised with a deterministic address
     if (typeof clientIp !== 'undefined') {
       Object.defineProperty(req, 'ip', { value: clientIp, configurable: true });
     }
@@ -104,21 +109,31 @@ describe('enforceGeneratedTokenMetadata', () => {
 
   test('rejects when the client address is outside the token CIDR whitelist', async () => {
     readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
-    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), '198.51.100.5');
 
-    await request(app)
-      .put('/')
-      .set('x-forwarded-for', '198.51.100.5')
-      .expect(HTTP_STATUS.FORBIDDEN);
+    await request(app).put('/').expect(HTTP_STATUS.FORBIDDEN);
 
     expect(logger.warn).toHaveBeenCalled();
   });
 
   test('allows when the client address is inside the token CIDR whitelist', async () => {
     readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
-    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), '203.0.113.5');
 
-    await request(app).get('/').set('x-forwarded-for', '203.0.113.5').expect(HTTP_STATUS.OK);
+    await request(app).get('/').expect(HTTP_STATUS.OK);
+  });
+
+  test('ignores a spoofed x-forwarded-for when trust proxy is not configured', async () => {
+    // SECURITY: with no trust proxy, the forwarded header is attacker-controlled
+    // and must NOT satisfy the CIDR whitelist. The real socket address
+    // (198.51.100.5) is outside the range, so the request is rejected even
+    // though the header claims an allowed address.
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), '198.51.100.5');
+
+    await request(app).put('/').set('x-forwarded-for', '203.0.113.5').expect(HTTP_STATUS.FORBIDDEN);
+
+    expect(logger.warn).toHaveBeenCalled();
   });
 
   test('falls back to req.ip for the CIDR check when no x-forwarded-for is present', async () => {
@@ -137,9 +152,29 @@ describe('enforceGeneratedTokenMetadata', () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
-  test('uses the first x-forwarded-for entry for the CIDR check', async () => {
+  test('honors x-forwarded-for for the CIDR check when trust proxy is configured', async () => {
     readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
-    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+    // trust proxy enabled -> req.ip is derived from the forwarded chain
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), undefined, true);
+
+    await request(app).get('/').set('x-forwarded-for', '203.0.113.5').expect(HTTP_STATUS.OK);
+  });
+
+  test('rejects an out-of-range x-forwarded-for even when trust proxy is configured', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), undefined, true);
+
+    await request(app)
+      .put('/')
+      .set('x-forwarded-for', '198.51.100.5')
+      .expect(HTTP_STATUS.FORBIDDEN);
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('uses the upstream-most forwarded entry when trust proxy is configured', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), undefined, true);
 
     await request(app)
       .get('/')

--- a/packages/middleware/test/token-auth.spec.ts
+++ b/packages/middleware/test/token-auth.spec.ts
@@ -44,8 +44,8 @@ function buildApp(
   }
   app.use((req: Request, _res: Response, next: NextFunction) => {
     (req as any).remote_user = remoteUser;
-    // `req.ip` is a read-only accessor derived from the socket; shadow it so the
-    // socket-address path can be exercised with a deterministic address
+    // `req.ip` is a read-only accessor derived from the socket; shadow it to
+    // provide a deterministic client address for these tests
     if (typeof clientIp !== 'undefined') {
       Object.defineProperty(req, 'ip', { value: clientIp, configurable: true });
     }


### PR DESCRIPTION
## Summary

`enforceGeneratedTokenMetadata` (added in #5942) enforces a generated npm token's `cidr_whitelist` by comparing the request's client IP against the allowed ranges. This PR fixes **how that client IP is determined** so the CIDR restriction cannot be bypassed.

## Finding

The middleware resolved the client address by reading the `X-Forwarded-For` header **directly and unconditionally**, taking its left-most (client-most) entry, and only falling back to `req.ip`/socket when the header was absent:

```ts
const forwardedFor = req.headers['x-forwarded-for'];
if (forwardedFor) return ipUtils.normalizeAddress(forwardedFor.split(',')[0]);
return ipUtils.normalizeAddress(req.ip || req.socket.remoteAddress);
```

`X-Forwarded-For` is client-supplied text. When Verdaccio is reachable directly (the default — no `server.trustProxy`), any caller can set the header to an allowed address and satisfy the whitelist:

```
curl -H "Authorization: Bearer <cidr-pinned-token>" \
     -H "X-Forwarded-For: 203.0.113.5" \
     http://registry/...
```

A token pinned to e.g. `203.0.113.0/24` could therefore be used from anywhere, defeating the restriction. Taking the **left-most** entry made it worse — that is the most attacker-controlled part of the chain. The net effect: a control that looks like it restricts by network but does not, giving operators a false sense of security.

## Root cause

The middleware reimplemented client-IP resolution from the raw header instead of using Express' `req.ip`, which is derived from the app's `trust proxy` setting. Verdaccio already wires that from config (`src/api/index.ts`):

```ts
if (config.server?.trustProxy) {
  app.set('trust proxy', config.server.trustProxy);
}
```

By bypassing `req.ip`, the enforcement ignored the operator's proxy-trust configuration entirely.

## Fix

Resolve the client address from `req.ip` (falling back to the raw socket), and never read `X-Forwarded-For` directly:

```ts
function getClientAddress(req: Request): string | undefined {
  return ipUtils.normalizeAddress(req.ip || req.socket.remoteAddress);
}
```

- **No `trustProxy` (default):** `X-Forwarded-For` is ignored; the real socket peer is used — forged headers do nothing.
- **`trustProxy` configured:** Express returns the upstream-most *untrusted* address from the forwarded chain — the real client as reported by trusted infrastructure.

## Operator note (behavior change)

`cidr_whitelist` on generated tokens now depends on `server.trustProxy` matching the deployment:

- **Direct exposure** → works out of the box (socket IP).
- **Behind a proxy / load balancer** → set `server.trustProxy` so the client IP can be recovered from `X-Forwarded-For`; otherwise requests appear to originate from the proxy and CIDR-pinned tokens will not match.

This is not a regression in capability — it is the difference between *spoofable* and *correctly configured*, and matches how the rest of Verdaccio sources the client address.

## Tests

`packages/middleware/test/token-auth.spec.ts`:

- **Regression:** a spoofed `X-Forwarded-For` is ignored when `trust proxy` is not configured (request rejected on the real socket address).
- `X-Forwarded-For` is honored only when `trust proxy` is configured (allow in-range / reject out-of-range / upstream-most entry).
- Socket-address allow/reject cases retained.
