### PR TITLE
fix: harden plugin loading and logger for the ESM build

### DIFF
--- a/.changeset/loaders-logger-esm-hardening.md
+++ b/.changeset/loaders-logger-esm-hardening.md
@@ -1,0 +1,20 @@
+---
+'@verdaccio/loaders': patch
+'@verdaccio/logger': patch
+---
+
+fix: harden plugin loading and logger for the ESM build
+
+- loaders: use a real `createRequire` in both output formats (the ESM build
+  previously relied on a throwing `require` stub, so every plugin — including
+  CommonJS ones — was loaded through the `import()` fallback with interop
+  differences); report `err.message` instead of the nonexistent `err.msg`;
+  rethrow real plugin evaluation errors instead of retrying via `import()`
+  (which ran plugin side effects twice and masked the original error); support
+  ESM plugins using top-level await (`ERR_REQUIRE_ASYNC_MODULE`); resolve
+  entry points for manifest-less directory plugins; use `path.isAbsolute()`
+  so Windows paths convert to `file://` URLs correctly.
+- logger: import `on-exit-leak-free` statically (the lazy `require` crashed
+  the ESM build when `setupOnExit` ran) and make the transport directory
+  detection immune to the `__dirname` global that `node -e`/REPL leak into
+  ES modules.

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -1,13 +1,24 @@
 import buildDebug from 'debug';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { createRequire } from 'node:module';
+import { isAbsolute, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import type { pluginUtils } from '@verdaccio/core';
 
 const debug = buildDebug('verdaccio:plugin:loader:utils');
 const MODULE_NOT_FOUND = 'MODULE_NOT_FOUND';
 const ERR_REQUIRE_ESM = 'ERR_REQUIRE_ESM';
+// thrown by require(esm) when the module uses top-level await
+const ERR_REQUIRE_ASYNC_MODULE = 'ERR_REQUIRE_ASYNC_MODULE';
+
+// the ESM build has no ambient require; create one so CJS plugins keep loading.
+// rolldown rewrites bare `require` to a throwing stub in the ESM output and
+// lowers `import.meta` to `{}` in the CJS output, so `import.meta.url` is only
+// truthy in the ESM build; module-scoped __filename covers the CJS build
+// (checking `typeof __filename`/`typeof require` instead is unsafe: node -e and
+// the REPL leak both as globals into ES modules)
+const requireModule = import.meta.url ? createRequire(import.meta.url) : createRequire(__filename);
 
 export type PluginType<T> = T extends pluginUtils.Plugin<T> ? T : never;
 
@@ -28,25 +39,28 @@ export function isES6<T>(plugin: PluginType<T>): boolean {
 export function tryLoad<T>(path: string, onError: any): PluginType<T> | null {
   try {
     debug('loading plugin %s', path);
-    return require(path) as PluginType<T>;
+    return requireModule(path) as PluginType<T>;
   } catch (err: any) {
     if (err.code === MODULE_NOT_FOUND) {
       debug('"require" failed for plugin %s', path);
-      // If loading fails, because a dependency is missing,
-      // we want to log the error message and require stack
-      // to see where the missing dependency is.
       const message = err.message.replace(/\\\\/g, '\\').split('\n');
       if (!message[0].includes(path)) {
+        // the plugin itself was found but one of its own dependencies is
+        // missing: that is a real load error — reporting "not found" (and
+        // re-evaluating the plugin through the import() fallback) would mask
+        // the actual cause and run its side effects twice
         debug('%o', message[0]); // error message
         debug('%o', message.slice(1)); // stack trace
+        onError({ err: err.message }, 'error loading plugin @{err}');
+        throw err;
       }
       return null;
     }
-    if (err.code === ERR_REQUIRE_ESM) {
+    if (err.code === ERR_REQUIRE_ESM || err.code === ERR_REQUIRE_ASYNC_MODULE) {
       debug('"require" failed for ESM plugin %s, will try dynamic import', path);
       return null;
     }
-    onError({ err: err.msg }, 'error loading plugin @{err}');
+    onError({ err: err.message }, 'error loading plugin @{err}');
     throw err;
   }
 }
@@ -61,19 +75,24 @@ function resolveEntryPoint(dirPath: string): string {
   if (existsSync(pkgPath)) {
     try {
       const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-      // Check exports first, then module, then main
+      // Check exports first, then module, then main; only string entries are
+      // usable paths — condition objects without them fall through to the
+      // next field (otherwise we would return the directory itself, which
+      // dynamic import() rejects)
       if (pkg.exports) {
-        const dotExport = pkg.exports['.'];
+        // exports may use the sugar form with conditions at the top level
+        // instead of a '.' subpath map
+        const dotExport = pkg.exports['.'] ?? pkg.exports;
         if (typeof dotExport === 'string') {
           return join(dirPath, dotExport);
         }
-        if (dotExport?.import?.default) {
+        if (typeof dotExport?.import === 'string') {
+          return join(dirPath, dotExport.import);
+        }
+        if (typeof dotExport?.import?.default === 'string') {
           return join(dirPath, dotExport.import.default);
         }
-        if (dotExport?.import) {
-          return join(dirPath, typeof dotExport.import === 'string' ? dotExport.import : '');
-        }
-        if (dotExport?.default) {
+        if (typeof dotExport?.default === 'string') {
           return join(dirPath, dotExport.default);
         }
       }
@@ -104,30 +123,56 @@ export async function tryLoadAsync<T>(path: string, onError: any): Promise<Plugi
       return cjsResult;
     }
   } catch (err: any) {
-    // require() may throw for various reasons (ESM module, bundler shim, etc.)
-    // — always fall through to dynamic import()
-    debug('require() threw for %s: %s — falling back to import()', path, err.message);
+    // tryLoad() returns null for the not-found / ESM cases and only throws on
+    // a real load error (the plugin itself failed to evaluate); retrying via
+    // import() would run the plugin's side effects twice and mask the error
+    debug('require() threw a real load error for %s: %s', path, err.message);
+    throw err;
   }
 
   // Fallback to dynamic import for ESM modules
+  // import() doesn't support directory imports — resolve the entry point,
+  // also for manifest-less directory plugins that only ship an index.js
+  let importPath = path;
   try {
-    // import() doesn't support directory imports — resolve the entry point
-    let importPath = path;
-    if (existsSync(path) && existsSync(join(path, 'package.json'))) {
+    if (
+      isAbsolute(path) &&
+      (existsSync(join(path, 'package.json')) || existsSync(join(path, 'index.js')))
+    ) {
       importPath = resolveEntryPoint(path);
       debug('resolved ESM entry point: %s', importPath);
     }
 
-    // Convert to file URL for import() compatibility
-    const importUrl = importPath.startsWith('/') ? pathToFileURL(importPath).href : importPath;
+    // Convert to file URL for import() compatibility (isAbsolute also covers
+    // Windows paths like C:\..., which startsWith('/') would miss)
+    const importUrl = isAbsolute(importPath) ? pathToFileURL(importPath).href : importPath;
     debug('trying dynamic import for plugin %s', importUrl);
     const module = await import(importUrl);
     debug('dynamic import succeeded for plugin %s', importUrl);
     return module as PluginType<T>;
   } catch (err: any) {
-    if (err.code === MODULE_NOT_FOUND || err.code === 'ERR_MODULE_NOT_FOUND') {
+    if (err.code === 'ERR_UNSUPPORTED_DIR_IMPORT') {
+      // only the plugin path itself is ever imported as a directory
       debug('"import" failed for plugin %s', path);
       return null;
+    }
+    if (err.code === MODULE_NOT_FOUND || err.code === 'ERR_MODULE_NOT_FOUND') {
+      // "not found" may refer to the plugin itself (plugin not installed:
+      // return null) or to a missing dependency inside an existing plugin —
+      // a real load error that must surface, mirroring the require() path
+      // the missing specifier may be reported as a file:// URL
+      const missingRaw = /Cannot find (?:module|package) '([^']+)'/.exec(err.message)?.[1];
+      const missing = missingRaw?.startsWith('file://') ? fileURLToPath(missingRaw) : missingRaw;
+      const refersToPlugin =
+        missing === undefined ||
+        missing === path ||
+        missing === importPath ||
+        missing.startsWith(path);
+      if (refersToPlugin) {
+        debug('"import" failed for plugin %s', path);
+        return null;
+      }
+      debug('plugin %s exists but its dependency %s is missing', path, missing);
     }
     onError({ err: err.message }, 'error loading plugin @{err}');
     throw err;

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-broken-plugin/index.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-broken-plugin/index.js
@@ -1,0 +1,3 @@
+globalThis.__verdaccioBrokenPluginEvaluations =
+  (globalThis.__verdaccioBrokenPluginEvaluations || 0) + 1;
+throw new Error('plugin init exploded');

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-broken-plugin/package.json
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-broken-plugin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "verdaccio-broken-plugin",
+  "version": "1.0.0",
+  "main": "./index.js"
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-cjs-plugin/index.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-cjs-plugin/index.js
@@ -1,0 +1,3 @@
+module.exports = function plugin() {
+  return { register_middlewares() {} };
+};

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-cjs-plugin/package.json
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-cjs-plugin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "verdaccio-cjs-plugin",
+  "version": "1.0.0",
+  "main": "./index.js"
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-empty-dir-plugin/README.md
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-empty-dir-plugin/README.md
@@ -1,0 +1,1 @@
+# not a plugin entry point

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-esm-missing-dep-plugin/index.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-esm-missing-dep-plugin/index.js
@@ -1,0 +1,2 @@
+import 'this-esm-dep-does-not-exist-xyz';
+export default function plugin() {}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-esm-missing-dep-plugin/package.json
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-esm-missing-dep-plugin/package.json
@@ -1,0 +1,1 @@
+{ "name": "verdaccio-esm-missing-dep-plugin", "version": "1.0.0", "type": "module", "main": "./index.js" }

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-esm-plugin/index.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-esm-plugin/index.js
@@ -1,0 +1,3 @@
+export default function plugin() {
+  return { register_middlewares() {} };
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-esm-plugin/package.json
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-esm-plugin/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "verdaccio-esm-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "default": "./index.js"
+      }
+    }
+  }
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-exports-no-default-plugin/index.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-exports-no-default-plugin/index.js
@@ -1,0 +1,3 @@
+export default function plugin() {
+  return { register_middlewares() {} };
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-exports-no-default-plugin/package.json
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-exports-no-default-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "verdaccio-exports-no-default-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": { ".": { "import": { "types": "./index.d.ts" } } }
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-exports-sugar-plugin/entry.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-exports-sugar-plugin/entry.js
@@ -1,0 +1,3 @@
+export default function plugin() {
+  return { register_middlewares() {} };
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-exports-sugar-plugin/package.json
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-exports-sugar-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "verdaccio-exports-sugar-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": { "import": "./entry.js" }
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-missing-dep-plugin/index.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-missing-dep-plugin/index.js
@@ -1,0 +1,4 @@
+globalThis.__verdaccioMissingDepEvaluations =
+  (globalThis.__verdaccioMissingDepEvaluations || 0) + 1;
+require('this-dependency-does-not-exist-xyz');
+module.exports = function plugin() {};

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-missing-dep-plugin/package.json
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-missing-dep-plugin/package.json
@@ -1,0 +1,1 @@
+{ "name": "verdaccio-missing-dep-plugin", "version": "1.0.0", "main": "./index.js" }

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-no-manifest-plugin/index.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-no-manifest-plugin/index.js
@@ -1,0 +1,3 @@
+export default function plugin() {
+  return { register_middlewares() {} };
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-tla-plugin/index.js
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-tla-plugin/index.js
@@ -1,0 +1,4 @@
+await Promise.resolve();
+export default function plugin() {
+  return { register_middlewares() {} };
+}

--- a/packages/loaders/test/partials/modern-plugins/verdaccio-tla-plugin/package.json
+++ b/packages/loaders/test/partials/modern-plugins/verdaccio-tla-plugin/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "verdaccio-tla-plugin",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./index.js"
+}

--- a/packages/loaders/test/utils.spec.ts
+++ b/packages/loaders/test/utils.spec.ts
@@ -1,0 +1,122 @@
+import path from 'node:path';
+import { describe, expect, test, vi } from 'vitest';
+
+import { tryLoadAsync } from '../src/utils';
+
+const pluginsDir = path.join(import.meta.dirname, 'partials', 'modern-plugins');
+const pluginPath = (name: string) => path.join(pluginsDir, name);
+
+describe('tryLoadAsync', () => {
+  test('loads a CommonJS plugin via require', async () => {
+    const onError = vi.fn();
+    const plugin = await tryLoadAsync(pluginPath('verdaccio-cjs-plugin'), onError);
+
+    expect(typeof plugin).toBe('function');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('loads an ESM directory plugin via the dynamic import fallback', async () => {
+    const onError = vi.fn();
+    const plugin: any = await tryLoadAsync(pluginPath('verdaccio-esm-plugin'), onError);
+
+    expect(typeof plugin?.default).toBe('function');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('loads an ESM plugin using top-level await', async () => {
+    const onError = vi.fn();
+    const plugin: any = await tryLoadAsync(pluginPath('verdaccio-tla-plugin'), onError);
+
+    expect(typeof plugin?.default).toBe('function');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('loads a manifest-less ESM directory plugin (index.js only)', async () => {
+    const onError = vi.fn();
+    const plugin: any = await tryLoadAsync(pluginPath('verdaccio-no-manifest-plugin'), onError);
+
+    expect(typeof plugin?.default).toBe('function');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('falls back past a non-string exports import condition (no default)', async () => {
+    const onError = vi.fn();
+    const plugin: any = await tryLoadAsync(
+      pluginPath('verdaccio-exports-no-default-plugin'),
+      onError
+    );
+
+    expect(typeof plugin?.default).toBe('function');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('resolves the exports sugar form without a dot subpath', async () => {
+    const onError = vi.fn();
+    const plugin: any = await tryLoadAsync(pluginPath('verdaccio-exports-sugar-plugin'), onError);
+
+    expect(typeof plugin?.default).toBe('function');
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('returns null for a directory without any entry point', async () => {
+    const onError = vi.fn();
+    const plugin = await tryLoadAsync(pluginPath('verdaccio-empty-dir-plugin'), onError);
+
+    expect(plugin).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('reports the real error when a plugin dependency is missing', async () => {
+    const onError = vi.fn();
+    // @ts-expect-error test-only marker set by the fixture
+    delete globalThis.__verdaccioMissingDepEvaluations;
+
+    await expect(tryLoadAsync(pluginPath('verdaccio-missing-dep-plugin'), onError)).rejects.toThrow(
+      "Cannot find module 'this-dependency-does-not-exist-xyz'"
+    );
+    expect(onError).toHaveBeenCalledWith(
+      { err: expect.stringContaining('this-dependency-does-not-exist-xyz') },
+      'error loading plugin @{err}'
+    );
+    // no import() retry: the plugin must be evaluated exactly once
+    // @ts-expect-error test-only marker set by the fixture
+    expect(globalThis.__verdaccioMissingDepEvaluations).toBe(1);
+  });
+
+  test('reports the real error when an ESM plugin dependency is missing', async () => {
+    const onError = vi.fn();
+
+    await expect(
+      tryLoadAsync(pluginPath('verdaccio-esm-missing-dep-plugin'), onError)
+    ).rejects.toThrow("Cannot find package 'this-esm-dep-does-not-exist-xyz'");
+    expect(onError).toHaveBeenCalledWith(
+      { err: expect.stringContaining('this-esm-dep-does-not-exist-xyz') },
+      'error loading plugin @{err}'
+    );
+  });
+
+  test('returns null when the plugin does not exist', async () => {
+    const onError = vi.fn();
+    const plugin = await tryLoadAsync(pluginPath('verdaccio-does-not-exist'), onError);
+
+    expect(plugin).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  test('rethrows evaluation errors without retrying via import()', async () => {
+    const onError = vi.fn();
+    // @ts-expect-error test-only marker set by the broken plugin fixture
+    delete globalThis.__verdaccioBrokenPluginEvaluations;
+
+    await expect(tryLoadAsync(pluginPath('verdaccio-broken-plugin'), onError)).rejects.toThrow(
+      'plugin init exploded'
+    );
+    expect(onError).toHaveBeenCalledWith(
+      { err: expect.stringContaining('plugin init exploded') },
+      'error loading plugin @{err}'
+    );
+    // an import() retry would evaluate the module a second time
+    // @ts-expect-error test-only marker set by the broken plugin fixture
+    expect(globalThis.__verdaccioBrokenPluginEvaluations).toBe(1);
+  });
+});

--- a/packages/logger/src/prettify.ts
+++ b/packages/logger/src/prettify.ts
@@ -1,6 +1,7 @@
 import type { WriteStream } from 'node:fs';
 import { Transform, pipeline } from 'node:stream';
 import { isMainThread } from 'node:worker_threads';
+import { register as onExitRegister, unregister as onExitUnregister } from 'on-exit-leak-free';
 import build from 'pino-abstract-transport';
 import type { SonicBoomOpts } from 'sonic-boom';
 import SonicBoom from 'sonic-boom';
@@ -68,11 +69,11 @@ export function autoEnd(stream: SonicBoom & { destroyed?: boolean }, eventName: 
 }
 
 function setupOnExit(stream) {
-  // WeakRef/FinalizationRegistry are guaranteed available in Node 20+ (pino v10 minimum)
-  const onExit = require('on-exit-leak-free');
-  onExit.register(stream, autoEnd);
+  // static import instead of a lazy require: rolldown rewrites bare `require`
+  // to a throwing stub in the ESM output, which would crash this path
+  onExitRegister(stream, autoEnd);
   stream.on('close', function () {
-    onExit.unregister(stream);
+    onExitUnregister(stream);
   });
 }
 

--- a/packages/logger/src/transport.ts
+++ b/packages/logger/src/transport.ts
@@ -6,9 +6,11 @@ import type { LoggerConfigItem, LoggerFormat } from '@verdaccio/types';
 import { hasColors } from './colors';
 
 // Pino transports run in a worker thread via require(), so CJS output must work.
-// import.meta.dirname works in ESM; __dirname works in CJS.
-const currentDir =
-  typeof __dirname !== 'undefined' ? __dirname : dirname(fileURLToPath(import.meta.url));
+// rolldown lowers `import.meta` to `{}` in the CJS output, so `import.meta.url`
+// is only truthy in the ESM build; module-scoped __dirname covers the CJS build
+// (checking `typeof __dirname` instead is unsafe: node -e and the REPL leak it
+// as a global into ES modules)
+const currentDir = import.meta.url ? dirname(fileURLToPath(import.meta.url)) : __dirname;
 const prettifyPath = join(currentDir, '..', 'build', 'prettify.js');
 
 export function isPrettyFormat(format: LoggerFormat | undefined): boolean {

--- a/packages/logger/test/prettify-onexit.spec.ts
+++ b/packages/logger/test/prettify-onexit.spec.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type * as workerThreads from 'node:worker_threads';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, describe, expect, test, vi } from 'vitest';
 
 const { register, unregister } = vi.hoisted(() => ({
   register: vi.fn(),
@@ -26,6 +26,10 @@ describe('buildSafeSonicBoom exit handling', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   test('registers a flush-on-exit handler for async streams', async () => {

--- a/packages/logger/test/prettify-onexit.spec.ts
+++ b/packages/logger/test/prettify-onexit.spec.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type * as workerThreads from 'node:worker_threads';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const { register, unregister } = vi.hoisted(() => ({
+  register: vi.fn(),
+  unregister: vi.fn(),
+}));
+
+vi.mock('on-exit-leak-free', () => ({ register, unregister }));
+// buildSafeSonicBoom only registers exit handlers on the main thread; force it
+// so the test does not depend on the vitest worker pool
+vi.mock('node:worker_threads', async (importOriginal) => ({
+  ...(await importOriginal<typeof workerThreads>()),
+  isMainThread: true,
+}));
+
+import { buildSafeSonicBoom } from '../src/prettify';
+
+describe('buildSafeSonicBoom exit handling', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prettify-'));
+  let fileCount = 0;
+  const nextDest = () => path.join(tmpDir, `out-${fileCount++}.log`);
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('registers a flush-on-exit handler for async streams', async () => {
+    const stream = buildSafeSonicBoom({ dest: nextDest(), sync: false });
+
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(register).toHaveBeenCalledWith(stream, expect.any(Function));
+
+    await new Promise<void>((resolve) => {
+      stream.on('close', () => resolve());
+      stream.end();
+    });
+    expect(unregister).toHaveBeenCalledWith(stream);
+  });
+
+  test('does not register an exit handler for sync streams', () => {
+    const stream = buildSafeSonicBoom({ dest: nextDest(), sync: true });
+
+    expect(register).not.toHaveBeenCalled();
+    stream.destroy();
+  });
+
+  test('flush-on-exit handler ends the stream so buffered logs are not lost', async () => {
+    const dest = nextDest();
+    const stream = buildSafeSonicBoom({ dest, sync: false });
+    await new Promise<void>((resolve) => stream.once('ready', () => resolve()));
+    stream.write('tail line\n');
+
+    const autoEnd = register.mock.calls[0][1];
+    await new Promise<void>((resolve) => {
+      stream.on('close', () => resolve());
+      // simulate the process exit callback from on-exit-leak-free
+      autoEnd(stream, 'beforeExit');
+    });
+
+    expect(fs.readFileSync(dest, 'utf8')).toContain('tail line');
+  });
+});


### PR DESCRIPTION
Backport of the hardening developed on the 8.x branch (PR #6053):

loaders:
- use a real createRequire in both output formats: rolldown rewrites bare require to a throwing stub in the ESM output, so every plugin (including CommonJS ones) was silently loaded through the import() fallback with interop differences; the guard prefers import.meta.url because typeof require/__filename checks are unsafe (node -e and the REPL leak them as globals into ES modules)
- report err.message instead of the nonexistent err.msg on load errors
- rethrow real plugin evaluation errors instead of retrying via import(), which ran plugin side effects twice and masked the original error
- treat ERR_REQUIRE_ASYNC_MODULE like ERR_REQUIRE_ESM so ESM plugins using top-level await fall back to import()
- resolve entry points for manifest-less directory plugins (import() rejects directory imports with ERR_UNSUPPORTED_DIR_IMPORT)
- use path.isAbsolute() instead of startsWith('/') so Windows absolute paths convert to file:// URLs
- add utils.spec.ts with fixture plugins covering CJS, ESM, top-level-await, manifest-less, missing, and failing-evaluation scenarios

logger:
- import on-exit-leak-free statically in prettify: the lazy require crashed the ESM build when setupOnExit ran
- transport: prefer import.meta.url over the typeof __dirname guard for the same global-leak reason