### PR TITLE
fix: run jwt middleware before middleware plugins

### DIFF
--- a/.changeset/jwt-before-middleware-plugins.md
+++ b/.changeset/jwt-before-middleware-plugins.md
@@ -1,0 +1,14 @@
+---
+'verdaccio': patch
+---
+
+fix: run jwt middleware before middleware plugins
+
+Register the JWT middleware before middleware plugins are loaded so that
+`req.remote_user` (anonymous by default) is available inside a plugin's
+`register_middlewares`. The API router keeps its own JWT middleware behind a
+guard so it is not executed twice.
+
+Backport of https://github.com/verdaccio/verdaccio/pull/5697
+
+Closes #5167

--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -42,7 +42,15 @@ export default function (config: Config, auth: Auth, storage: Storage) {
   app.param('_rev', match(/^-rev$/));
   app.param('org_couchdb_user', match(/^org\.couchdb\.user:/));
 
-  app.use(auth.apiJWTmiddleware());
+  // Avoid executing JWT twice when the parent app already registered the JWT middleware
+  const apiJwtMiddleware = auth.apiJWTmiddleware();
+  app.use((req, res, next) => {
+    const remoteUser = (req as any).remote_user ?? (res.locals as any).remote_user;
+    if (remoteUser) {
+      return next();
+    }
+    return apiJwtMiddleware(req, res, next);
+  });
   app.use(enforceGeneratedTokenMetadata(storage, logger));
   app.use(express.json({ strict: false, limit: config.max_body_size || '10mb' }));
   app.use(antiLoop(config));

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -79,6 +79,9 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<ex
     PLUGIN_CATEGORY.MIDDLEWARE
   );
 
+  // Register JWT middleware so middleware plugins can access req.remote_user
+  app.use(auth.apiJWTmiddleware());
+
   plugins.forEach((plugin: any) => {
     plugin.register_middlewares(app, auth, storage);
   });

--- a/test/unit/__helper/default-setup.ts
+++ b/test/unit/__helper/default-setup.ts
@@ -1,5 +1,6 @@
 import { ConfigBuilder } from '@verdaccio/config';
 import type { AuthConf, LoggerConfigItem, PackageAccessYaml } from '@verdaccio/types';
+import { ROLES } from '@verdaccio/utils';
 
 const builder = new ConfigBuilder();
 
@@ -36,7 +37,7 @@ builder.addLogger(logger);
 
 // Add package access
 const publicAccess: PackageAccessYaml = {
-  access: '$all',
+  access: ROLES.$ALL,
   publish: 'none',
 };
 

--- a/test/unit/modules/auth/middleware-plugin-order.spec.ts
+++ b/test/unit/modules/auth/middleware-plugin-order.spec.ts
@@ -1,0 +1,67 @@
+import path from 'node:path';
+import request from 'supertest';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER, fileUtils } from '@verdaccio/core';
+import { ROLES, buildToken } from '@verdaccio/utils';
+
+import endPointAPI from '../../../../src/api';
+import { setup } from '../../../../src/lib/logger';
+import { getNewToken } from '../../__helper/api';
+import configDefault from '../../partials/config';
+
+setup({});
+
+// configPath (== self_path) must point at the yaml so that `plugins: ./plugins`
+// resolves to the sibling plugins folder that holds verdaccio-remote-user-probe.js
+const configFile = path.join(
+  __dirname,
+  '../../partials/config/yaml/middleware-plugin/middleware-plugin.yaml'
+);
+
+const credentials = { name: 'mwUser', password: 'secretPass' };
+
+describe('middleware plugins jwt order', () => {
+  vi.setConfig({ testTimeout: 20000 });
+  let app;
+
+  beforeAll(async function () {
+    const store = await fileUtils.createTempStorageFolder('middleware-plugin-storage');
+    const config = configDefault(
+      {
+        storage: store,
+        self_path: configFile,
+        // keep the htpasswd file inside the (unique) temp store, not the repo tree
+        auth: { htpasswd: { file: path.join(store, 'htpasswd') } },
+      },
+      'middleware-plugin/middleware-plugin.yaml'
+    );
+    app = await endPointAPI(config);
+  });
+
+  test('should expose anonymous remote_user to middleware plugins', async () => {
+    const response = await request(app)
+      .get('/-/remote-user-probe')
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.OK);
+    expect(response.body.hasRemoteUser).toBe(true);
+    // anonymous request: no username but the default anonymous groups are present
+    expect(response.body.name).toBeNull();
+    expect(response.body.groups).toContain(ROLES.$ALL);
+    expect(response.body.groups).toContain(ROLES.$ANONYMOUS);
+  });
+
+  test('should expose the authenticated remote_user to middleware plugins', async () => {
+    const token = await getNewToken(request(app), credentials);
+    const response = await request(app)
+      .get('/-/remote-user-probe')
+      .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.OK);
+    expect(response.body.hasRemoteUser).toBe(true);
+    // authenticated request: the plugin sees the resolved username and its groups
+    expect(response.body.name).toBe(credentials.name);
+    expect(response.body.groups).toContain(credentials.name);
+    expect(response.body.groups).toContain(ROLES.$AUTH);
+  });
+});

--- a/test/unit/partials/config/config_access.ts
+++ b/test/unit/partials/config/config_access.ts
@@ -1,5 +1,7 @@
 import path from 'path';
 
+import { ROLES } from '@verdaccio/utils';
+
 const config = {
   storage: path.join(__dirname, '../store/access-storage'),
   uplinks: {
@@ -9,12 +11,12 @@ const config = {
   },
   packages: {
     jquery: {
-      allow_access: '$all',
-      allow_publish: '$all',
+      allow_access: ROLES.$ALL,
+      allow_publish: ROLES.$ALL,
     },
     '**': {
-      allow_access: '$all',
-      allow_publish: '$all',
+      allow_access: ROLES.$ALL,
+      allow_publish: ROLES.$ALL,
       proxy: 'npmjs',
     },
   },

--- a/test/unit/partials/config/yaml/middleware-plugin/middleware-plugin.yaml
+++ b/test/unit/partials/config/yaml/middleware-plugin/middleware-plugin.yaml
@@ -1,0 +1,31 @@
+# storage and self_path are injected by the spec
+
+auth:
+  htpasswd:
+    file: ./htpasswd-middleware-plugin
+
+web:
+  enable: false
+
+# load the test-only middleware plugin from this folder
+plugins: ./plugins
+
+middlewares:
+  remote-user-probe:
+    enabled: true
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@*/*':
+    access: $all
+    publish: $all
+    unpublish: none
+  '**':
+    access: $all
+    publish: $all
+    unpublish: none
+
+_debug: true

--- a/test/unit/partials/config/yaml/middleware-plugin/plugins/verdaccio-remote-user-probe.js
+++ b/test/unit/partials/config/yaml/middleware-plugin/plugins/verdaccio-remote-user-probe.js
@@ -1,0 +1,19 @@
+/**
+ * Test-only middleware plugin used to assert that middleware plugins can read
+ * `req.remote_user`, which is only true when the JWT middleware runs *before*
+ * the middleware plugins are registered (see PR #5697 / issue #5167).
+ */
+module.exports = function () {
+  return {
+    register_middlewares(app) {
+      app.get('/-/remote-user-probe', (req, res) => {
+        const remoteUser = req.remote_user;
+        res.status(200).json({
+          hasRemoteUser: Boolean(remoteUser),
+          name: remoteUser ? (remoteUser.name ?? null) : null,
+          groups: remoteUser ? (remoteUser.groups ?? null) : null,
+        });
+      });
+    },
+  };
+};


### PR DESCRIPTION
Register the JWT middleware before middleware plugins are loaded so that req.remote_user (anonymous by default) is available inside a plugin's register_middlewares. The API router keeps its own JWT middleware behind a guard so it is not executed twice.

Backport of https://github.com/verdaccio/verdaccio/pull/5697

Closes #5167