### PR TITLE
chore: add changeset for js-yaml 4.3.0 security release

### DIFF
--- a/.changeset/js-yaml-security-release.md
+++ b/.changeset/js-yaml-security-release.md
@@ -1,0 +1,13 @@
+---
+'@verdaccio/config': patch
+---
+
+fix: publish the js-yaml 4.3.0 security upgrade (GHSA-52cp-r559-cp3m)
+
+The js-yaml upgrades to 4.2.0 (#5969) and 4.3.0 (#6012) were merged without a
+changeset, so they were never released: the published `@verdaccio/config@8.1.2`
+still pins `js-yaml@4.1.1`, which is vulnerable to GHSA-52cp-r559-cp3m (YAML
+merge-key chains forcing quadratic CPU consumption, high severity). Because the
+pin is exact, downstream consumers such as the verdaccio 6.x server cannot heal
+it through their own installs. This changeset releases the already-merged
+upgrade.


### PR DESCRIPTION
## Why

The js-yaml upgrades to 4.2.0 (#5969) and 4.3.0 (#6012) were merged via renovate without a changeset, so `@verdaccio/config` was never republished: npm still ships `8.1.2` (published Jun 19) pinning `js-yaml@4.1.1`, which is vulnerable to [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) (YAML merge-key chains forcing quadratic CPU consumption, high severity).

Because the pin is exact, downstream consumers — notably the verdaccio 6.x server, where `yarn npm audit` currently fails on this — cannot heal it through their own installs; only a release fixes it for end users.

## What

Adds a patch changeset for `@verdaccio/config` so the next release publishes the already-merged js-yaml 4.3.0. Via the `fixed` group, `@verdaccio/core` bumps alongside it. Once published, verdaccio 6.x can drop its temporary `"@verdaccio/config/js-yaml"` resolution and take a plain dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)