### PR TITLE
fix: tie generated token CIDR enforcement to trust proxy

### DIFF
--- a/.changeset/token-cidr-trust-proxy.md
+++ b/.changeset/token-cidr-trust-proxy.md
@@ -1,0 +1,16 @@
+---
+'@verdaccio/middleware': patch
+---
+
+fix: tie generated token CIDR enforcement to trust proxy
+
+The `enforceGeneratedTokenMetadata` middleware resolved the client address by
+reading the `X-Forwarded-For` header directly (and taking its left-most,
+client-most entry), regardless of the application's `trust proxy` setting. Any
+client could therefore satisfy a generated token's `cidr_whitelist` by sending a
+forged `X-Forwarded-For` header, defeating the CIDR restriction.
+
+The middleware now derives the client address from Express' `req.ip`, which
+already honors `config.server.trustProxy`: forwarded headers are trusted only
+for operator-configured proxies, otherwise the direct socket address is used and
+`X-Forwarded-For` is ignored.

--- a/packages/api/src/v1/token.ts
+++ b/packages/api/src/v1/token.ts
@@ -64,8 +64,14 @@ export default function (
     TOKEN_API_ENDPOINTS.get_tokens,
     rateLimit(config?.userRateLimit),
     function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
-      const { password, readonly, cidr_whitelist } = req.body;
+      const { password } = req.body;
       const { name } = req.remote_user;
+      // `readonly` and `cidr_whitelist` are optional: npm >= 11 rewrote
+      // `npm token create` to omit them (and only sends `cidr_whitelist` with
+      // `--cidr`), so default them rather than rejecting the request. A wrong
+      // type is still rejected.
+      const readonly = req.body.readonly ?? false;
+      const cidr_whitelist = req.body.cidr_whitelist ?? [];
 
       if (!isBoolean(readonly) || !Array.isArray(cidr_whitelist)) {
         return next(errorUtils.getCode(HTTP_STATUS.BAD_DATA, SUPPORT_ERRORS.PARAMETERS_NOT_VALID));

--- a/packages/api/src/v1/token.ts
+++ b/packages/api/src/v1/token.ts
@@ -10,6 +10,21 @@ import type { Config, Logger, RemoteUser, Token } from '@verdaccio/types';
 
 import type { $NextFunctionVer, $RequestExtend } from '../../types/custom';
 
+// Granular access token options (npm >= 11) that Verdaccio does not implement
+// yet. They are accepted so `npm token create` succeeds, but the restrictions
+// they express are NOT enforced — warn so the operator is not misled.
+const UNSUPPORTED_TOKEN_OPTIONS = [
+  'packages_and_scopes_permission',
+  'packages',
+  'packages_all',
+  'scopes',
+  'orgs',
+  'orgs_permission',
+  'expires',
+  'description',
+  'bypass_2fa',
+];
+
 export type NormalizeToken = Token & {
   cidr_whitelist: string[];
   created: string;
@@ -75,6 +90,16 @@ export default function (
 
       if (!isBoolean(readonly) || !Array.isArray(cidr_whitelist)) {
         return next(errorUtils.getCode(HTTP_STATUS.BAD_DATA, SUPPORT_ERRORS.PARAMETERS_NOT_VALID));
+      }
+
+      const unsupportedOptions = UNSUPPORTED_TOKEN_OPTIONS.filter(
+        (option) => isNil(req.body[option]) === false
+      );
+      if (unsupportedOptions.length > 0) {
+        logger.warn(
+          { options: unsupportedOptions.join(', '), userAgent: req.get('user-agent') ?? 'unknown' },
+          'granular access token options are not supported yet and will be ignored: @{options} (client: @{userAgent})'
+        );
       }
 
       auth.authenticate(name, password, async (err, user?: RemoteUser) => {

--- a/packages/api/test/integration/config/token.jwt.yaml
+++ b/packages/api/test/integration/config/token.jwt.yaml
@@ -8,6 +8,10 @@ security:
 
 storage: ./storage
 
+# trust the forwarding chain so X-Forwarded-For is honored for token CIDR checks
+server:
+  trustProxy: true
+
 auth:
   htpasswd:
     file: ./htpasswd

--- a/packages/api/test/integration/config/token.yaml
+++ b/packages/api/test/integration/config/token.yaml
@@ -1,5 +1,9 @@
 storage: ./storage
 
+# trust the forwarding chain so X-Forwarded-For is honored for token CIDR checks
+server:
+  trustProxy: true
+
 auth:
   htpasswd:
     file: ./htpasswd

--- a/packages/api/test/integration/token.spec.ts
+++ b/packages/api/test/integration/token.spec.ts
@@ -95,22 +95,55 @@ describe('token', () => {
     });
 
     test.each([['token.yaml'], ['token.jwt.yaml']])(
-      'should fail if readonly is missing',
+      'should reject readonly when it has the wrong type',
       async (conf) => {
         const app = await initializeServer(conf);
         const credentials = { name: 'jota_token', password: 'secretPass' };
         const token = await getNewToken(app, credentials);
         const resp = await generateTokenCLI(app, token, {
           password: credentials.password,
+          readonly: 'nope',
           cidr_whitelist: [],
+        });
+        expect(resp.body.error).toEqual(SUPPORT_ERRORS.PARAMETERS_NOT_VALID);
+      }
+    );
+
+    test.each([['token.yaml'], ['token.jwt.yaml']])(
+      'should reject cidr_whitelist when it has the wrong type',
+      async (conf) => {
+        const app = await initializeServer(conf);
+        const credentials = { name: 'jota_token', password: 'secretPass' };
+        const token = await getNewToken(app, credentials);
+        const resp = await generateTokenCLI(app, token, {
+          password: credentials.password,
+          readonly: false,
+          cidr_whitelist: 'not-an-array',
         });
         expect(resp.body.error).toEqual(SUPPORT_ERRORS.PARAMETERS_NOT_VALID);
       }
     );
   });
 
+  // npm >= 11 rewrote `npm token create` to omit `readonly` and to send
+  // `cidr_whitelist` only with `--cidr`; the endpoint must default them.
   test.each([['token.yaml'], ['token.jwt.yaml']])(
-    'should fail if cidr_whitelist is missing',
+    'should default readonly to false when omitted',
+    async (conf) => {
+      const app = await initializeServer(conf);
+      const credentials = { name: 'jota_token', password: 'secretPass' };
+      const token = await getNewToken(app, credentials);
+      const resp = await generateTokenCLI(app, token, {
+        password: credentials.password,
+        cidr_whitelist: [],
+      });
+      expect(resp.body.token).toBeDefined();
+      expect(resp.body.readonly).toBe(false);
+    }
+  );
+
+  test.each([['token.yaml'], ['token.jwt.yaml']])(
+    'should default cidr_whitelist to empty when omitted',
     async (conf) => {
       const app = await initializeServer(conf);
       const credentials = { name: 'jota_token', password: 'secretPass' };
@@ -119,7 +152,23 @@ describe('token', () => {
         password: credentials.password,
         readonly: false,
       });
-      expect(resp.body.error).toEqual(SUPPORT_ERRORS.PARAMETERS_NOT_VALID);
+      expect(resp.body.token).toBeDefined();
+      expect(resp.body.cidr).toEqual([]);
+    }
+  );
+
+  test.each([['token.yaml'], ['token.jwt.yaml']])(
+    'should create a token from a body with only a password',
+    async (conf) => {
+      const app = await initializeServer(conf);
+      const credentials = { name: 'jota_token', password: 'secretPass' };
+      const token = await getNewToken(app, credentials);
+      const resp = await generateTokenCLI(app, token, {
+        password: credentials.password,
+      });
+      expect(resp.body.token).toBeDefined();
+      expect(resp.body.readonly).toBe(false);
+      expect(resp.body.cidr).toEqual([]);
     }
   );
 

--- a/packages/api/test/integration/token.spec.ts
+++ b/packages/api/test/integration/token.spec.ts
@@ -172,6 +172,44 @@ describe('token', () => {
     }
   );
 
+  // npm >= 11 granular access token options are accepted but not enforced; the
+  // token is still created (a warning is logged, including the client user
+  // agent) rather than failing.
+  test.each([['token.yaml'], ['token.jwt.yaml']])(
+    'should create a token ignoring unsupported granular options',
+    async (conf) => {
+      const app = await initializeServer(conf);
+      const credentials = { name: 'jota_token', password: 'secretPass' };
+      const token = await getNewToken(app, credentials);
+      const resp = await supertest(app)
+        .post('/-/npm/v1/tokens')
+        .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+        // the package-manager user agent is captured in the warning log
+        .set('user-agent', 'npm/12.0.0-pre.0.0 node/v24.15.0 darwin x64')
+        .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+        .send(
+          JSON.stringify({
+            password: credentials.password,
+            readonly: false,
+            cidr_whitelist: [],
+            packages_and_scopes_permission: 'read-only',
+            packages: ['@scope/pkg'],
+            scopes: ['@scope'],
+            orgs: ['my-org'],
+            expires: 30,
+            description: 'ci token',
+            bypass_2fa: true,
+          })
+        )
+        .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET);
+
+      expect(resp.body.token).toBeDefined();
+      // the unsupported options are not persisted on the token
+      expect(resp.body).not.toHaveProperty('packages_and_scopes_permission');
+      expect(resp.body).not.toHaveProperty('expires');
+    }
+  );
+
   describe('generated token authorization', () => {
     test.each([['token.yaml'], ['token.jwt.yaml']])(
       'should allow writes with a writable generated token within its constraints',

--- a/packages/middleware/src/middlewares/token-auth.ts
+++ b/packages/middleware/src/middlewares/token-auth.ts
@@ -24,25 +24,22 @@ export interface TokenReadableStorage {
 /**
  * Resolve the client address of an incoming request for CIDR matching.
  *
- * Prefers the `x-forwarded-for` header (taking the first, client-most entry of
- * the comma-separated list) and falls back to `req.ip` and then the raw socket
- * address. The result is normalized (trimmed and IPv4-mapped IPv6 prefixes
- * stripped) via {@link ipUtils.normalizeAddress}.
+ * Uses Express' `req.ip`, which already honors the application's `trust proxy`
+ * setting (`config.server.trustProxy`): when the operator has declared trusted
+ * proxies, `req.ip` is the upstream-most untrusted address parsed from
+ * `X-Forwarded-For`; otherwise it is the direct socket peer and the forwarded
+ * header is ignored entirely.
+ *
+ * The middleware must NOT read `X-Forwarded-For` on its own — doing so
+ * unconditionally would let any client spoof its address (and bypass a token's
+ * CIDR whitelist) simply by sending the header. Falls back to the raw socket
+ * address and is normalized (trimmed, IPv4-mapped IPv6 prefix stripped) via
+ * {@link ipUtils.normalizeAddress}.
  *
  * @param req the incoming Express request
  * @returns the normalized client address, or `undefined` when none can be determined
  */
 function getClientAddress(req: Request): string | undefined {
-  const forwardedFor = req.headers['x-forwarded-for'];
-
-  if (Array.isArray(forwardedFor)) {
-    return ipUtils.normalizeAddress(forwardedFor[0]?.split(',')[0]);
-  }
-
-  if (typeof forwardedFor === 'string') {
-    return ipUtils.normalizeAddress(forwardedFor.split(',')[0]);
-  }
-
   return ipUtils.normalizeAddress(req.ip || req.socket.remoteAddress);
 }
 

--- a/packages/middleware/test/encode.spec.ts
+++ b/packages/middleware/test/encode.spec.ts
@@ -1,10 +1,15 @@
 import request from 'supertest';
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
 import { HTTP_STATUS } from '@verdaccio/core';
 
 import { encodeScopePackage } from '../src';
 import { getApp } from './helper';
+
+// supertest binds a fresh ephemeral HTTP server per request; under the parallel
+// monorepo test run the event loop can be starved enough to exceed the default
+// 5s timeout, so give these network-bound tests extra headroom to avoid flakes.
+vi.setConfig({ testTimeout: 30000 });
 
 test('encode is json with relative path', async () => {
   const app = getApp([]);

--- a/packages/middleware/test/token-auth.spec.ts
+++ b/packages/middleware/test/token-auth.spec.ts
@@ -34,13 +34,18 @@ function buildApp(
   storage: TokenReadableStorage,
   logger: Logger,
   remoteUser: RemoteUser,
-  clientIp?: string
+  clientIp?: string,
+  trustProxy?: boolean | string | number
 ): Application {
   const app = express();
+  // mirrors Verdaccio wiring `config.server.trustProxy` -> app.set('trust proxy')
+  if (typeof trustProxy !== 'undefined') {
+    app.set('trust proxy', trustProxy);
+  }
   app.use((req: Request, _res: Response, next: NextFunction) => {
     (req as any).remote_user = remoteUser;
     // `req.ip` is a read-only accessor derived from the socket; shadow it so the
-    // no-x-forwarded-for fallback can be exercised with a deterministic address
+    // socket-address path can be exercised with a deterministic address
     if (typeof clientIp !== 'undefined') {
       Object.defineProperty(req, 'ip', { value: clientIp, configurable: true });
     }
@@ -104,21 +109,31 @@ describe('enforceGeneratedTokenMetadata', () => {
 
   test('rejects when the client address is outside the token CIDR whitelist', async () => {
     readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
-    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), '198.51.100.5');
 
-    await request(app)
-      .put('/')
-      .set('x-forwarded-for', '198.51.100.5')
-      .expect(HTTP_STATUS.FORBIDDEN);
+    await request(app).put('/').expect(HTTP_STATUS.FORBIDDEN);
 
     expect(logger.warn).toHaveBeenCalled();
   });
 
   test('allows when the client address is inside the token CIDR whitelist', async () => {
     readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
-    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), '203.0.113.5');
 
-    await request(app).get('/').set('x-forwarded-for', '203.0.113.5').expect(HTTP_STATUS.OK);
+    await request(app).get('/').expect(HTTP_STATUS.OK);
+  });
+
+  test('ignores a spoofed x-forwarded-for when trust proxy is not configured', async () => {
+    // SECURITY: with no trust proxy, the forwarded header is attacker-controlled
+    // and must NOT satisfy the CIDR whitelist. The real socket address
+    // (198.51.100.5) is outside the range, so the request is rejected even
+    // though the header claims an allowed address.
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), '198.51.100.5');
+
+    await request(app).put('/').set('x-forwarded-for', '203.0.113.5').expect(HTTP_STATUS.FORBIDDEN);
+
+    expect(logger.warn).toHaveBeenCalled();
   });
 
   test('falls back to req.ip for the CIDR check when no x-forwarded-for is present', async () => {
@@ -137,9 +152,29 @@ describe('enforceGeneratedTokenMetadata', () => {
     expect(logger.warn).toHaveBeenCalled();
   });
 
-  test('uses the first x-forwarded-for entry for the CIDR check', async () => {
+  test('honors x-forwarded-for for the CIDR check when trust proxy is configured', async () => {
     readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
-    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }));
+    // trust proxy enabled -> req.ip is derived from the forwarded chain
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), undefined, true);
+
+    await request(app).get('/').set('x-forwarded-for', '203.0.113.5').expect(HTTP_STATUS.OK);
+  });
+
+  test('rejects an out-of-range x-forwarded-for even when trust proxy is configured', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), undefined, true);
+
+    await request(app)
+      .put('/')
+      .set('x-forwarded-for', '198.51.100.5')
+      .expect(HTTP_STATUS.FORBIDDEN);
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  test('uses the upstream-most forwarded entry when trust proxy is configured', async () => {
+    readTokens.mockResolvedValue([buildToken({ cidr: ['203.0.113.0/24'] })]);
+    const app = buildApp(storage, logger, buildRemoteUser({ tokenKey: 'abc123' }), undefined, true);
 
     await request(app)
       .get('/')

--- a/packages/middleware/test/token-auth.spec.ts
+++ b/packages/middleware/test/token-auth.spec.ts
@@ -44,8 +44,8 @@ function buildApp(
   }
   app.use((req: Request, _res: Response, next: NextFunction) => {
     (req as any).remote_user = remoteUser;
-    // `req.ip` is a read-only accessor derived from the socket; shadow it so the
-    // socket-address path can be exercised with a deterministic address
+    // `req.ip` is a read-only accessor derived from the socket; shadow it to
+    // inject a deterministic client address via req.ip for the test
     if (typeof clientIp !== 'undefined') {
       Object.defineProperty(req, 'ip', { value: clientIp, configurable: true });
     }

--- a/packages/tools/helpers/src/initializeServer.ts
+++ b/packages/tools/helpers/src/initializeServer.ts
@@ -20,6 +20,11 @@ export async function initializeServer(
   const app = express();
   const logger = await setup(configObject.log ?? {});
   const config = new Config(configObject);
+  // mirror the real server wiring so tests can exercise `trust proxy`-dependent
+  // behavior (e.g. generated token CIDR enforcement against X-Forwarded-For)
+  if (config.server?.trustProxy) {
+    app.set('trust proxy', config.server.trustProxy);
+  }
   config.storage = path.join(os.tmpdir(), '/storage', cryptoUtils.generateRandomHexString());
   // httpass would get path.basename() for configPath thus we need to create a dummy folder
   // to avoid conflics

--- a/packages/ui-components/src/components/Readme/github-markdown.css
+++ b/packages/ui-components/src/components/Readme/github-markdown.css
@@ -1113,9 +1113,9 @@
 .markdown-body .Box {
   background-color: var(--bgColor-default);
   border-color: var(--borderColor-default);
-  border-radius: var(--borderRadius-medium);
   border-style: solid;
   border-width: var(--borderWidth-thin);
+  border-radius: var(--borderRadius-medium);
 }
 
 .markdown-body .Box--condensed {
@@ -1133,25 +1133,25 @@
 }
 
 .markdown-body .Box-header {
+  padding: var(--stack-padding-normal);
+  margin: calc(var(--borderWidth-thin)*-1) calc(var(--borderWidth-thin)*-1) 0;
   background-color: var(--bgColor-muted);
   border-color: var(--borderColor-default);
-  border-top-left-radius: var(--borderRadius-medium);
-  border-top-right-radius: var(--borderRadius-medium);
   border-style: solid;
   border-width: var(--borderWidth-thin);
-  margin: calc(var(--borderWidth-thin)*-1) calc(var(--borderWidth-thin)*-1) 0;
-  padding: var(--stack-padding-normal);
+  border-top-left-radius: var(--borderRadius-medium);
+  border-top-right-radius: var(--borderRadius-medium);
 }
 
 .markdown-body .Box-body {
-  border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
   padding: var(--stack-padding-normal);
+  border-bottom: var(--borderWidth-thin) solid var(--borderColor-default);
 }
 
 .markdown-body .Box-body:last-of-type {
-  border-bottom-left-radius: var(--borderRadius-medium);
-  border-bottom-right-radius: var(--borderRadius-medium);
   margin-bottom: calc(var(--borderWidth-thin)*-1);
+  border-bottom-right-radius: var(--borderRadius-medium);
+  border-bottom-left-radius: var(--borderRadius-medium);
 }
 
 .markdown-body .tmp-px-3 {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   esbuild: 0.28.1
+  form-data: '>=4.0.6'
 
 importers:
 
@@ -4427,8 +4428,8 @@ packages:
     resolution: {integrity: sha512-G6NsmEW15s0Uw9XnCg+33H3ViYRyiM0hMrMhhqQOR8NFc5GhYrI+6I3u7OTw7b91J2g8rtvMBZJDbcGb2YUniw==}
     engines: {node: '>= 18'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formidable@3.5.4:
@@ -4597,6 +4598,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-jsx-runtime@2.3.0:
@@ -7556,7 +7561,7 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 4.0.4
+      form-data: 4.0.6
       http-signature: 1.4.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
@@ -8625,7 +8630,7 @@ snapshots:
   '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 24.12.0
-      form-data: 4.0.4
+      form-data: 4.0.6
 
   '@types/node@12.20.55': {}
 
@@ -8701,7 +8706,7 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 24.12.0
-      form-data: 4.0.4
+      form-data: 4.0.6
 
   '@types/supertest@7.2.0':
     dependencies:
@@ -10215,12 +10220,12 @@ snapshots:
 
   form-data-encoder@4.1.0: {}
 
-  form-data@4.0.4:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formidable@3.5.4:
@@ -10407,6 +10412,10 @@ snapshots:
       type-fest: 0.8.1
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -12432,7 +12441,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.4
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,10 @@ minimumReleaseAgeExclude:
 # See GHSA-gv7w-rqvm-qjhr (RCE via NPM_CONFIG_REGISTRY, fixed in 0.28.1).
 overrides:
   esbuild: '0.28.1'
+  # Force the form-data CRLF-injection patch (>= 4.0.6) across the whole tree.
+  # Pulled in transitively via supertest > superagent (dev only).
+  # See GHSA-hmw2-7cc7-3qxx (fixed in 4.0.6).
+  form-data: '>=4.0.6'
 saveExact: true
 ignoreScripts: true
 preferFrozenLockfile: true


### PR DESCRIPTION
## Summary

`enforceGeneratedTokenMetadata` (added in #5942) enforces a generated npm token's `cidr_whitelist` by comparing the request's client IP against the allowed ranges. This PR fixes **how that client IP is determined** so the CIDR restriction cannot be bypassed.

## Finding

The middleware resolved the client address by reading the `X-Forwarded-For` header **directly and unconditionally**, taking its left-most (client-most) entry, and only falling back to `req.ip`/socket when the header was absent:

```ts
const forwardedFor = req.headers['x-forwarded-for'];
if (forwardedFor) return ipUtils.normalizeAddress(forwardedFor.split(',')[0]);
return ipUtils.normalizeAddress(req.ip || req.socket.remoteAddress);
```

`X-Forwarded-For` is client-supplied text. When Verdaccio is reachable directly (the default — no `server.trustProxy`), any caller can set the header to an allowed address and satisfy the whitelist:

```
curl -H "Authorization: Bearer <cidr-pinned-token>" \
     -H "X-Forwarded-For: 203.0.113.5" \
     http://registry/...
```

A token pinned to e.g. `203.0.113.0/24` could therefore be used from anywhere, defeating the restriction. Taking the **left-most** entry made it worse — that is the most attacker-controlled part of the chain. The net effect: a control that looks like it restricts by network but does not, giving operators a false sense of security.

## Root cause

The middleware reimplemented client-IP resolution from the raw header instead of using Express' `req.ip`, which is derived from the app's `trust proxy` setting. Verdaccio already wires that from config (`src/api/index.ts`):

```ts
if (config.server?.trustProxy) {
  app.set('trust proxy', config.server.trustProxy);
}
```

By bypassing `req.ip`, the enforcement ignored the operator's proxy-trust configuration entirely.

## Fix

Resolve the client address from `req.ip` (falling back to the raw socket), and never read `X-Forwarded-For` directly:

```ts
function getClientAddress(req: Request): string | undefined {
  return ipUtils.normalizeAddress(req.ip || req.socket.remoteAddress);
}
```

- **No `trustProxy` (default):** `X-Forwarded-For` is ignored; the real socket peer is used — forged headers do nothing.
- **`trustProxy` configured:** Express returns the upstream-most *untrusted* address from the forwarded chain — the real client as reported by trusted infrastructure.

## Operator note (behavior change)

`cidr_whitelist` on generated tokens now depends on `server.trustProxy` matching the deployment:

- **Direct exposure** → works out of the box (socket IP).
- **Behind a proxy / load balancer** → set `server.trustProxy` so the client IP can be recovered from `X-Forwarded-For`; otherwise requests appear to originate from the proxy and CIDR-pinned tokens will not match.

This is not a regression in capability — it is the difference between *spoofable* and *correctly configured*, and matches how the rest of Verdaccio sources the client address.

## Tests

`packages/middleware/test/token-auth.spec.ts`:

- **Regression:** a spoofed `X-Forwarded-For` is ignored when `trust proxy` is not configured (request rejected on the real socket address).
- `X-Forwarded-For` is honored only when `trust proxy` is configured (allow in-range / reject out-of-range / upstream-most entry).
- Socket-address allow/reject cases retained.
