### PR TITLE
fix(deps): resolve high-severity audit findings (brace-expansion, fas…

### DIFF
--- a/.changeset/minimatch-brace-expansion-security.md
+++ b/.changeset/minimatch-brace-expansion-security.md
@@ -1,0 +1,16 @@
+---
+'@verdaccio/core': patch
+'@verdaccio/utils': patch
+---
+
+fix: upgrade minimatch to 10.2.5 to resolve brace-expansion DoS advisories
+
+minimatch 7.4.9 depends on brace-expansion ^2.0.2, a range that has no patch
+for GHSA-mh99-v99m-4gvg (unbounded expansion length causing an out-of-memory
+crash, high severity) and resolved to a version also affected by
+GHSA-3jxr-9vmj-r5cp (exponential-time expansion of consecutive non-expanding
+`{}` groups, high severity). Only brace-expansion >=5.0.8 fixes both, so
+downstream consumers cannot heal through their own installs while minimatch 7
+is in the dependency tree. minimatch 10.2.5 depends on brace-expansion ^5.0.5
+and both packages already use the v9+ named-export API, so this is a drop-in
+upgrade.

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -47,7 +47,7 @@
     "ajv": "8.18.0",
     "http-errors": "2.0.1",
     "http-status-codes": "2.3.0",
-    "minimatch": "7.4.9",
+    "minimatch": "10.2.5",
     "process-warning": "1.0.0",
     "semver": "7.7.4"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@verdaccio/core": "workspace:8.1.2",
     "lodash": "4.18.1",
-    "minimatch": "7.4.9"
+    "minimatch": "10.2.5"
   },
   "devDependencies": {
     "@verdaccio/types": "workspace:13.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   typescript: 5.3.3
+  '@verdaccio/e2e-cli>js-yaml': 4.3.0
+  fast-uri: 3.1.4
 
 importers:
 
@@ -281,8 +283,8 @@ importers:
         specifier: 2.3.0
         version: 2.3.0
       minimatch:
-        specifier: 7.4.9
-        version: 7.4.9
+        specifier: 10.2.5
+        version: 10.2.5
       process-warning:
         specifier: 1.0.0
         version: 1.0.0
@@ -932,8 +934,8 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
       minimatch:
-        specifier: 7.4.9
-        version: 7.4.9
+        specifier: 10.2.5
+        version: 10.2.5
     devDependencies:
       '@verdaccio/types':
         specifier: workspace:13.0.3
@@ -2586,15 +2588,15 @@ packages:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -3025,8 +3027,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3387,16 +3389,8 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
-
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   js-yaml@4.3.0:
@@ -3707,6 +3701,10 @@ packages:
 
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
@@ -5745,7 +5743,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -6419,7 +6417,7 @@ snapshots:
       '@verdaccio/registry-cli': 1.1.0
       debug: 4.4.0
       get-port: 5.1.1
-      js-yaml: 4.1.0
+      js-yaml: 4.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6741,7 +6739,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6871,16 +6869,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7308,7 +7306,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fastq@1.20.1:
     dependencies:
@@ -7693,15 +7691,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -7987,23 +7977,27 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.8
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimatch@4.2.6:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimatch@7.4.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,10 @@ allowBuilds:
   unrs-resolver: true
 overrides:
   typescript: 5.3.3
+  # Security: @verdaccio/e2e-cli pins js-yaml exactly, force the GHSA-52cp-r559-cp3m fix
+  '@verdaccio/e2e-cli>js-yaml': 4.3.0
+  # Security: ajv resolves fast-uri in range, pin the GHSA-v2hh-gcrm-f6hx / GHSA-4c8g-83qw-93j6 fix
+  fast-uri: 3.1.4
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@verdaccio/*'
@@ -24,6 +28,10 @@ minimumReleaseAgeExclude:
   - js-yaml@4.2.0
   # Renovate security update: vite@8.0.16
   - vite@8.0.16
+  # Security update: brace-expansion GHSA-mh99-v99m-4gvg (via minimatch 10)
+  - brace-expansion@5.0.8
+  # Security update: fast-uri GHSA-v2hh-gcrm-f6hx (via ajv)
+  - fast-uri@3.1.4
 ignoreScripts: true
 saveExact: true
 preferFrozenLockfile: true


### PR DESCRIPTION
…t-uri, js-yaml)

- bump minimatch 7.4.9 -> 10.2.5 in @verdaccio/core and @verdaccio/utils so brace-expansion resolves to 5.0.8 (GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg)
- pin fast-uri 3.1.4 via pnpm override for ajv (GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6)
- override js-yaml 4.3.0 under @verdaccio/e2e-cli, which pins 4.1.0 exactly (GHSA-52cp-r559-cp3m)
- allow brace-expansion@5.0.8 and fast-uri@3.1.4 through minimumReleaseAge