### PR TITLE
Docs/verdaccio 7 release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next-7",
   "initialVersions": {
     "verdaccio": "7.0.0-next-7.20"

--- a/README.md
+++ b/README.md
@@ -141,11 +141,13 @@ You can now navigate to [http://localhost:4873/](http://localhost:4873/) where y
 
 ## Publishing
 
-#### 1. Create a User and Log In
+#### 1. Log In
 
 ```bash
-npm adduser --registry http://localhost:4873
+npm login --registry http://localhost:4873 --auth-type=legacy
 ```
+
+> npm 12 removed `npm adduser`. Use `npm adduser --registry http://localhost:4873 --auth-type=legacy` only with npm 11 or older if you still depend on CLI-based user creation.
 
 > If you use HTTPS, add appropriate CA information. ("null" indicates getting the CA list from the OS.)
 
@@ -172,7 +174,7 @@ docker pull verdaccio/verdaccio
 Available as [tags](https://hub.docker.com/r/verdaccio/verdaccio/tags/).
 
 ```bash
-docker pull verdaccio/verdaccio:7.x-next
+docker pull verdaccio/verdaccio:7
 ```
 
 ### Running Verdaccio using Docker
@@ -202,16 +204,16 @@ Verdaccio aims to support all relevant features of a standard npm client for pri
 
 ### User management
 
-- Registering new users (`npm adduser {newuser}`) - **supported**
+- Registering new users (`npm adduser {newuser}`) - **supported with npm 11 or older**; npm 12 removed `npm adduser`
 - Change password (`npm profile set password`) - **supported**
 - Transferring ownership (`npm owner add {user} {pkg}`) - not supported, _PRs welcome_
 - Token (`npm token`) - **supported** (under flag)
 
 ### Miscellany
 
-- Search (`npm search`) - **supported** (cli (`/-/all` and `v1`) / browser)
+- Search (`npm search`) - **supported** (cli (`/-/v1/search`) / browser)
 - Ping (`npm ping`) - **supported**
-- Starring (`npm star`, `npm unstar`, `npm stars`) - **supported**
+- Starring (`npm star`, `npm unstar`, `npm stars`) - not supported in Verdaccio 7.x
 
 ### Security
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ci:version": "pnpm ci:version:changeset && pnpm ci:version:install",
     "ci:version:changeset": "changeset version",
     "ci:version:install": "pnpm install --frozen-lockfile=false --config.prefer-online=true",
-    "ci:publish": "changeset publish",
+    "ci:publish": "changeset publish --tag next-7",
     "type-check": "tsc --noEmit",
     "cache:clean": "pnpm store prune",
     "type-check:watch": "pnpm run type-check -- --watch",


### PR DESCRIPTION
Documentation for the Verdaccio 7 release.

This PR tracks the release documentation work for Verdaccio 7 and links the related public rollout material.

## Release rollout notes

- Verdaccio 7 is published under the explicit `7` npm dist-tag first.
- The npm `latest` dist-tag will move a few days after the initial release, after the release has had time to settle.
- Docker images are published with explicit version tags such as `7` or an exact version.
- Docker `latest` is not published for this release line during the initial rollout.
- Helm users should pin the Verdaccio 7 image tag explicitly.

## References

- Verdaccio 7 tracking issue: https://github.com/verdaccio/verdaccio/issues/5680
- Helm chart release PR: https://github.com/verdaccio/charts/pull/198
- Website docs/update PR: https://github.com/verdaccio/website/pull/473
