### PR TITLE
fix: rate limit and bound the npm search v1 endpoint

### DIFF
--- a/.changeset/search-rate-limit-bound-scan.md
+++ b/.changeset/search-rate-limit-bound-scan.md
@@ -1,0 +1,9 @@
+---
+"verdaccio": patch
+---
+
+fix: rate limit and bound the npm search v1 endpoint
+
+The `/-/v1/search` endpoint now applies the `userRateLimit` rate limiting middleware (matching the login, token and profile endpoints), clamps the `size` (max 250, like the public npm registry) and `from` (max 10000) pagination parameters, and stops evaluating package access as soon as the requested page is filled instead of running an auth check over the entire result set. The clamped values are also what gets forwarded to uplink registries (the raw request URL is no longer passed through), so the bounds hold end-to-end. This prevents cheap anonymous requests from triggering unbounded full-catalog scans. As part of this, pagination is fixed: results were sliced with `slice(from, size)` instead of `slice(from, from + size)`, so pages beyond the first were wrong.
+
+Search results for local packages also emit npm-search-compatible maintainers (`{ username, email }`) — npm 11 on Node 24 crashes rendering entries without `username` (`The "str" argument must be of type string. Received undefined`) — and the `publisher` field is now populated from `_npmUser` when the publishing client provided it, falling back to the first maintainer, so the npm CLI shows the publishing user instead of `by ???`.

--- a/src/api/endpoint/api/v1/search.ts
+++ b/src/api/endpoint/api/v1/search.ts
@@ -1,11 +1,29 @@
 import _ from 'lodash';
 import semver from 'semver';
 
-import { SEARCH_API_ENDPOINTS } from '@verdaccio/middleware';
-import type { Manifest } from '@verdaccio/types';
+import { SEARCH_API_ENDPOINTS, rateLimit } from '@verdaccio/middleware';
+import type { Config, Manifest } from '@verdaccio/types';
 
 import { HTTP_STATUS } from '../../../../lib/constants';
 import { logger } from '../../../../lib/logger';
+
+const DEFAULT_SIZE = 20;
+// the public npm registry caps page size at 250 as well
+const MAX_SIZE = 250;
+// upper bound for the pagination offset so a single request cannot force
+// an access check on an arbitrarily large slice of the catalog
+const MAX_FROM = 10_000;
+// access checks run in batches so the scan can stop early once the
+// requested page is filled
+const CHECK_ACCESS_BATCH_SIZE = 50;
+
+function parseQueryInt(value: unknown, defaultValue: number, max: number): number {
+  const parsed = Number.parseInt(String(value), 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return defaultValue;
+  }
+  return Math.min(parsed, max);
+}
 
 type PublisherMaintainer = {
   username: string;
@@ -159,13 +177,30 @@ async function sendResponse(
       return pkg;
     }
   });
-  const checkAccessPromises: SearchResult[] = await Promise.all(
-    removeDuplicates(resultsCollection).map((pkgItem) => {
-      return checkAccess(pkgItem, auth, req.remote_user);
-    })
-  );
+  const uniqueResults = removeDuplicates(resultsCollection);
 
-  const final: SearchResult[] = checkAccessPromises.filter((i) => !_.isNull(i)).slice(from, size);
+  // evaluate access in batches and stop as soon as the requested page
+  // is filled, instead of running an auth check on every result
+  const requested = from + size;
+  const allowed: SearchResult[] = [];
+  for (
+    let i = 0;
+    i < uniqueResults.length && allowed.length < requested;
+    i += CHECK_ACCESS_BATCH_SIZE
+  ) {
+    const batch = await Promise.all(
+      uniqueResults
+        .slice(i, i + CHECK_ACCESS_BATCH_SIZE)
+        .map((pkgItem) => checkAccess(pkgItem, auth, req.remote_user))
+    );
+    for (const item of batch) {
+      if (!_.isNull(item)) {
+        allowed.push(item as SearchResult);
+      }
+    }
+  }
+
+  const final: SearchResult[] = allowed.slice(from, requested);
   logger.debug(`search results ${final?.length}`);
 
   const response: SearchResults = {
@@ -182,66 +217,75 @@ async function sendResponse(
  * Endpoint for npm search v1
  * req: 'GET /-/v1/search?text=react&size=20&from=0&quality=0.65&popularity=0.98&maintenance=0.5'
  */
-export default function (route, auth, storage): void {
-  route.get(SEARCH_API_ENDPOINTS.search, async (req, res, next) => {
-    // TODO: implement proper result scoring weighted by quality, popularity and maintenance query parameters
-    let [text, size, from /* , quality, popularity, maintenance */] = [
-      'text',
-      'size',
-      'from' /* , 'quality', 'popularity', 'maintenance' */,
-    ].map((k) => req.query[k]);
+export default function (route, auth, storage, config: Config): void {
+  route.get(
+    SEARCH_API_ENDPOINTS.search,
+    rateLimit(config?.userRateLimit),
+    async (req, res, next) => {
+      // TODO: implement proper result scoring weighted by quality, popularity and maintenance query parameters
+      const text = req.query.text as string;
 
-    size = parseInt(size) || 20;
-    from = parseInt(from) || 0;
+      // `size` and `from` are attacker-controlled: clamp them so a single
+      // request cannot demand unbounded work
+      const size = parseQueryInt(req.query.size, DEFAULT_SIZE, MAX_SIZE);
+      const from = parseQueryInt(req.query.from, 0, MAX_FROM);
 
-    const isInteresting = compileTextSearch(text);
+      // rebuild the relative url from the clamped values so the bounds hold
+      // end-to-end: the uplink proxy forwards it verbatim to the remote registry
+      const searchParams = new URLSearchParams(req.query as Record<string, string>);
+      searchParams.set('size', String(size));
+      searchParams.set('from', String(from));
+      const safeUrl = `${req.url.split('?')[0]}?${searchParams.toString()}`;
 
-    const resultStream = storage.search(0, { req });
-    let resultBuf = [] as any;
-    let completed = false;
+      const isInteresting = compileTextSearch(text);
 
-    resultStream.on('data', (pkg: SearchResult[] | PackageResults) => {
-      // packages from the upstreams
-      if (_.isArray(pkg)) {
-        resultBuf = resultBuf.concat(
-          (pkg as SearchResult[]).filter((pkgItem) => {
-            if (!isInteresting(pkgItem?.package)) {
-              return;
-            }
-            logger.debug(`[remote] pkg name ${pkgItem?.package?.name}`);
-            return true;
-          })
-        );
-      } else {
-        // packages from local
-        // due compability with `/-/all` we cannot refactor storage.search();
-        if (!isInteresting(pkg)) {
-          return;
+      const resultStream = storage.search(0, { req, url: safeUrl });
+      let resultBuf = [] as any;
+      let completed = false;
+
+      resultStream.on('data', (pkg: SearchResult[] | PackageResults) => {
+        // packages from the upstreams
+        if (_.isArray(pkg)) {
+          resultBuf = resultBuf.concat(
+            (pkg as SearchResult[]).filter((pkgItem) => {
+              if (!isInteresting(pkgItem?.package)) {
+                return;
+              }
+              logger.debug(`[remote] pkg name ${pkgItem?.package?.name}`);
+              return true;
+            })
+          );
+        } else {
+          // packages from local
+          // due compability with `/-/all` we cannot refactor storage.search();
+          if (!isInteresting(pkg)) {
+            return;
+          }
+          logger.debug(`[local] pkg name ${(pkg as PackageResults)?.name}`);
+          resultBuf.push(pkg);
         }
-        logger.debug(`[local] pkg name ${(pkg as PackageResults)?.name}`);
-        resultBuf.push(pkg);
-      }
-    });
+      });
 
-    resultStream.on('error', function () {
-      logger.error('search endpoint has failed');
-      res.socket.destroy();
-    });
+      resultStream.on('error', function () {
+        logger.error('search endpoint has failed');
+        res.socket.destroy();
+      });
 
-    resultStream.on('end', async () => {
-      if (!completed) {
-        completed = true;
-        try {
-          const response = await sendResponse(resultBuf, resultStream, auth, req, from, size);
-          // @ts-expect-error
-          logger.info('search endpoint ok results @{total}', { total: response.total });
-          res.status(HTTP_STATUS.OK).json(response);
-        } catch (err) {
-          // @ts-expect-error
-          logger.error('search endpoint has failed @{err}', { err });
-          next(err);
+      resultStream.on('end', async () => {
+        if (!completed) {
+          completed = true;
+          try {
+            const response = await sendResponse(resultBuf, resultStream, auth, req, from, size);
+            // @ts-expect-error
+            logger.info('search endpoint ok results @{total}', { total: response.total });
+            res.status(HTTP_STATUS.OK).json(response);
+          } catch (err) {
+            // @ts-expect-error
+            logger.error('search endpoint has failed @{err}', { err });
+            next(err);
+          }
         }
-      }
-    });
-  });
+      });
+    }
+  );
 }

--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -64,7 +64,7 @@ export default function (config: Config, auth: Auth, storage: Storage) {
   publish(app, auth, storage, config);
   ping(app);
   stars(app, storage);
-  v1Search(app, auth, storage);
+  v1Search(app, auth, storage, config);
   token(app, auth, storage, config);
   pkg(app, auth, storage, config);
   return app;

--- a/src/lib/storage-utils.ts
+++ b/src/lib/storage-utils.ts
@@ -212,11 +212,33 @@ export function prepareSearchPackage(data: Manifest, time: unknown): any {
   if (latest && data.versions[latest]) {
     const version: Version = data.versions[latest];
     const versions: any = { [latest]: 'latest' };
+    // packument maintainers carry `name`, but the npm search API contract uses
+    // `username` and the npm CLI crashes on entries without it — emit both
+    const rawMaintainers = version.maintainers || [version.author].filter(Boolean);
+    const maintainers = Array.isArray(rawMaintainers)
+      ? rawMaintainers.map((maintainer: any) =>
+          typeof maintainer === 'string'
+            ? { username: maintainer, email: '' }
+            : {
+                ...maintainer,
+                username: maintainer?.username ?? maintainer?.name ?? '',
+                email: maintainer?.email ?? '',
+              }
+        )
+      : [];
+    // npmjs fills `publisher` with the user who published the version; use
+    // `_npmUser` when the publishing client provided it and fall back to the
+    // first maintainer, otherwise the npm CLI renders "published by ???"
+    const npmUser = (version as any)._npmUser;
+    const publisher = npmUser?.name
+      ? { username: npmUser.name, email: npmUser.email ?? '' }
+      : (maintainers[0] ?? {});
     const pkg: any = {
       name: version.name,
       description: version.description,
       [DIST_TAGS]: { latest },
-      maintainers: version.maintainers || [version.author].filter(Boolean),
+      maintainers,
+      publisher,
       author: version.author,
       repository: version.repository,
       readmeFilename: version.readmeFilename || '',

--- a/src/lib/up-storage.ts
+++ b/src/lib/up-storage.ts
@@ -523,7 +523,9 @@ class ProxyStorage {
   public search(options: any) {
     const transformStream: any = new Stream.PassThrough({ objectMode: true });
     const requestStream: Stream.Readable = this.request({
-      uri: options.req.url,
+      // prefer the sanitized url (clamped pagination) built by the search
+      // endpoint over the raw request url
+      uri: options.url || options.req.url,
       req: options.req,
       headers: {
         // query for search

--- a/test/unit/modules/api/config/search-rate-limit.yaml
+++ b/test/unit/modules/api/config/search-rate-limit.yaml
@@ -1,0 +1,21 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd-search-rate-limit
+
+## low limit so the third request in the test is rejected
+userRateLimit:
+  windowMs: 60000
+  max: 2
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: fatal }
+
+packages:
+  '**':
+    access: $all
+    publish: $authenticated
+
+_debug: true

--- a/test/unit/modules/api/config/search-uplink.yaml
+++ b/test/unit/modules/api/config/search-uplink.yaml
@@ -1,0 +1,19 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd-search-uplink
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+log: { type: stdout, format: pretty, level: fatal }
+
+packages:
+  '**':
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
+
+_debug: true

--- a/test/unit/modules/api/search.spec.ts
+++ b/test/unit/modules/api/search.spec.ts
@@ -1,5 +1,6 @@
+import nock from 'nock';
 import supertest from 'supertest';
-import { beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { HEADERS, HEADER_TYPE, HTTP_STATUS } from '@verdaccio/core';
 
@@ -39,8 +40,13 @@ describe('search', () => {
             {
               name: 'User NPM',
               email: 'user@domain.com',
+              username: 'User NPM',
             },
           ],
+          publisher: {
+            username: 'foo',
+            email: '',
+          },
           author: {
             name: 'User NPM',
             email: 'user@domain.com',
@@ -101,8 +107,13 @@ describe('search', () => {
             {
               name: 'User NPM',
               email: 'user@domain.com',
+              username: 'User NPM',
             },
           ],
+          publisher: {
+            username: 'foo',
+            email: '',
+          },
           author: {
             name: 'User NPM',
             email: 'user@domain.com',
@@ -135,6 +146,85 @@ describe('search', () => {
       );
     });
   });
+  describe('pagination', () => {
+    test('should honor the size and from parameters', async () => {
+      const res = await createUser(app, 'test', 'test');
+      await publishVersionWithToken(app, 'foo-a', '1.0.0', res.body.token);
+      await publishVersionWithToken(app, 'foo-b', '1.0.0', res.body.token);
+      await publishVersionWithToken(app, 'foo-c', '1.0.0', res.body.token);
+
+      const firstPage = await supertest(app)
+        .get('/-/v1/search?text=foo&size=2&from=0')
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .expect(HEADERS.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+        .expect(HTTP_STATUS.OK);
+      expect(firstPage.body.objects).toHaveLength(2);
+
+      const secondPage = await supertest(app)
+        .get('/-/v1/search?text=foo&size=2&from=2')
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .expect(HEADERS.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+        .expect(HTTP_STATUS.OK);
+      expect(secondPage.body.objects).toHaveLength(1);
+
+      const names = [...firstPage.body.objects, ...secondPage.body.objects].map(
+        (item) => item.package.name
+      );
+      expect(names.sort()).toEqual(['foo-a', 'foo-b', 'foo-c']);
+    });
+
+    test('should fall back to defaults on invalid size and from values', async () => {
+      const res = await createUser(app, 'test', 'test');
+      await publishVersionWithToken(app, 'foo-a', '1.0.0', res.body.token);
+
+      const response = await supertest(app)
+        .get('/-/v1/search?text=foo&size=-1&from=invalid')
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .expect(HEADERS.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+        .expect(HTTP_STATUS.OK);
+      expect(response.body.objects).toHaveLength(1);
+    });
+  });
+
+  describe('rate limiting', () => {
+    test('should reject requests above the configured user rate limit', async () => {
+      const app = await initializeServer('search-rate-limit.yaml');
+      const searchUrl = '/-/v1/search?text=foo&size=20&from=0';
+
+      await supertest(app).get(searchUrl).set(HEADERS.ACCEPT, HEADERS.JSON).expect(HTTP_STATUS.OK);
+      await supertest(app).get(searchUrl).set(HEADERS.ACCEPT, HEADERS.JSON).expect(HTTP_STATUS.OK);
+      // third request exceeds `userRateLimit.max: 2` in search-rate-limit.yaml
+      await supertest(app).get(searchUrl).set(HEADERS.ACCEPT, HEADERS.JSON).expect(429);
+    });
+  });
+
+  describe('uplink forwarding', () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    test('should forward the clamped size and from values to the uplink', async () => {
+      let forwardedPath;
+      nock('https://registry.npmjs.org')
+        .get(/\/-\/v1\/search/)
+        .reply(200, function () {
+          forwardedPath = this.req.path;
+          return { objects: [], total: 0, time: '' };
+        });
+
+      const app = await initializeServer('search-uplink.yaml');
+      await supertest(app)
+        .get('/-/v1/search?text=clamp-check&size=99999&from=99999')
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .expect(HTTP_STATUS.OK);
+
+      const forwardedQuery = new URL(forwardedPath, 'https://registry.npmjs.org').searchParams;
+      expect(forwardedQuery.get('text')).toBe('clamp-check');
+      expect(forwardedQuery.get('size')).toBe('250');
+      expect(forwardedQuery.get('from')).toBe('10000');
+    });
+  });
+
   describe('error handling', () => {
     test.todo('should able to abort the request');
   });

--- a/test/unit/modules/storage/storage-utils.spec.ts
+++ b/test/unit/modules/storage/storage-utils.spec.ts
@@ -4,8 +4,14 @@ import { describe, expect, test } from 'vitest';
 
 import type { Manifest } from '@verdaccio/types';
 
+import { generatePackageMetadata } from '@verdaccio/test-helper';
+
 import { DIST_TAGS, STORAGE } from '../../../../src/lib/constants';
-import { mergeUplinkTimeIntoLocal, normalizePackage } from '../../../../src/lib/storage-utils';
+import {
+  mergeUplinkTimeIntoLocal,
+  normalizePackage,
+  prepareSearchPackage,
+} from '../../../../src/lib/storage-utils';
 
 function readFile(filePath) {
   return fs.readFileSync(path.join(__dirname, `/${filePath}`));
@@ -132,6 +138,67 @@ describe('Storage Utils', () => {
       };
       const mergedPkg = mergeUplinkTimeIntoLocal(pkg1, pkg2);
       expect(Object.keys(mergedPkg.time)).toEqual(['modified', 'created', ...Object.keys(vGroup1)]);
+    });
+  });
+
+  describe('prepareSearchPackage', () => {
+    const time = '2018-01-14T11:17:40.712Z';
+
+    test('should map packument maintainers to the npm search username format', () => {
+      const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
+      manifest.versions['1.0.0'].maintainers = [
+        { name: 'jota', email: 'jota@verdaccio.org' },
+      ] as any;
+
+      const pkg = prepareSearchPackage(manifest, time);
+      // the npm CLI reads `maintainers[].username` and crashes when missing
+      expect(pkg.maintainers).toEqual([
+        { name: 'jota', email: 'jota@verdaccio.org', username: 'jota' },
+      ]);
+      // generatePackageMetadata includes _npmUser: { name: 'foo' }
+      expect(pkg.publisher).toEqual({ username: 'foo', email: '' });
+    });
+
+    test('should fall back to the first maintainer as publisher without _npmUser', () => {
+      const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
+      delete (manifest.versions['1.0.0'] as any)._npmUser;
+      manifest.versions['1.0.0'].maintainers = [
+        { name: 'jota', email: 'jota@verdaccio.org' },
+      ] as any;
+
+      const pkg = prepareSearchPackage(manifest, time);
+      expect(pkg.publisher).toEqual({
+        name: 'jota',
+        email: 'jota@verdaccio.org',
+        username: 'jota',
+      });
+    });
+
+    test('should fall back to the version author when maintainers are missing', () => {
+      const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
+      delete (manifest.versions['1.0.0'] as any)._npmUser;
+      delete manifest.versions['1.0.0'].maintainers;
+
+      const pkg = prepareSearchPackage(manifest, time);
+      expect(pkg.maintainers).toEqual([
+        { name: 'User NPM', email: 'user@domain.com', username: 'User NPM' },
+      ]);
+      expect(pkg.publisher).toEqual({
+        name: 'User NPM',
+        email: 'user@domain.com',
+        username: 'User NPM',
+      });
+    });
+
+    test('should map missing maintainers and author to an empty list', () => {
+      const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
+      delete (manifest.versions['1.0.0'] as any)._npmUser;
+      delete manifest.versions['1.0.0'].maintainers;
+      delete (manifest.versions['1.0.0'] as any).author;
+
+      const pkg = prepareSearchPackage(manifest, time);
+      expect(pkg.maintainers).toEqual([]);
+      expect(pkg.publisher).toEqual({});
     });
   });
 });


### PR DESCRIPTION
Port of verdaccio/verdaccio@51d49f0 (master) to 6.x.

The /-/v1/search route had no rate limiting and fetched the entire result set, running a per-package auth check over every item before slicing to a page — a cheap amplification vector for anonymous requests.

- apply rateLimit(config.userRateLimit) like login/token/profile
- clamp size (max 250, npm registry parity) and from (max 10000), and forward the clamped values to uplink registries instead of the raw request url
- evaluate package access in batches and stop once the requested page is filled instead of scanning the full catalog
- fix pagination: results were sliced with slice(from, size) instead of slice(from, from + size)
- emit npm-search-compatible maintainers ({ username, email }) and populate publisher from _npmUser (falling back to the first maintainer), so npm 11 on Node 24 no longer crashes rendering search results