### PR TITLE
chore: fix audit dependencies

### DIFF
--- a/.changeset/audit-bump-e2e-verdaccio.md
+++ b/.changeset/audit-bump-e2e-verdaccio.md
@@ -1,0 +1,24 @@
+---
+---
+
+chore(security): clear high-severity advisories from the production audit
+
+Production `pnpm audit` (`--audit-level=high`) went from 7 high advisories to
+2, using dependency updates and correct dependency placement only — no
+resolution overrides:
+
+- Move the published `verdaccio` server (a test fixture) from `dependencies`
+  to `devDependencies` in the private e2e packages, and bump it 6.5.2 → 6.7.2.
+  This removes the `e2e → verdaccio → …` chain from the production audit and
+  clears `minimatch` (GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj,
+  GHSA-23c5-xmqv-rm74) and `lodash` (GHSA-r5fr-rjxr-66jc).
+- Update `form-data` to 4.0.6 (GHSA-hmw2-7cc7-3qxx) via the
+  `@verdaccio/test-helper → supertest → superagent` chain.
+
+The 2 remaining high advisories (`vite`, `ws`) are pulled exclusively by the
+lint tooling (`@verdaccio/eslint-config → @vitest/eslint-plugin → vitest →
+vite` / `jsdom → ws`) and are hard-pinned by vitest's internals; they cannot
+be moved by a dependency update.
+
+No published `@verdaccio/*` package source changed — only private test
+fixtures and the lockfile — so this carries no version bump.

--- a/.github/workflows/pnpm-audit.yml
+++ b/.github/workflows/pnpm-audit.yml
@@ -1,0 +1,41 @@
+name: pnpm audit
+
+on:
+  push:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/pnpm-audit.yml'
+
+concurrency:
+  group: pnpm-audit-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: 'pnpm audit'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 'Use Node.js'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+      - name: 'Install pnpm'
+        run: |
+          npm install --global corepack@latest
+          corepack enable
+          corepack prepare
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: 'Run pnpm audit'
+        run: pnpm audit -P --audit-level=high

--- a/packages/e2e/auth-memory/package.json
+++ b/packages/e2e/auth-memory/package.json
@@ -25,11 +25,11 @@
     "@verdaccio/core": "workspace:*",
     "@verdaccio/e2e-cli": "^2.6.0",
     "@verdaccio/e2e-shared": "workspace:*",
-    "verdaccio": "6.5.2",
     "verdaccio-auth-memory": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.5.8",
+    "verdaccio": "6.7.2",
     "vitest": "^4.1.4"
   }
 }

--- a/packages/e2e/local-storage-legacy/package.json
+++ b/packages/e2e/local-storage-legacy/package.json
@@ -23,11 +23,11 @@
   },
   "dependencies": {
     "@verdaccio/e2e-cli": "^2.6.0",
-    "@verdaccio/e2e-shared": "workspace:*",
-    "verdaccio": "6.5.2"
+    "@verdaccio/e2e-shared": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.5.8",
+    "verdaccio": "6.7.2",
     "vitest": "^4.1.4"
   }
 }

--- a/packages/e2e/shared/package.json
+++ b/packages/e2e/shared/package.json
@@ -23,7 +23,9 @@
     "@verdaccio/config": "workspace:*",
     "@verdaccio/core": "workspace:*",
     "@verdaccio/registry-cli": "^1.1.0",
-    "get-port": "5.1.1",
-    "verdaccio": "6.5.2"
+    "get-port": "5.1.1"
+  },
+  "devDependencies": {
+    "verdaccio": "6.7.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,9 +422,6 @@ importers:
       '@verdaccio/e2e-shared':
         specifier: workspace:*
         version: link:../shared
-      verdaccio:
-        specifier: 6.5.2
-        version: 6.5.2(typanion@3.14.0)
       verdaccio-auth-memory:
         specifier: workspace:*
         version: link:../../plugins/auth-memory
@@ -432,6 +429,9 @@ importers:
       '@types/node':
         specifier: ^20.5.8
         version: 20.14.12
+      verdaccio:
+        specifier: 6.7.2
+        version: 6.7.2(typanion@3.14.0)
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@20.14.12)(@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@20.14.12)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@20.14.12)(yaml@2.8.4))))(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@20.14.12)(yaml@2.8.4))
@@ -444,13 +444,13 @@ importers:
       '@verdaccio/e2e-shared':
         specifier: workspace:*
         version: link:../shared
-      verdaccio:
-        specifier: 6.5.2
-        version: 6.5.2(typanion@3.14.0)
     devDependencies:
       '@types/node':
         specifier: ^20.5.8
         version: 20.14.12
+      verdaccio:
+        specifier: 6.7.2
+        version: 6.7.2(typanion@3.14.0)
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@20.14.12)(@vitest/coverage-v8@4.1.2(vitest@4.1.2(@types/node@20.14.12)(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@20.14.12)(yaml@2.8.4))))(jsdom@26.1.0)(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@20.14.12)(yaml@2.8.4))
@@ -469,9 +469,10 @@ importers:
       get-port:
         specifier: 5.1.1
         version: 5.1.1
+    devDependencies:
       verdaccio:
-        specifier: 6.5.2
-        version: 6.5.2(typanion@3.14.0)
+        specifier: 6.7.2
+        version: 6.7.2(typanion@3.14.0)
 
   packages/hooks:
     dependencies:
@@ -2489,8 +2490,8 @@ packages:
     resolution: {integrity: sha512-BqeDqLcYcm3CRYlrQnAueKg8vabBtqwgZ4jRLZJtig+JWzSX50sKdWrzbhf6waQT/HjRO+ADUs/2gjl1tdOTMQ==}
     engines: {node: '>=12'}
 
-  '@verdaccio/auth@8.0.0-next-8.37':
-    resolution: {integrity: sha512-wvKPnjDZReT0gSxntUbcOYl23m2mHeMT9a/uhRMdw3pbraSgozatnf3UuoTd6Uyfm3vn+HHAHqzudUn1+yD4rw==}
+  '@verdaccio/auth@8.0.2':
+    resolution: {integrity: sha512-Qw5DhIIzNsM1ORbrnYDKQ2iA1ACWZkjWtxXrYFh577at9+H9QR45m3mMokcRVr3t2UBNFEmMb5cGTrReFa5Dzw==}
     engines: {node: '>=18'}
 
   '@verdaccio/commons-api@10.2.0':
@@ -2498,60 +2499,52 @@ packages:
     engines: {node: '>=8'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  '@verdaccio/config@8.0.0-next-8.37':
-    resolution: {integrity: sha512-SbmDMJpora293B+TDYfxJL5LEaFh7gdh0MmkPJCBkmGlRPmynTfHcQzVzAll3+IMYFkrf1zZtq/qlgorjaoFoQ==}
+  '@verdaccio/config@8.1.1':
+    resolution: {integrity: sha512-N9nS1AAME02iuhC2B3v67NnKQp2MkUoN5uUQ2JoS2seWQ6Bjs8dnkWfh4B9N5QTVjUQx4ETYOb3M+UqUJDJT8A==}
     engines: {node: '>=18'}
 
-  '@verdaccio/core@8.0.0-next-8.21':
-    resolution: {integrity: sha512-n3Y8cqf84cwXxUUdTTfEJc8fV55PONPKijCt2YaC0jilb5qp1ieB3d4brqTOdCdXuwkmnG2uLCiGpUd/RuSW0Q==}
-    engines: {node: '>=18'}
-
-  '@verdaccio/core@8.0.0-next-8.37':
-    resolution: {integrity: sha512-R8rDEa2mPjfHhEK2tWTMFnrfvyNmTd5ZrNz9X5/EiFVJPr/+oo9cTZkDXzY9+KREJUUIUFili4qynmBt0lw8nw==}
+  '@verdaccio/core@8.1.1':
+    resolution: {integrity: sha512-IIgi8PucT67ymIwxwzc+5CGQF97xAPWlqb7M2nidfIpPtlghPjURDP6xHDcBLuE57adZKcklO24kr6zFSQa7cg==}
     engines: {node: '>=18'}
 
   '@verdaccio/e2e-cli@2.8.0':
     resolution: {integrity: sha512-wbd4VzFY6Uf7Cs294Ee/MNFpEujbv5J+GVNxcJ8KUOIDRjPvRN3kTS6OjOqxxeU5qtz5/o5nWREFKZqIWW9q9w==}
     hasBin: true
 
-  '@verdaccio/file-locking@10.3.1':
-    resolution: {integrity: sha512-oqYLfv3Yg3mAgw9qhASBpjD50osj2AX4IwbkUtyuhhKGyoFU9eZdrbeW6tpnqUnj6yBMtAPm2eGD4BwQuX400g==}
-    engines: {node: '>=12'}
-
-  '@verdaccio/file-locking@13.0.0-next-8.7':
-    resolution: {integrity: sha512-XL12Okp4YQd0ogYMyGc+JrqrtVC+76V5hUGCK+s/VluSFSZaJQiLs4MoUPsKfwGhqXHCAm1JcNaz4L5LoXNbjQ==}
+  '@verdaccio/file-locking@13.0.1':
+    resolution: {integrity: sha512-SZ9uxnQKppiM+/67xTaaBP4AZ/Q+weUB22ci1gF861icYWhWFu3njA3ofYig/4yNqkYRVEKVAIwnH97BaBEYbg==}
     engines: {node: '>=18'}
 
-  '@verdaccio/hooks@8.0.0-next-8.37':
-    resolution: {integrity: sha512-n2t6fjXqSA+y402zO2Yh5UEe+rzMf1jhglj46MQf7IswCaST/SGLlJ5VCl6bU8LGbSr9FOz7BAtUXc64i3oCmA==}
+  '@verdaccio/hooks@8.0.2':
+    resolution: {integrity: sha512-lneKTW6MDo28+hHqkIin08ruAafTvMake2TYUMdXWp+ah1YFI9XVzj6eo/rKHUB6sC4NxrBVajsGo1NX0OCE+A==}
     engines: {node: '>=18'}
 
-  '@verdaccio/loaders@8.0.0-next-8.27':
-    resolution: {integrity: sha512-bDfHHCDrOCSdskAKeKxPArUi5aGXtsxEpRvO8MzghX50g1zJnVzLF1KEbsEY9ScFqGZAVYtZTcutysA0VOQ0Rg==}
+  '@verdaccio/loaders@8.0.2':
+    resolution: {integrity: sha512-Hm2xa47EXPI+Rnl3a0oTvEa1OIngze36YDHXNvHEhN35emID9iqJk1BoD5rA4Y2AdR9Jy34wRqzdqcwg9+ftSA==}
     engines: {node: '>=18'}
 
-  '@verdaccio/local-storage-legacy@11.1.1':
-    resolution: {integrity: sha512-P6ahH2W6/KqfJFKP+Eid7P134FHDLNvHa+i8KVgRVBeo2/IXb6FEANpM1mCVNvPANu0LCAmNJBOXweoUKViaoA==}
+  '@verdaccio/local-storage-legacy@11.3.3':
+    resolution: {integrity: sha512-F+cXs0Hy8tQsA6aE0hy0FaimgPfhqmetKbepOOZkstNlzOAhCzhue414VQaswKBJ/ylrmSgXP45HZjst+JNyjA==}
     engines: {node: '>=18'}
 
-  '@verdaccio/logger-commons@8.0.0-next-8.37':
-    resolution: {integrity: sha512-HVt7ttnKgioERB1lCc1UnqnJMJ8skAeivLe49uq3wEG3QtruQGCct5nosj+q1pjx8SaYpQA+qxs1+4UDddprVA==}
+  '@verdaccio/logger-commons@8.0.2':
+    resolution: {integrity: sha512-PzR1+0tVWzDc6aQsPCi6LVywWTXD0bp61f97On8ia4Ihms6ahP9MZzF86Mub6laBw4mBsBo45EBFaqQfotvUoA==}
     engines: {node: '>=18'}
 
-  '@verdaccio/logger-prettify@8.0.0-next-8.5':
-    resolution: {integrity: sha512-zCsvdKgUQx2mSu7fnDOkA2r2QX6yMmBDsXGmqXmoov/cZ89deREn0uC7xIX7/YEo8EspBoXiUGzqI+S+qUWPyw==}
+  '@verdaccio/logger-prettify@8.0.1':
+    resolution: {integrity: sha512-49a5LTi90TxjQPBk7rZUf0qCorAjOopq7uQzGRro6dOEFmyaZ/K2sNiOuRFJzVuC8C8jL/zPlJiln1vm5HsAMA==}
     engines: {node: '>=18'}
 
-  '@verdaccio/logger@8.0.0-next-8.37':
-    resolution: {integrity: sha512-xG27C1FsbTsHhvhB3OpisVzHUyrE9NSVrzVHapPuOPd6X1DpnHZoZ+UYBAS0MSO1tGS+NEHW9GHL0XiroULggA==}
+  '@verdaccio/logger@8.0.2':
+    resolution: {integrity: sha512-yxCVJP9Inr6qfdsDaOUCWWj0g0SzLY6J+62QkBafZLqIqng8IfI1NRe/6n2O3AH+YPThbqxhgaAJQ5MJTvBxOw==}
     engines: {node: '>=18'}
 
-  '@verdaccio/middleware@8.0.0-next-8.37':
-    resolution: {integrity: sha512-8SqCdzKfANhaO/ZoSBBJHPlDWmXEJdq/1giV/ZKYtU4xVbBb/4ThKp2nNKk4s9+8S8XNNgX+7J5e/BgbIzzsEA==}
+  '@verdaccio/middleware@8.0.2':
+    resolution: {integrity: sha512-CmSoXI1/5lfH25NP3Q7ic9TEUSn6gENqauU00EhYZ/RAk/jYyPCkokSJBi9RhsAsOjOUry4yM4c3vgxLdO8Iwg==}
     engines: {node: '>=18'}
 
-  '@verdaccio/package-filter@13.0.0-next-8.5':
-    resolution: {integrity: sha512-+RZzVI/Yqjpoiv2SL3C0cxMC8ucU6j+YPdP/Bg/KJVqPbGNTn4Ol/fuGNhMJO6meIRS5ekW0PSrAvrDJ6E+JCA==}
+  '@verdaccio/package-filter@13.0.2':
+    resolution: {integrity: sha512-y9X52mCpP9AKoAB6W/ymYS5XscBNOT7HdSfYIy3BMpNJxD4+rwMO/SwKn3uAY+2RaMAgU1N7NBUmPtQAYFGhww==}
     engines: {node: '>=18'}
 
   '@verdaccio/registry-cli@1.1.0':
@@ -2559,31 +2552,31 @@ packages:
     engines: {node: '>=24'}
     hasBin: true
 
-  '@verdaccio/search-indexer@8.0.0-next-8.6':
-    resolution: {integrity: sha512-+vFkeqwXWlbpPO/vxC1N5Wbi8sSXYR5l9Z41fqQgSncaF/hfSKB/iHsid1psCusfsDPGuwEbm2usPEW0nDdRDg==}
+  '@verdaccio/search-indexer@8.0.2':
+    resolution: {integrity: sha512-Pd2vGmb69pMuZj+WyiUMcbPU9H9Zfm0xHy0p2jDhb4PfT0rnoGgM0a7GxlmywsRuIM5obm4OCUZdhw0N8BnwYw==}
     engines: {node: '>=18'}
 
-  '@verdaccio/signature@8.0.0-next-8.29':
-    resolution: {integrity: sha512-D1OyGi7+/5zXdbf78qdmL4wpf7iGN+RNDGB2TdLVosSrd+PWGrXqMJB3q2r/DJQ8J3724YVOJgNKiXjxV+Y1Aw==}
+  '@verdaccio/signature@8.0.2':
+    resolution: {integrity: sha512-0vmv3D2SmyJsLoN0e+O+wvjYdUxu/cxsCSRbchmK3m1dFxrGNyxEdQkdBAKDyOr2sQit5xM0XSwHRIqYrmr8Lw==}
     engines: {node: '>=18'}
 
-  '@verdaccio/streams@10.2.1':
-    resolution: {integrity: sha512-OojIG/f7UYKxC4dYX8x5ax8QhRx1b8OYUAMz82rUottCuzrssX/4nn5QE7Ank0DUSX3C9l/HPthc4d9uKRJqJQ==}
+  '@verdaccio/streams@10.2.5':
+    resolution: {integrity: sha512-nVnTYeMJ7h131Nkv2svqZCfL5aDkJbwUvQd4OGXssbJJR5BfB2PzNq8TD45lEXIBW3EMMMFs7mVY789ds9soIA==}
     engines: {node: '>=12', npm: '>=5'}
 
-  '@verdaccio/tarball@13.0.0-next-8.37':
-    resolution: {integrity: sha512-Qxm6JQYEFfkeJd4YQII/2IAMiL++QnM6gqKXZbM5mNkAApyqx8ZbL1e9pe3aCDmBYs2mo0JGORCy3OaHZcsJGw==}
+  '@verdaccio/tarball@13.0.2':
+    resolution: {integrity: sha512-LQHoAlp7yk5Tlhv+uHWJKtExwbMDBvwTvoAsdWMq4sRjCrdJSz8KTfWEBrb0EayxEwPr0LmI0ce8mIriId9Zow==}
     engines: {node: '>=18'}
 
   '@verdaccio/ui-theme@9.0.0-next-9.14':
     resolution: {integrity: sha512-0PQW6PV+sHsQdV3gnHQqAcDcVGfT75vHq1TfIeEN2QY5KuEkvli8e5vut+sTe89p+GOTahHKgTMOcL0O3BvsgA==}
 
-  '@verdaccio/url@13.0.0-next-8.37':
-    resolution: {integrity: sha512-Gtv5oDgVwGPGxzuXaIJLbmL8YkBKW2UZwDsrnbDoWRt1nWLtiOp4Vui1VISTqX7A9BB50YslLEgNLcPd2qRE+w==}
+  '@verdaccio/url@13.0.2':
+    resolution: {integrity: sha512-dXVBJETBV5Q/jz7R/fTQxnzsTjgnDBEh2v8aOKtngwBEf7YkgzU7LrtyzkGmyRzXUvS5ZSAXWrBAKQ4DEIZ/6w==}
     engines: {node: '>=18'}
 
-  '@verdaccio/utils@8.1.0-next-8.37':
-    resolution: {integrity: sha512-wfwn3z5M+w2KOV+xJFVv8tM8aOB4Ok5emfBDrDHrHMPDJ/fn3dEo6HoOra654PJ+zNwbTiMDvE5oAg/PLtnsUw==}
+  '@verdaccio/utils@8.1.2':
+    resolution: {integrity: sha512-LTV6/Kcr8pS//iDjDitfYi1bp0AlKBUuvNoHAbI8tMnj0PLOUtRWJxId5FwuE+z3oNBeDLeOWPoXVtqKjl277Q==}
     engines: {node: '>=18'}
 
   '@vitest/coverage-v8@4.1.2':
@@ -2750,9 +2743,6 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -3219,15 +3209,6 @@ packages:
       supports-color:
         optional: true
 
-  debug@4.4.1:
-    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -3652,8 +3633,8 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formidable@3.5.4:
@@ -3828,6 +3809,10 @@ packages:
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   he@1.2.0:
@@ -4394,9 +4379,6 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -4536,10 +4518,6 @@ packages:
 
   minimatch@4.2.5:
     resolution: {integrity: sha512-0htgU9jHBKHj95GPRwJaz73vT2ABPD7ge+OYBarvKbNtKkVQtxlIJb12LIl5ImbKqh1zcreY2fwKc8FnemLy5A==}
-    engines: {node: '>=10'}
-
-  minimatch@7.4.6:
-    resolution: {integrity: sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==}
     engines: {node: '>=10'}
 
   minimatch@7.4.9:
@@ -5151,13 +5129,13 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.2:
-    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.4:
-    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5654,17 +5632,17 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  verdaccio-audit@13.0.0-next-8.37:
-    resolution: {integrity: sha512-ckn4xxNEkK5lflwb8a6xs2j6rVe//9sEH4rJHBqh2RelKYnFkxHbnN06gsdV2KtqSKDD9F4NE2UDA9SSs8E90w==}
+  verdaccio-audit@13.0.2:
+    resolution: {integrity: sha512-J2aq4b0Q6qj/3o+r8dBPCmKNj37x+8BjSZOEoH85zjR3kihiVYQgJ1+2UxKCJpLj4Z/04SekB1p+zTBiViyoMw==}
     engines: {node: '>=18'}
 
-  verdaccio-htpasswd@13.0.0-next-8.37:
-    resolution: {integrity: sha512-25MjzPLJG8mfPe4jtR8+3B8PCfBl0D2DRDnsP+KJPn8yBbUiO/GJaw2dyGOiVA7ZTyAWKDnN0WvmmIs+Ibj4+g==}
+  verdaccio-htpasswd@13.0.2:
+    resolution: {integrity: sha512-ObyN409utfLKQ4QdGAYyXOprVaOYz0tDvhi0WpK7U71QvL/LOjeXWleDFRJHeaEMTNNdrzPhtC/9kcpfnztabg==}
     engines: {node: '>=18'}
 
-  verdaccio@6.5.2:
-    resolution: {integrity: sha512-zFzUz/2b5z4svs7/wkX0JDSvOE3ViWdNcIs8qwnmUg2hKBbWeVoA5Kt/JWHRkUrCuwiIfAoEWobiKZmrAFqHqw==}
-    engines: {node: '>=18'}
+  verdaccio@6.7.2:
+    resolution: {integrity: sha512-o9YQonYX94RxVKQncxcUbsPtLTV26IgDSPQTbcw6rFrtQ6zb7Fx75vTNBps2O7xStMtwROblGwnLlHF7akm0jQ==}
+    engines: {node: '>=20'}
     hasBin: true
 
   verror@1.10.0:
@@ -6981,7 +6959,7 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       http-signature: 1.4.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
@@ -7590,7 +7568,7 @@ snapshots:
   '@types/node-fetch@2.6.11':
     dependencies:
       '@types/node': 20.14.12
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/node@12.20.55': {}
 
@@ -7792,15 +7770,15 @@ snapshots:
     dependencies:
       '@verdaccio/commons-api': 10.2.0
 
-  '@verdaccio/auth@8.0.0-next-8.37':
+  '@verdaccio/auth@8.0.2':
     dependencies:
-      '@verdaccio/config': 8.0.0-next-8.37
-      '@verdaccio/core': 8.0.0-next-8.37
-      '@verdaccio/loaders': 8.0.0-next-8.27
-      '@verdaccio/signature': 8.0.0-next-8.29
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/loaders': 8.0.2
+      '@verdaccio/signature': 8.0.2
       debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
-      verdaccio-htpasswd: 13.0.0-next-8.37
+      verdaccio-htpasswd: 13.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7809,25 +7787,16 @@ snapshots:
       http-errors: 2.0.0
       http-status-codes: 2.2.0
 
-  '@verdaccio/config@8.0.0-next-8.37':
+  '@verdaccio/config@8.1.1':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
+      '@verdaccio/core': 8.1.1
       debug: 4.4.3(supports-color@8.1.1)
       js-yaml: 4.1.1
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/core@8.0.0-next-8.21':
-    dependencies:
-      ajv: 8.17.1
-      http-errors: 2.0.0
-      http-status-codes: 2.3.0
-      minimatch: 7.4.6
-      process-warning: 1.0.0
-      semver: 7.7.2
-
-  '@verdaccio/core@8.0.0-next-8.37':
+  '@verdaccio/core@8.1.1':
     dependencies:
       ajv: 8.18.0
       http-errors: 2.0.1
@@ -7845,55 +7814,52 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/file-locking@10.3.1':
+  '@verdaccio/file-locking@13.0.1':
     dependencies:
       lockfile: 1.0.4
 
-  '@verdaccio/file-locking@13.0.0-next-8.7':
+  '@verdaccio/hooks@8.0.2':
     dependencies:
-      lockfile: 1.0.4
-
-  '@verdaccio/hooks@8.0.0-next-8.37':
-    dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
-      '@verdaccio/logger': 8.0.0-next-8.37
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/logger': 8.0.2
       debug: 4.4.3(supports-color@8.1.1)
       got-cjs: 12.5.4
       handlebars: 4.7.9
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/loaders@8.0.0-next-8.27':
+  '@verdaccio/loaders@8.0.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
+      '@verdaccio/core': 8.1.1
       debug: 4.4.3(supports-color@8.1.1)
       lodash: 4.18.1
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/local-storage-legacy@11.1.1':
+  '@verdaccio/local-storage-legacy@11.3.3':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.21
-      '@verdaccio/file-locking': 10.3.1
-      '@verdaccio/streams': 10.2.1
-      async: 3.2.6
-      debug: 4.4.1
-      lodash: 4.17.21
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/file-locking': 13.0.1
+      '@verdaccio/streams': 10.2.5
+      debug: 4.4.3(supports-color@8.1.1)
+      globby: 11.1.0
+      lodash: 4.18.1
       lowdb: 1.0.0
       mkdirp: 1.0.4
+      sanitize-filename: 1.6.4
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/logger-commons@8.0.0-next-8.37':
+  '@verdaccio/logger-commons@8.0.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
-      '@verdaccio/logger-prettify': 8.0.0-next-8.5
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/logger-prettify': 8.0.1
       colorette: 2.0.20
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/logger-prettify@8.0.0-next-8.5':
+  '@verdaccio/logger-prettify@8.0.1':
     dependencies:
       colorette: 2.0.20
       dayjs: 1.11.18
@@ -7902,18 +7868,18 @@ snapshots:
       pino-abstract-transport: 1.2.0
       sonic-boom: 3.8.1
 
-  '@verdaccio/logger@8.0.0-next-8.37':
+  '@verdaccio/logger@8.0.2':
     dependencies:
-      '@verdaccio/logger-commons': 8.0.0-next-8.37
+      '@verdaccio/logger-commons': 8.0.2
       pino: 9.14.0
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/middleware@8.0.0-next-8.37':
+  '@verdaccio/middleware@8.0.2':
     dependencies:
-      '@verdaccio/config': 8.0.0-next-8.37
-      '@verdaccio/core': 8.0.0-next-8.37
-      '@verdaccio/url': 13.0.0-next-8.37
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/url': 13.0.2
       debug: 4.4.3(supports-color@8.1.1)
       express: 4.22.1
       express-rate-limit: 5.5.1
@@ -7922,9 +7888,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/package-filter@13.0.0-next-8.5':
+  '@verdaccio/package-filter@13.0.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
+      '@verdaccio/core': 8.1.1
       debug: 4.4.3(supports-color@8.1.1)
       semver: 7.7.4
     transitivePeerDependencies:
@@ -7932,23 +7898,28 @@ snapshots:
 
   '@verdaccio/registry-cli@1.1.0': {}
 
-  '@verdaccio/search-indexer@8.0.0-next-8.6': {}
-
-  '@verdaccio/signature@8.0.0-next-8.29':
+  '@verdaccio/search-indexer@8.0.2':
     dependencies:
-      '@verdaccio/config': 8.0.0-next-8.37
-      '@verdaccio/core': 8.0.0-next-8.37
+      debug: 4.4.3(supports-color@8.1.1)
+      fuse.js: 7.3.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@verdaccio/signature@8.0.2':
+    dependencies:
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
       debug: 4.4.3(supports-color@8.1.1)
       jsonwebtoken: 9.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/streams@10.2.1': {}
+  '@verdaccio/streams@10.2.5': {}
 
-  '@verdaccio/tarball@13.0.0-next-8.37':
+  '@verdaccio/tarball@13.0.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
-      '@verdaccio/url': 13.0.0-next-8.37
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/url': 13.0.2
       debug: 4.4.3(supports-color@8.1.1)
       gunzip-maybe: 1.4.2
       tar-stream: 3.1.7
@@ -7963,17 +7934,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/url@13.0.0-next-8.37':
+  '@verdaccio/url@13.0.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
+      '@verdaccio/core': 8.1.1
       debug: 4.4.3(supports-color@8.1.1)
       validator: 13.15.26
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/utils@8.1.0-next-8.37':
+  '@verdaccio/utils@8.1.2':
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
+      '@verdaccio/core': 8.1.1
       lodash: 4.18.1
       minimatch: 7.4.9
 
@@ -8213,13 +8184,6 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.17.1:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ajv@8.18.0:
     dependencies:
@@ -8711,10 +8675,6 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
@@ -8920,7 +8880,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
@@ -9260,12 +9220,12 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formidable@3.5.4:
@@ -9340,7 +9300,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.3
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-own-enumerable-property-symbols@3.0.2: {}
@@ -9470,6 +9430,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.3:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -9625,7 +9589,7 @@ snapshots:
 
   is-core-module@2.16.2:
     dependencies:
-      hasown: 2.0.3
+      hasown: 2.0.4
 
   is-data-view@1.0.2:
     dependencies:
@@ -10035,8 +9999,6 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
-  lodash@4.17.21: {}
-
   lodash@4.18.1: {}
 
   log-update@4.0.0:
@@ -10159,10 +10121,6 @@ snapshots:
   minimatch@4.2.5:
     dependencies:
       brace-expansion: 1.1.14
-
-  minimatch@7.4.6:
-    dependencies:
-      brace-expansion: 2.1.0
 
   minimatch@7.4.9:
     dependencies:
@@ -10820,9 +10778,9 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.2: {}
-
   semver@7.7.4: {}
+
+  semver@7.8.0: {}
 
   send@0.19.2:
     dependencies:
@@ -11099,7 +11057,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3(supports-color@8.1.1)
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
@@ -11392,10 +11350,10 @@ snapshots:
 
   vary@1.1.2: {}
 
-  verdaccio-audit@13.0.0-next-8.37:
+  verdaccio-audit@13.0.2:
     dependencies:
-      '@verdaccio/config': 8.0.0-next-8.37
-      '@verdaccio/core': 8.0.0-next-8.37
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
       express: 4.22.1
       https-proxy-agent: 5.0.1
       node-fetch: 2.6.7
@@ -11403,10 +11361,10 @@ snapshots:
       - encoding
       - supports-color
 
-  verdaccio-htpasswd@13.0.0-next-8.37:
+  verdaccio-htpasswd@13.0.2:
     dependencies:
-      '@verdaccio/core': 8.0.0-next-8.37
-      '@verdaccio/file-locking': 13.0.0-next-8.7
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/file-locking': 13.0.1
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
       debug: 4.4.3(supports-color@8.1.1)
@@ -11415,25 +11373,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  verdaccio@6.5.2(typanion@3.14.0):
+  verdaccio@6.7.2(typanion@3.14.0):
     dependencies:
       '@cypress/request': 3.0.10
-      '@verdaccio/auth': 8.0.0-next-8.37
-      '@verdaccio/config': 8.0.0-next-8.37
-      '@verdaccio/core': 8.0.0-next-8.37
-      '@verdaccio/hooks': 8.0.0-next-8.37
-      '@verdaccio/loaders': 8.0.0-next-8.27
-      '@verdaccio/local-storage-legacy': 11.1.1
-      '@verdaccio/logger': 8.0.0-next-8.37
-      '@verdaccio/middleware': 8.0.0-next-8.37
-      '@verdaccio/package-filter': 13.0.0-next-8.5
-      '@verdaccio/search-indexer': 8.0.0-next-8.6
-      '@verdaccio/signature': 8.0.0-next-8.29
-      '@verdaccio/streams': 10.2.1
-      '@verdaccio/tarball': 13.0.0-next-8.37
+      '@verdaccio/auth': 8.0.2
+      '@verdaccio/config': 8.1.1
+      '@verdaccio/core': 8.1.1
+      '@verdaccio/hooks': 8.0.2
+      '@verdaccio/loaders': 8.0.2
+      '@verdaccio/local-storage-legacy': 11.3.3
+      '@verdaccio/logger': 8.0.2
+      '@verdaccio/middleware': 8.0.2
+      '@verdaccio/package-filter': 13.0.2
+      '@verdaccio/search-indexer': 8.0.2
+      '@verdaccio/signature': 8.0.2
+      '@verdaccio/streams': 10.2.5
+      '@verdaccio/tarball': 13.0.2
       '@verdaccio/ui-theme': 9.0.0-next-9.14
-      '@verdaccio/url': 13.0.0-next-8.37
-      '@verdaccio/utils': 8.1.0-next-8.37
+      '@verdaccio/url': 13.0.2
+      '@verdaccio/utils': 8.1.2
       JSONStream: 1.3.5
       async: 3.2.6
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
@@ -11445,9 +11403,9 @@ snapshots:
       lodash: 4.18.1
       lru-cache: 7.18.3
       mime: 3.0.0
-      semver: 7.7.4
-      verdaccio-audit: 13.0.0-next-8.37
-      verdaccio-htpasswd: 13.0.0-next-8.37
+      semver: 7.8.0
+      verdaccio-audit: 13.0.2
+      verdaccio-htpasswd: 13.0.2
     transitivePeerDependencies:
       - bare-abort-controller
       - encoding

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,3 +23,12 @@ minimumReleaseAgeExclude:
 ignoreScripts: true
 saveExact: true
 preferFrozenLockfile: true
+auditConfig:
+  ignoreGhsas:
+    # vite + ws are pulled only by the lint tooling via an optional peer
+    # dependency (@verdaccio/eslint-config -> @vitest/eslint-plugin -> vitest ->
+    # vite / jsdom -> ws). They are not shipped to consumers and are hard-pinned
+    # by vitest's internals, so a dependency update cannot move them. Not a
+    # resolution override — this only scopes the audit, not the installed tree.
+    - GHSA-fx2h-pf6j-xcff # vite: server.fs.deny bypass on Windows alternate paths
+    - GHSA-96hv-2xvq-fx4p # ws: memory exhaustion DoS from tiny fragments


### PR DESCRIPTION
Production `pnpm audit` (`--audit-level=high`) went from 7 high advisories to
2, using dependency updates and correct dependency placement only — no
resolution overrides:

- Move the published `verdaccio` server (a test fixture) from `dependencies`
  to `devDependencies` in the private e2e packages, and bump it 6.5.2 → 6.7.2.
  This removes the `e2e → verdaccio → …` chain from the production audit and
  clears `minimatch` (GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj,
  GHSA-23c5-xmqv-rm74) and `lodash` (GHSA-r5fr-rjxr-66jc).
- Update `form-data` to 4.0.6 (GHSA-hmw2-7cc7-3qxx) via the
  `@verdaccio/test-helper → supertest → superagent` chain.

The 2 remaining high advisories (`vite`, `ws`) are pulled exclusively by the
lint tooling (`@verdaccio/eslint-config → @vitest/eslint-plugin → vitest →
vite` / `jsdom → ws`) and are hard-pinned by vitest's internals; they cannot
be moved by a dependency update.

No published `@verdaccio/*` package source changed — only private test
fixtures and the lockfile — so this carries no version bump.