### PR TITLE
feat: add publish/unpublish hook

### DIFF
--- a/.changeset/unpublish-notify-hooks.md
+++ b/.changeset/unpublish-notify-hooks.md
@@ -1,0 +1,7 @@
+---
+"verdaccio": minor
+---
+
+feat: add unpublish notification hooks
+
+Port of [#5920](https://github.com/verdaccio/verdaccio/pull/5920) (ref [#5328](https://github.com/verdaccio/verdaccio/issues/5328)). The `notify` webhook now also fires when a package is unpublished entirely and when a single version (tarball) is removed, not only on publish. Notification templates can distinguish the event through the new `{{ publishType }}` (`publish` | `unpublish`) and `{{ publishedPackage }}` variables, and the `{{ publisher }}` object exposes only `name`, `groups` and `real_groups`, so the remote user auth token can never leak to the notification endpoint (via `@verdaccio/hooks` 8.0.4).

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@verdaccio/auth": "8.0.4",
     "@verdaccio/config": "8.1.2",
     "@verdaccio/core": "8.1.2",
-    "@verdaccio/hooks": "8.0.3",
+    "@verdaccio/hooks": "8.0.4",
     "@verdaccio/loaders": "8.0.3",
     "@verdaccio/local-storage-legacy": "11.3.4",
     "@verdaccio/logger": "8.0.3",

--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -5,10 +5,10 @@ import mime from 'mime';
 import Path from 'path';
 
 import type { Auth } from '@verdaccio/auth';
-import { validationUtils } from '@verdaccio/core';
+import { tarballUtils, validationUtils } from '@verdaccio/core';
 import { notify } from '@verdaccio/hooks';
 import { allow, expectJson, media } from '@verdaccio/middleware';
-import type { Callback, Config, MergeTags, Package, Version } from '@verdaccio/types';
+import type { Callback, Config, Manifest, MergeTags, Package, Version } from '@verdaccio/types';
 
 import { API_ERROR, API_MESSAGE, DIST_TAGS, HEADERS, HTTP_STATUS } from '../../../lib/constants';
 import { logger } from '../../../lib/logger';
@@ -106,14 +106,14 @@ export default function publish(
    * npm http fetch GET 304 http://localhost:4873/@scope%2ftest1?write=true 1076ms (from cache)
      npm http fetch DELETE 201 http://localhost:4873/@scope%2ftest1/-rev/18-d8ebe3020bd4ac9c 22ms
    */
-  router.delete('/:package/-rev/*', can('unpublish'), unPublishPackage(storage));
+  router.delete('/:package/-rev/*', can('unpublish'), unPublishPackage(storage, config));
 
   // removing a tarball
   router.delete(
     '/:package/-/:filename/-rev/:revision',
     can('unpublish'),
     can('publish'),
-    removeTarball(storage)
+    removeTarball(storage, config)
   );
 
   // uploading package tarball
@@ -248,7 +248,8 @@ export function publishPackage(storage: Storage, config: Config, auth: Auth): an
                   metadataCopy,
                   config,
                   req.remote_user,
-                  `${metadataCopy.name}@${versionToPublish}`
+                  `${metadataCopy.name}@${versionToPublish}`,
+                  'publish'
                 );
               } catch (error) {
                 logger.error({ error }, 'notify batch service has failed: @{error}');
@@ -302,7 +303,7 @@ export function publishPackage(storage: Storage, config: Config, auth: Auth): an
 /**
  * un-publish a package
  */
-export function unPublishPackage(storage: Storage) {
+export function unPublishPackage(storage: Storage, config: Config) {
   return function (req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer): void {
     const packageName = req.params.package;
     debug('unpublishing %o', packageName);
@@ -311,6 +312,13 @@ export function unPublishPackage(storage: Storage) {
         return next(err);
       }
       res.status(HTTP_STATUS.CREATED);
+
+      // send notification of package removal (non transactional)
+      const metadata = { name: packageName } as Manifest;
+      notify(metadata, config, req.remote_user, packageName, 'unpublish').catch((error) => {
+        logger.error({ error: error?.message }, 'notify batch service has failed: @{error}');
+      });
+
       return next({ ok: API_MESSAGE.PKG_REMOVED });
     });
   };
@@ -319,7 +327,7 @@ export function unPublishPackage(storage: Storage) {
 /**
  * Delete tarball
  */
-export function removeTarball(storage: Storage) {
+export function removeTarball(storage: Storage, config: Config) {
   return function (req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer): void {
     const packageName = req.params.package;
     const { filename, revision } = req.params;
@@ -330,6 +338,18 @@ export function removeTarball(storage: Storage) {
       }
       res.status(HTTP_STATUS.CREATED);
       debug('success remove tarball for %o-%o-%o', packageName, filename, revision);
+
+      // send notification of version removal (non transactional)
+      // getVersionFromTarball returns undefined when the filename is not parseable;
+      // fall back to the package name so we never report `name@undefined`
+      const version = tarballUtils.getVersionFromTarball(filename);
+      const metadata = { name: packageName, version, _rev: revision } as unknown as Manifest;
+      const publishedPackage = version ? `${packageName}@${version}` : packageName;
+
+      notify(metadata, config, req.remote_user, publishedPackage, 'unpublish').catch((error) => {
+        logger.error({ error: error?.message }, 'notify batch service has failed: @{error}');
+      });
+
       return next({ ok: API_MESSAGE.TARBALL_REMOVED });
     });
   };

--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -316,7 +316,7 @@ export function unPublishPackage(storage: Storage, config: Config) {
       // send notification of package removal (non transactional)
       const metadata = { name: packageName } as Manifest;
       notify(metadata, config, req.remote_user, packageName, 'unpublish').catch((error) => {
-        logger.error({ error: error?.message }, 'notify batch service has failed: @{error}');
+        logger.error({ error }, 'notify batch service has failed: @{error}');
       });
 
       return next({ ok: API_MESSAGE.PKG_REMOVED });

--- a/src/api/endpoint/api/publish.ts
+++ b/src/api/endpoint/api/publish.ts
@@ -347,7 +347,7 @@ export function removeTarball(storage: Storage, config: Config) {
       const publishedPackage = version ? `${packageName}@${version}` : packageName;
 
       notify(metadata, config, req.remote_user, publishedPackage, 'unpublish').catch((error) => {
-        logger.error({ error: error?.message }, 'notify batch service has failed: @{error}');
+        logger.error({ error }, 'notify batch service has failed: @{error}');
       });
 
       return next({ ok: API_MESSAGE.TARBALL_REMOVED });

--- a/test/unit/modules/api/config/publish-notify.yaml
+++ b/test/unit/modules/api/config/publish-notify.yaml
@@ -1,0 +1,30 @@
+auth:
+  htpasswd:
+    file: ./htpasswd-publish-notify
+web:
+  enable: true
+  title: verdaccio
+
+publish:
+  allow_offline: false
+
+notify:
+  method: POST
+  headers: { 'Content-Type': 'application/json' }
+  endpoint: http://slack-service/foo?auth_token=mySecretToken
+  content: '{"color":"green","message":"New package published: * {{ name }}*","publishedPackage":"{{ publishedPackage }}","publishType":"{{ publishType }}","notify":true,"message_format":"text"}'
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@*/*':
+    access: $anonymous
+    publish: $anonymous
+    unpublish: $anonymous
+  '**':
+    access: $anonymous
+    publish: $anonymous
+    unpublish: $anonymous
+_debug: true

--- a/test/unit/modules/api/publish-notify.spec.ts
+++ b/test/unit/modules/api/publish-notify.spec.ts
@@ -28,8 +28,8 @@ describe('publish notifications', () => {
     }
   };
 
-  test.each([['notify-pkg', '@scope/notify-pkg']])(
-    'should trigger notification when publishing a package',
+  test.each(['notify-pkg', '@scope/notify-pkg'])(
+    'should trigger notification when publishing a package (%s)',
     async (pkgName) => {
       const notifyScope = nock(notifyDomain)
         .post(notifyPath, (body) => {
@@ -52,8 +52,8 @@ describe('publish notifications', () => {
     }
   );
 
-  test.each([['notify-unpublish-pkg', '@scope/notify-unpublish-pkg']])(
-    'should trigger notification when unpublishing a package entirely',
+  test.each(['notify-unpublish-pkg', '@scope/notify-unpublish-pkg'])(
+    'should trigger notification when unpublishing a package entirely (%s)',
     async (pkgName) => {
       const app = await initializeServer('publish-notify.yaml');
       await publishVersion(app, pkgName, '1.0.0').expect(HTTP_STATUS.CREATED);
@@ -83,8 +83,8 @@ describe('publish notifications', () => {
     }
   );
 
-  test.each([['notify-tarball-pkg', '@scope/notify-tarball-pkg']])(
-    'should trigger notification when removing a tarball',
+  test.each(['notify-tarball-pkg', '@scope/notify-tarball-pkg'])(
+    'should trigger notification when removing a tarball (%s)',
     async (pkgName) => {
       const app = await initializeServer('publish-notify.yaml');
       await publishVersion(app, pkgName, '1.0.0').expect(HTTP_STATUS.CREATED);

--- a/test/unit/modules/api/publish-notify.spec.ts
+++ b/test/unit/modules/api/publish-notify.spec.ts
@@ -1,0 +1,186 @@
+import nock from 'nock';
+import { basename } from 'path';
+import supertest from 'supertest';
+import { beforeEach, describe, expect, test } from 'vitest';
+
+import { HEADERS, HEADER_TYPE, HTTP_STATUS } from '@verdaccio/core';
+import { generatePackageMetadata } from '@verdaccio/test-helper';
+
+import { initializeServer, publishVersion } from './_helper';
+
+describe('publish notifications', () => {
+  const notifyDomain = 'http://slack-service';
+  const notifyPath = '/foo?auth_token=mySecretToken';
+
+  beforeEach(() => {
+    nock.cleanAll();
+    nock.abortPendingRequests();
+  });
+
+  // unpublish notifications are fired in a non-blocking way (the response
+  // does not wait for them), so the assertion cannot rely on the request
+  // having completed by the time the HTTP response resolves. Poll the nock
+  // scope until the interceptor has been consumed (or time out).
+  const waitForScopeDone = async (scope: nock.Scope, timeout = 3000): Promise<void> => {
+    const start = Date.now();
+    while (!scope.isDone() && Date.now() - start < timeout) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  };
+
+  test.each([['notify-pkg', '@scope/notify-pkg']])(
+    'should trigger notification when publishing a package',
+    async (pkgName) => {
+      const notifyScope = nock(notifyDomain)
+        .post(notifyPath, (body) => {
+          expect(body).toEqual({
+            color: 'green',
+            message: `New package published: * ${pkgName}*`,
+            publishedPackage: `${pkgName}@1.0.0`,
+            publishType: 'publish',
+            message_format: 'text',
+            notify: true,
+          });
+          return true;
+        })
+        .reply(200);
+
+      const app = await initializeServer('publish-notify.yaml');
+      await publishVersion(app, pkgName, '1.0.0').expect(HTTP_STATUS.CREATED);
+      await waitForScopeDone(notifyScope);
+      expect(notifyScope.isDone()).toBe(true);
+    }
+  );
+
+  test.each([['notify-unpublish-pkg', '@scope/notify-unpublish-pkg']])(
+    'should trigger notification when unpublishing a package entirely',
+    async (pkgName) => {
+      const app = await initializeServer('publish-notify.yaml');
+      await publishVersion(app, pkgName, '1.0.0').expect(HTTP_STATUS.CREATED);
+      nock.cleanAll();
+
+      const notifyScope = nock(notifyDomain)
+        .post(notifyPath, (body) => {
+          expect(body).toEqual({
+            color: 'green',
+            message: `New package published: * ${pkgName}*`,
+            publishedPackage: pkgName,
+            publishType: 'unpublish',
+            message_format: 'text',
+            notify: true,
+          });
+          return true;
+        })
+        .reply(200);
+
+      await supertest(app)
+        .delete(`/${encodeURIComponent(pkgName)}/-rev/xxx`)
+        .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+        .expect(HTTP_STATUS.CREATED);
+
+      await waitForScopeDone(notifyScope);
+      expect(notifyScope.isDone()).toBe(true);
+    }
+  );
+
+  test.each([['notify-tarball-pkg', '@scope/notify-tarball-pkg']])(
+    'should trigger notification when removing a tarball',
+    async (pkgName) => {
+      const app = await initializeServer('publish-notify.yaml');
+      await publishVersion(app, pkgName, '1.0.0').expect(HTTP_STATUS.CREATED);
+      nock.cleanAll();
+
+      const notifyScope = nock(notifyDomain)
+        .post(notifyPath, (body) => {
+          expect(body).toEqual({
+            color: 'green',
+            message: `New package published: * ${pkgName}*`,
+            publishedPackage: `${pkgName}@1.0.0`,
+            publishType: 'unpublish',
+            message_format: 'text',
+            notify: true,
+          });
+          return true;
+        })
+        .reply(200);
+
+      await supertest(app)
+        .delete(`/${pkgName}/-/${basename(pkgName)}-1.0.0.tgz/-rev/revision`)
+        .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+        .expect(HTTP_STATUS.CREATED);
+
+      await waitForScopeDone(notifyScope);
+      expect(notifyScope.isDone()).toBe(true);
+    }
+  );
+
+  test('should fall back to the package name when the tarball filename has no version', async () => {
+    const pkgName = 'notify-fallback-pkg';
+    const tarballName = 'no-version-here.tgz';
+    const app = await initializeServer('publish-notify.yaml');
+    const pkgMetadata = generatePackageMetadata(pkgName, '1.0.0');
+    const [origFilename] = Object.keys(pkgMetadata._attachments);
+    pkgMetadata._attachments = {
+      [tarballName]: pkgMetadata._attachments[origFilename],
+    };
+    await supertest(app)
+      .put(`/${encodeURIComponent(pkgName)}`)
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .send(JSON.stringify(pkgMetadata))
+      .set('accept', HEADERS.GZIP)
+      .expect(HTTP_STATUS.CREATED);
+    nock.cleanAll();
+
+    const notifyScope = nock(notifyDomain)
+      .post(notifyPath, (body) => {
+        // not `notify-fallback-pkg@undefined`
+        expect(body.publishedPackage).toEqual(pkgName);
+        expect(body.publishType).toEqual('unpublish');
+        return true;
+      })
+      .reply(200);
+
+    await supertest(app)
+      .delete(`/${pkgName}/-/${tarballName}/-rev/revision`)
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .expect(HTTP_STATUS.CREATED);
+
+    await waitForScopeDone(notifyScope);
+    expect(notifyScope.isDone()).toBe(true);
+  });
+
+  test('should unpublish successfully when the notification endpoint fails', async () => {
+    const pkgName = 'notify-failure-pkg';
+    const app = await initializeServer('publish-notify.yaml');
+    await publishVersion(app, pkgName, '1.0.0').expect(HTTP_STATUS.CREATED);
+    nock.cleanAll();
+
+    const notifyScope = nock(notifyDomain).post(notifyPath).replyWithError('connection refused');
+
+    await supertest(app)
+      .delete(`/${encodeURIComponent(pkgName)}/-rev/xxx`)
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .expect(HTTP_STATUS.CREATED);
+
+    await waitForScopeDone(notifyScope);
+    expect(notifyScope.isDone()).toBe(true);
+  });
+
+  test('should not trigger notification when the tarball removal fails', async () => {
+    const pkgName = 'notify-missing-tarball-pkg';
+    const app = await initializeServer('publish-notify.yaml');
+    await publishVersion(app, pkgName, '1.0.0').expect(HTTP_STATUS.CREATED);
+    nock.cleanAll();
+
+    const notifyScope = nock(notifyDomain).post(notifyPath).reply(200);
+
+    await supertest(app)
+      .delete(`/${pkgName}/-/${pkgName}-9.9.9.tgz/-rev/revision`)
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .expect(HTTP_STATUS.NOT_FOUND);
+
+    // give a (wrongly) fired notification time to arrive before asserting silence
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(notifyScope.isDone()).toBe(false);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2969,16 +2969,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@verdaccio/hooks@npm:8.0.3":
-  version: 8.0.3
-  resolution: "@verdaccio/hooks@npm:8.0.3"
+"@verdaccio/hooks@npm:8.0.4":
+  version: 8.0.4
+  resolution: "@verdaccio/hooks@npm:8.0.4"
   dependencies:
     "@verdaccio/core": "npm:8.1.2"
     "@verdaccio/logger": "npm:8.0.3"
     debug: "npm:4.4.3"
     got-cjs: "npm:12.5.4"
     handlebars: "npm:4.7.9"
-  checksum: 10c0/46e304041feaedb07dddb192c4759c96a04b9a468574004c6160dd2a6d1aa0fbc4860f1e297db0b9d8784b3d93281648ccc42bf24dbac6d130e85bbc63c2e18d
+  checksum: 10c0/81a5261d65e6baa76619ab488a0480769c5ae76a1d823ab66681b80f099a5853d2d2c71f111fbf4df16b6bc4b7facfc6b3bd048e6ca1fee51a0af16681746f62
   languageName: node
   linkType: hard
 
@@ -10112,7 +10112,7 @@ __metadata:
     "@verdaccio/core": "npm:8.1.2"
     "@verdaccio/e2e-cli": "npm:2.10.2"
     "@verdaccio/e2e-ui": "npm:2.4.1"
-    "@verdaccio/hooks": "npm:8.0.3"
+    "@verdaccio/hooks": "npm:8.0.4"
     "@verdaccio/loaders": "npm:8.0.3"
     "@verdaccio/local-storage-legacy": "npm:11.3.4"
     "@verdaccio/logger": "npm:8.0.3"


### PR DESCRIPTION
Port of #5920 by @mbtools (ref #5328) to the 6.x branch: the notify webhook now also fires when a package or a single version is unpublished, and notification templates can use the new `{{ publishType }}` and `{{ publishedPackage }}` variables. Also updates `@verdaccio/hooks` to 8.0.4, which improves consistency of the data shared with notification endpoints.