### PR TITLE
fix: allow npm token create without readonly/cidr_whitelist

### DIFF
--- a/.changeset/token-create-optional-params.md
+++ b/.changeset/token-create-optional-params.md
@@ -1,0 +1,13 @@
+---
+'verdaccio': patch
+---
+
+fix: allow npm token create without readonly/cidr_whitelist
+
+`npm token create` in npm >= 11 (and the npm 12 prereleases) rewrote the
+request body: it no longer sends `readonly` and only sends `cidr_whitelist`
+when `--cidr` is passed. The `POST /-/npm/v1/tokens` endpoint required both,
+so modern npm clients failed with `422 the parameters are not valid`.
+
+The endpoint now defaults `readonly` to `false` and `cidr_whitelist` to `[]`
+when they are absent, while still rejecting values of the wrong type.

--- a/src/api/endpoint/api/v1/token.ts
+++ b/src/api/endpoint/api/v1/token.ts
@@ -59,14 +59,12 @@ export default function (router: Router, auth: Auth, storage: Storage, config: C
     '/-/npm/v1/tokens',
     rateLimit(config?.userRateLimit),
     function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
-      const { password } = req.body;
+      const { password, readonly = false, cidr_whitelist = [] } = req.body;
       const { name } = req.remote_user;
       // `readonly` and `cidr_whitelist` are optional: npm >= 11 rewrote
       // `npm token create` to omit them (and only sends `cidr_whitelist` with
       // `--cidr`), so default them rather than rejecting the request. A wrong
       // type is still rejected.
-      const readonly = req.body.readonly ?? false;
-      const cidr_whitelist = req.body.cidr_whitelist ?? [];
 
       if (!_.isBoolean(readonly) || !_.isArray(cidr_whitelist)) {
         return next(ErrorCode.getCode(HTTP_STATUS.BAD_DATA, SUPPORT_ERRORS.PARAMETERS_NOT_VALID));

--- a/src/api/endpoint/api/v1/token.ts
+++ b/src/api/endpoint/api/v1/token.ts
@@ -59,8 +59,14 @@ export default function (router: Router, auth: Auth, storage: Storage, config: C
     '/-/npm/v1/tokens',
     rateLimit(config?.userRateLimit),
     function (req: $RequestExtend, res: Response, next: $NextFunctionVer) {
-      const { password, readonly, cidr_whitelist } = req.body;
+      const { password } = req.body;
       const { name } = req.remote_user;
+      // `readonly` and `cidr_whitelist` are optional: npm >= 11 rewrote
+      // `npm token create` to omit them (and only sends `cidr_whitelist` with
+      // `--cidr`), so default them rather than rejecting the request. A wrong
+      // type is still rejected.
+      const readonly = req.body.readonly ?? false;
+      const cidr_whitelist = req.body.cidr_whitelist ?? [];
 
       if (!_.isBoolean(readonly) || !_.isArray(cidr_whitelist)) {
         return next(ErrorCode.getCode(HTTP_STATUS.BAD_DATA, SUPPORT_ERRORS.PARAMETERS_NOT_VALID));

--- a/src/api/endpoint/api/v1/token.ts
+++ b/src/api/endpoint/api/v1/token.ts
@@ -15,6 +15,22 @@ import { ErrorCode } from '../../../../lib/utils';
 import type { $NextFunctionVer, $RequestExtend } from '../../../../types';
 
 const debug = buildDebug('verdaccio:token');
+
+// Granular access token options (npm >= 11) that Verdaccio does not implement
+// yet. They are accepted so `npm token create` succeeds, but the restrictions
+// they express are NOT enforced — warn so the operator is not misled.
+const UNSUPPORTED_TOKEN_OPTIONS = [
+  'packages_and_scopes_permission',
+  'packages',
+  'packages_all',
+  'scopes',
+  'orgs',
+  'orgs_permission',
+  'expires',
+  'description',
+  'bypass_2fa',
+];
+
 export type NormalizeToken = Token & {
   created: string;
 };
@@ -68,6 +84,16 @@ export default function (router: Router, auth: Auth, storage: Storage, config: C
 
       if (!_.isBoolean(readonly) || !_.isArray(cidr_whitelist)) {
         return next(ErrorCode.getCode(HTTP_STATUS.BAD_DATA, SUPPORT_ERRORS.PARAMETERS_NOT_VALID));
+      }
+
+      const unsupportedOptions = UNSUPPORTED_TOKEN_OPTIONS.filter(
+        (option) => _.isNil(req.body[option]) === false
+      );
+      if (unsupportedOptions.length > 0) {
+        logger.warn(
+          { options: unsupportedOptions.join(', '), userAgent: req.get('user-agent') ?? 'unknown' },
+          'granular access token options are not supported yet and will be ignored: @{options} (client: @{userAgent})'
+        );
       }
 
       auth.authenticate(name, password, async (err, user?: RemoteUser) => {

--- a/test/unit/modules/api/token.spec.ts
+++ b/test/unit/modules/api/token.spec.ts
@@ -173,6 +173,44 @@ describe('token', () => {
     }
   );
 
+  // npm >= 11 granular access token options are accepted but not enforced; the
+  // token is still created (a warning is logged, including the client user
+  // agent) rather than failing.
+  test.each([['token.yaml'], ['token.jwt.yaml']])(
+    'should create a token ignoring unsupported granular options',
+    async (conf) => {
+      const app = await initializeServer(conf);
+      const credentials = { name: 'jota_token', password: 'secretPass' };
+      const token = await getNewToken(app, credentials);
+      const resp = await supertest(app)
+        .post('/-/npm/v1/tokens')
+        .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+        // the package-manager user agent is captured in the warning log
+        .set('user-agent', 'npm/12.0.0-pre.0.0 node/v24.15.0 darwin x64')
+        .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+        .send(
+          JSON.stringify({
+            password: credentials.password,
+            readonly: false,
+            cidr_whitelist: [],
+            packages_and_scopes_permission: 'read-only',
+            packages: ['@scope/pkg'],
+            scopes: ['@scope'],
+            orgs: ['my-org'],
+            expires: 30,
+            description: 'ci token',
+            bypass_2fa: true,
+          })
+        )
+        .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET);
+
+      expect(resp.body.token).toBeDefined();
+      // the unsupported options are not persisted on the token
+      expect(resp.body).not.toHaveProperty('packages_and_scopes_permission');
+      expect(resp.body).not.toHaveProperty('expires');
+    }
+  );
+
   describe('generated token authorization', () => {
     test.each([['token.yaml'], ['token.jwt.yaml']])(
       'should allow writes with a writable generated token within its constraints',

--- a/test/unit/modules/api/token.spec.ts
+++ b/test/unit/modules/api/token.spec.ts
@@ -96,22 +96,55 @@ describe('token', () => {
     });
 
     test.each([['token.yaml'], ['token.jwt.yaml']])(
-      'should fail if readonly is missing',
+      'should reject readonly when it has the wrong type',
       async (conf) => {
         const app = await initializeServer(conf);
         const credentials = { name: 'jota_token', password: 'secretPass' };
         const token = await getNewToken(app, credentials);
         const resp = await generateTokenCLI(app, token, {
           password: credentials.password,
+          readonly: 'nope',
           cidr_whitelist: [],
+        });
+        expect(resp.body.error).toEqual(SUPPORT_ERRORS.PARAMETERS_NOT_VALID);
+      }
+    );
+
+    test.each([['token.yaml'], ['token.jwt.yaml']])(
+      'should reject cidr_whitelist when it has the wrong type',
+      async (conf) => {
+        const app = await initializeServer(conf);
+        const credentials = { name: 'jota_token', password: 'secretPass' };
+        const token = await getNewToken(app, credentials);
+        const resp = await generateTokenCLI(app, token, {
+          password: credentials.password,
+          readonly: false,
+          cidr_whitelist: 'not-an-array',
         });
         expect(resp.body.error).toEqual(SUPPORT_ERRORS.PARAMETERS_NOT_VALID);
       }
     );
   });
 
+  // npm >= 11 rewrote `npm token create` to omit `readonly` and to send
+  // `cidr_whitelist` only with `--cidr`; the endpoint must default them.
   test.each([['token.yaml'], ['token.jwt.yaml']])(
-    'should fail if cidr_whitelist is missing',
+    'should default readonly to false when omitted',
+    async (conf) => {
+      const app = await initializeServer(conf);
+      const credentials = { name: 'jota_token', password: 'secretPass' };
+      const token = await getNewToken(app, credentials);
+      const resp = await generateTokenCLI(app, token, {
+        password: credentials.password,
+        cidr_whitelist: [],
+      });
+      expect(resp.body.token).toBeDefined();
+      expect(resp.body.readonly).toBe(false);
+    }
+  );
+
+  test.each([['token.yaml'], ['token.jwt.yaml']])(
+    'should default cidr_whitelist to empty when omitted',
     async (conf) => {
       const app = await initializeServer(conf);
       const credentials = { name: 'jota_token', password: 'secretPass' };
@@ -120,7 +153,23 @@ describe('token', () => {
         password: credentials.password,
         readonly: false,
       });
-      expect(resp.body.error).toEqual(SUPPORT_ERRORS.PARAMETERS_NOT_VALID);
+      expect(resp.body.token).toBeDefined();
+      expect(resp.body.cidr).toEqual([]);
+    }
+  );
+
+  test.each([['token.yaml'], ['token.jwt.yaml']])(
+    'should create a token from a body with only a password',
+    async (conf) => {
+      const app = await initializeServer(conf);
+      const credentials = { name: 'jota_token', password: 'secretPass' };
+      const token = await getNewToken(app, credentials);
+      const resp = await generateTokenCLI(app, token, {
+        password: credentials.password,
+      });
+      expect(resp.body.token).toBeDefined();
+      expect(resp.body.readonly).toBe(false);
+      expect(resp.body.cidr).toEqual([]);
     }
   );
 


### PR DESCRIPTION
`npm token create` in npm >= 11 (and the npm 12 prereleases) rewrote the
request body: it no longer sends `readonly` and only sends `cidr_whitelist`
when `--cidr` is passed. The `POST /-/npm/v1/tokens` endpoint required both,
so modern npm clients failed with `422 the parameters are not valid`.

The endpoint now defaults `readonly` to `false` and `cidr_whitelist` to `[]`
when they are absent, while still rejecting values of the wrong type.