### PR TITLE
fix(storage): check owner on package change

### DIFF
--- a/.changeset/real-shrimps-lick.md
+++ b/.changeset/real-shrimps-lick.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/store': patch
+---
+
+fix(storage): check owner on package change

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -1008,6 +1008,8 @@ class Storage {
       uplinksLook: false,
     });
 
+    await this.checkAllowedToChangePackage(localPackage, username);
+
     await this.changePackage(
       name,
       { ...localPackage, maintainers: maintainers as Author[] },

--- a/packages/store/test/storage.spec.ts
+++ b/packages/store/test/storage.spec.ts
@@ -777,6 +777,41 @@ describe('storage', () => {
           ).rejects.toThrow();
         }
       );
+
+      test.each([['foo', 'publishWithOwnerAndCheck.yaml']])(
+        'should fail changing owners as non-owner with check %s, %s',
+        async (pkgName, configFile) => {
+          const config = getConfig(configFile);
+          const storage = new Storage(config, logger);
+          await storage.init(config);
+          const bodyNewManifest = generatePackageMetadata(pkgName, '1.0.0');
+          const owner = { name: 'fooUser', email: 'fooUser@mail.abappm.com' };
+          const options = { ...defaultRequestOptions, username: owner.name };
+          await storage.updateManifest(bodyNewManifest, {
+            signal: new AbortController().signal,
+            name: pkgName,
+            uplinksLook: false,
+            requestOptions: options,
+          });
+
+          const manifest = (await storage.getPackageByOptions({
+            name: pkgName,
+            uplinksLook: false,
+            requestOptions: options,
+          })) as Manifest;
+
+          const nonOwner = 'barUser';
+          await expect(
+            executeChangeOwners(storage, {
+              _rev: manifest._rev,
+              _id: manifest._id,
+              name: pkgName,
+              username: nonOwner,
+              maintainers: [{ name: nonOwner, email: '' }],
+            })
+          ).rejects.toThrow();
+        }
+      );
     });
   });
 


### PR DESCRIPTION
Ref https://github.com/verdaccio/verdaccio/pull/4582

Fixed.`changeOwners()` was missing the maintainer check that `publishANewVersion`, `removeTarball`, and `removePackage` already use.

With `publish.check_owners: true`, only existing maintainers can change the maintainers list. A non-owner with publish permission gets `403 Forbidden: only owners are allowed to change package`.

