### PR TITLE
chore: return 403 error when uplink does on tarball path

### DIFF
--- a/.changeset/fix-uplink-403-tarball.md
+++ b/.changeset/fix-uplink-403-tarball.md
@@ -1,0 +1,7 @@
+---
+"verdaccio": patch
+---
+
+fix: return 403 to client when uplink responds with 403 for tarball requests
+
+Previously, any non-200/404 response from an uplink (e.g. a security proxy blocking a package download) would result in a generic 500 error being returned to the client. This change propagates 403 responses from the uplink through to the client, including any error detail from the response body, so callers can distinguish authorization failures from other upstream errors.

--- a/src/lib/up-storage.ts
+++ b/src/lib/up-storage.ts
@@ -484,6 +484,26 @@ class ProxyStorage {
       if (res.statusCode === HTTP_STATUS.NOT_FOUND) {
         return stream.emit('error', ErrorCode.getNotFound(API_ERROR.NOT_FILE_UPLINK));
       }
+      if (res.statusCode === HTTP_STATUS.FORBIDDEN) {
+        const chunks: Buffer[] = [];
+        readStream.on('data', (chunk: Buffer) => chunks.push(chunk));
+        readStream.once('end', () => {
+          let body: any;
+          const raw = Buffer.concat(chunks);
+          if (raw.length > 0) {
+            try {
+              body = JSON.parse(raw.toString('utf8'));
+            } catch {}
+          }
+          const message =
+            body?.detail ||
+            body?.title ||
+            body?.message ||
+            'tarball not available: forbidden by uplink';
+          stream.emit('error', ErrorCode.getForbidden(message));
+        });
+        return;
+      }
       if (!(res.statusCode >= HTTP_STATUS.OK && res.statusCode < HTTP_STATUS.MULTIPLE_CHOICES)) {
         return stream.emit(
           'error',

--- a/test/unit/modules/uplinks/up-storage.spec.ts
+++ b/test/unit/modules/uplinks/up-storage.spec.ts
@@ -355,6 +355,38 @@ describe('UpStorage', () => {
       });
     });
 
+    test('should throw a 403 on fetch a tarball from uplink', () => {
+      nock(UPLINK_URL).get('/jquery/-/forbidden-1.0.0.tgz').reply(403);
+      const proxy = generateProxy();
+      const tarball = `${UPLINK_URL}/jquery/-/forbidden-1.0.0.tgz`;
+      const stream = proxy.fetchTarball(tarball);
+      return new Promise((done) => {
+        stream.on('error', function (err: any) {
+          expect(err).not.toBeNull();
+          expect(err.statusCode).toBe(HTTP_STATUS.FORBIDDEN);
+          expect(err.message).toMatch('tarball not available: forbidden by uplink');
+          done(true);
+        });
+      });
+    });
+
+    test('should throw a 403 with uplink error detail on fetch a tarball from uplink', () => {
+      nock(UPLINK_URL)
+        .get('/jquery/-/forbidden-1.0.0.tgz')
+        .reply(403, { detail: 'package blocked by security policy' });
+      const proxy = generateProxy();
+      const tarball = `${UPLINK_URL}/jquery/-/forbidden-1.0.0.tgz`;
+      const stream = proxy.fetchTarball(tarball);
+      return new Promise((done) => {
+        stream.on('error', function (err: any) {
+          expect(err).not.toBeNull();
+          expect(err.statusCode).toBe(HTTP_STATUS.FORBIDDEN);
+          expect(err.message).toMatch('package blocked by security policy');
+          done(true);
+        });
+      });
+    });
+
     test('should be offline uplink', () => {
       // Use nock to simulate a connection error for the offline uplink
       const offlineUrl = 'http://offline.verdaccio.test';


### PR DESCRIPTION
https://github.com/orgs/verdaccio/discussions/5977

I am using a security tool as a proxy between Verdaccio and npmjs. It blocks downloads of packages based of a set of criteria, returning a 403 error with problem+json content-type-payload so the user know why they could not fetch the package. Verdaccio however returns a 500 error to the client for any non-200 or 404 responses from an uplink.

I think it would make sense to propagate the 403 back to the client for this case. Usage of security tools like this are becoming increasingly common with the recent spate of supply chain attacks.