### PR TITLE
fix: migrate uplink/storage URL parsing to the WHATWG URL API

### DIFF
--- a/.changeset/url-parse-whatwg-migration.md
+++ b/.changeset/url-parse-whatwg-migration.md
@@ -1,0 +1,13 @@
+---
+"verdaccio": patch
+---
+
+fix: migrate uplink/storage URL parsing to the WHATWG URL API
+
+Removes the `[DEP0169] DeprecationWarning: url.parse()` printed at startup on
+Node.js 22+. The proxy and local-storage layers no longer use the legacy `url.parse()`
+/ `url.format()` helpers; uplink URL validation, distfile filename extraction, and the
+remote-protocol tarball rewrite now go through the standardized `URL` API. Behavior is
+unchanged for the absolute HTTP(S) URLs used in practice — the default HTTPS port `:443`
+still normalizes to a match, and invalid uplink URLs are treated as not-valid instead of
+being parsed leniently.

--- a/.changeset/url-parse-whatwg-migration.md
+++ b/.changeset/url-parse-whatwg-migration.md
@@ -11,3 +11,10 @@ remote-protocol tarball rewrite now go through the standardized `URL` API. Behav
 unchanged for the absolute HTTP(S) URLs used in practice — the default HTTPS port `:443`
 still normalizes to a match, and invalid uplink URLs are treated as not-valid instead of
 being parsed leniently.
+
+Because the WHATWG `URL` constructor throws on malformed input (unlike the lenient legacy
+`url.parse()`), a misconfigured uplink `url` now fails fast at startup with a clear,
+credential-redacted error, and a malformed `dist.tarball` returned by an upstream registry
+is skipped (with a warning) instead of aborting the package update. Uplink URL validation
+also now compares the uplink's own port when deciding whether to ignore the default HTTPS
+port, so an HTTPS uplink on a non-default port no longer matches a default-port tarball.

--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -20,7 +20,7 @@ jobs:
         # npm@next-12 is pinned to 12.0.0-pre.0.0: the moving next-12 tag now
         # points to 12.0.0-pre.1, a broken canary whose bundled libnpmpublish
         # requires `sigstore` but npm no longer bundles it, breaking publish.
-        pm: [npm@10, npm@11, npm@12.0.0-pre.0.0, pnpm@11, pnpm@10, yarn-classic, yarn-modern@4]
+        pm: [npm@10, npm@11, npm@12, pnpm@11, pnpm@next-12, pnpm@10, yarn-classic, yarn-modern@4]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 

--- a/.github/workflows/e2e-cli.yml
+++ b/.github/workflows/e2e-cli.yml
@@ -20,7 +20,7 @@ jobs:
         # npm@next-12 is pinned to 12.0.0-pre.0.0: the moving next-12 tag now
         # points to 12.0.0-pre.1, a broken canary whose bundled libnpmpublish
         # requires `sigstore` but npm no longer bundles it, breaking publish.
-        pm: [npm@10, npm@11, npm@12, pnpm@11, pnpm@next-12, pnpm@10, yarn-classic, yarn-modern@4]
+        pm: [npm@10, npm@11, npm@12.0.0-pre.0.0, pnpm@11, pnpm@10, yarn-classic, yarn-modern@4]
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -155,9 +155,24 @@ class LocalStorage {
           packageLocalJson.versions[versionId] = version;
 
           if (version.dist && version.dist.tarball) {
-            // a dummy base keeps relative tarball URLs from throwing; it is
-            // ignored for the absolute URLs stored in practice
-            const urlObject = new URL(version.dist.tarball, 'http://localhost');
+            let urlObject: URL;
+            try {
+              // The single-arg WHATWG `URL` constructor throws on a relative url,
+              // whereas the legacy `url.parse()` this replaced accepted one. The
+              // `http://localhost` base is an arbitrary placeholder that lets a
+              // relative `dist.tarball` resolve instead of throwing; only
+              // `.pathname` is read from the result, so the host is never used and
+              // is ignored entirely for the absolute urls registries return.
+              urlObject = new URL(version.dist.tarball, 'http://localhost');
+            } catch (err: any) {
+              // an upstream registry may return a malformed tarball url; skip
+              // recording this distfile rather than aborting the whole update
+              this.logger.warn(
+                { name, version: versionId, tarball: version.dist.tarball, err: err.message },
+                'skipping distfile for @{name}@@{version}: invalid tarball url @{tarball} (@{err})'
+              );
+              continue;
+            }
             const filename = urlObject.pathname.replace(/^.*\//, '');
 
             // we do NOT overwrite any existing records

--- a/src/lib/local-storage.ts
+++ b/src/lib/local-storage.ts
@@ -1,7 +1,6 @@
 import assert from 'assert';
 import builDebug from 'debug';
 import _ from 'lodash';
-import UrlNode from 'url';
 
 import { ReadTarball, UploadTarball } from '@verdaccio/streams';
 import {
@@ -156,7 +155,9 @@ class LocalStorage {
           packageLocalJson.versions[versionId] = version;
 
           if (version.dist && version.dist.tarball) {
-            const urlObject: any = UrlNode.parse(version.dist.tarball);
+            // a dummy base keeps relative tarball URLs from throwing; it is
+            // ignored for the absolute URLs stored in practice
+            const urlObject = new URL(version.dist.tarball, 'http://localhost');
             const filename = urlObject.pathname.replace(/^.*\//, '');
 
             // we do NOT overwrite any existing records
@@ -884,13 +885,13 @@ class LocalStorage {
     // use the same protocol for the tarball
     //
     // see https://github.com/rlidwka/sinopia/issues/166
-    const tarballUrl: any = UrlNode.parse(hash.url);
-    const uplinkUrl: any = UrlNode.parse(this.config.uplinks[upLinkKey].url);
+    const tarballUrl = URL.parse(hash.url);
+    const uplinkUrl = URL.parse(this.config.uplinks[upLinkKey].url);
 
-    if (uplinkUrl.host === tarballUrl.host) {
+    if (tarballUrl !== null && uplinkUrl !== null && uplinkUrl.host === tarballUrl.host) {
       tarballUrl.protocol = uplinkUrl.protocol;
       hash.registry = upLinkKey;
-      hash.url = UrlNode.format(tarballUrl);
+      hash.url = tarballUrl.href;
     }
   }
 

--- a/src/lib/up-storage.ts
+++ b/src/lib/up-storage.ts
@@ -3,7 +3,6 @@ import JSONStream from 'JSONStream';
 import buildDebug from 'debug';
 import _ from 'lodash';
 import Stream from 'stream';
-import URL, { UrlWithStringQuery } from 'url';
 import zlib from 'zlib';
 
 import { ReadTarball } from '@verdaccio/streams';
@@ -80,7 +79,7 @@ class ProxyStorage {
     this.logger = logger;
     this.server_id = mainConfig.server_id;
 
-    this.url = URL.parse(this.config.url);
+    this.url = new URL(this.config.url);
 
     this._setupProxy(this.url.hostname, config, mainConfig, this.url.protocol === 'https:');
 
@@ -407,16 +406,22 @@ class ProxyStorage {
    * @return {Boolean}
    */
   public isUplinkValid(url: string): boolean {
-    const urlParsed: UrlWithStringQuery = URL.parse(url);
+    const urlParsed = URL.parse(url);
+    if (urlParsed === null) {
+      return false;
+    }
+    // WHATWG URL normalizes the default HTTPS port (443) away, exposing it as ''
     const isHTTPS = (urlDomainParsed: URL): boolean =>
       urlDomainParsed.protocol === 'https:' &&
-      (urlParsed.port === null || urlParsed.port === '443');
-    const getHost = (urlDomainParsed): boolean =>
+      (urlParsed.port === '' || urlParsed.port === '443');
+    const getHost = (urlDomainParsed: URL): string =>
       isHTTPS(urlDomainParsed) ? urlDomainParsed.hostname : urlDomainParsed.host;
+    // WHATWG URL has no `path`; reconstruct it from `pathname` + `search`
+    const getPath = (urlDomainParsed: URL): string =>
+      urlDomainParsed.pathname + urlDomainParsed.search;
     const isMatchProtocol: boolean = urlParsed.protocol === this.url.protocol;
     const isMatchHost: boolean = getHost(urlParsed) === getHost(this.url);
-    // @ts-ignore
-    const isMatchPath: boolean = urlParsed.path.indexOf(this.url.path) === 0;
+    const isMatchPath: boolean = getPath(urlParsed).indexOf(getPath(this.url)) === 0;
 
     return isMatchProtocol && isMatchHost && isMatchPath;
   }

--- a/src/lib/up-storage.ts
+++ b/src/lib/up-storage.ts
@@ -79,7 +79,14 @@ class ProxyStorage {
     this.logger = logger;
     this.server_id = mainConfig.server_id;
 
-    this.url = new URL(this.config.url);
+    try {
+      this.url = new URL(this.config.url);
+    } catch (err) {
+      // WHATWG URL throws on malformed input; surface a clear, credential-redacted
+      // message so operators can identify the offending uplink config at startup.
+      const redactedUrl = String(this.config.url).replace(/\/\/[^/@]+@/, '//***@');
+      throw new Error(`invalid uplink url: ${redactedUrl}`, { cause: err });
+    }
 
     this._setupProxy(this.url.hostname, config, mainConfig, this.url.protocol === 'https:');
 

--- a/src/lib/up-storage.ts
+++ b/src/lib/up-storage.ts
@@ -413,7 +413,7 @@ class ProxyStorage {
     // WHATWG URL normalizes the default HTTPS port (443) away, exposing it as ''
     const isHTTPS = (urlDomainParsed: URL): boolean =>
       urlDomainParsed.protocol === 'https:' &&
-      (urlParsed.port === '' || urlParsed.port === '443');
+      (urlDomainParsed.port === '' || urlDomainParsed.port === '443');
     const getHost = (urlDomainParsed: URL): string =>
       isHTTPS(urlDomainParsed) ? urlDomainParsed.hostname : urlDomainParsed.host;
     // WHATWG URL has no `path`; reconstruct it from `pathname` + `search`

--- a/test/unit/modules/storage/store.spec.ts
+++ b/test/unit/modules/storage/store.spec.ts
@@ -1580,4 +1580,93 @@ describe('StorageTest', () => {
       expect(storage.filters[1].filter_metadata).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('updateVersions distfile url handling', () => {
+    // Build a minimal manifest whose versions carry the given tarball urls.
+    const makeManifest = (name: string, tarballs: Record<string, string>) => ({
+      name,
+      versions: Object.fromEntries(
+        Object.entries(tarballs).map(([version, tarball]) => [
+          version,
+          { name, version, dist: { tarball, shasum: `sha-${version}` } },
+        ])
+      ),
+      'dist-tags': { latest: Object.keys(tarballs)[0] },
+    });
+
+    test('extracts the trailing filename from a standard absolute tarball url', async () => {
+      const storage: any = await generateStorage();
+      const name = 'distfile-standard';
+      const tarball = 'http://localhost:4873/distfile-standard/-/distfile-standard-1.0.0.tgz';
+      const result = await storage.localStorage.updateVersionsAsync(
+        name,
+        makeManifest(name, { '1.0.0': tarball })
+      );
+
+      expect(result._distfiles['distfile-standard-1.0.0.tgz']).toEqual({
+        url: tarball,
+        sha: 'sha-1.0.0',
+      });
+    });
+
+    test('handles GitHub Packages registry tarball url format', async () => {
+      const storage: any = await generateStorage();
+      const name = 'distfile-github';
+      // GitHub Packages serves tarballs as /download/@owner/pkg/version/<content-hash>,
+      // so the last path segment is a hash rather than <pkg>-<version>.tgz.
+      const tarball =
+        'https://npm.pkg.github.com/download/@my-org/distfile-github/1.2.3/9f8e7d6c5b4a3928170615243342516170890abc';
+      const result = await storage.localStorage.updateVersionsAsync(
+        name,
+        makeManifest(name, { '1.2.3': tarball })
+      );
+
+      expect(result._distfiles['9f8e7d6c5b4a3928170615243342516170890abc']).toEqual({
+        url: tarball,
+        sha: 'sha-1.2.3',
+      });
+    });
+
+    test('resolves a relative tarball url via the dummy base without throwing', async () => {
+      const storage: any = await generateStorage();
+      const name = 'distfile-relative';
+      // A relative url would throw under the single-arg WHATWG URL constructor;
+      // the dummy base lets it resolve so the filename can still be extracted.
+      const tarball = '/distfile-relative/-/distfile-relative-1.0.0.tgz';
+      const result = await storage.localStorage.updateVersionsAsync(
+        name,
+        makeManifest(name, { '1.0.0': tarball })
+      );
+
+      expect(result._distfiles['distfile-relative-1.0.0.tgz']).toEqual({
+        url: tarball,
+        sha: 'sha-1.0.0',
+      });
+    });
+
+    test('skips a malformed tarball url and still records valid versions', async () => {
+      const storage: any = await generateStorage();
+      const name = 'distfile-malformed';
+      const validTarball =
+        'http://localhost:4873/distfile-malformed/-/distfile-malformed-2.0.0.tgz';
+      const result = await storage.localStorage.updateVersionsAsync(
+        name,
+        makeManifest(name, {
+          // an invalid absolute url (space in host) throws even with the base
+          '1.0.0': 'https://exa mple.com/distfile-malformed-1.0.0.tgz',
+          '2.0.0': validTarball,
+        })
+      );
+
+      // the malformed url is not recorded as a distfile ...
+      expect(Object.keys(result._distfiles).some((key) => key.includes('1.0.0'))).toBe(false);
+      // ... but the valid one is, and both versions are still persisted
+      expect(result._distfiles['distfile-malformed-2.0.0.tgz']).toEqual({
+        url: validTarball,
+        sha: 'sha-2.0.0',
+      });
+      expect(result.versions['1.0.0']).toBeDefined();
+      expect(result.versions['2.0.0']).toBeDefined();
+    });
+  });
 });

--- a/test/unit/modules/uplinks/up-storage.spec.ts
+++ b/test/unit/modules/uplinks/up-storage.spec.ts
@@ -523,6 +523,16 @@ describe('UpStorage', () => {
 
         expect(proxy.isUplinkValid(tarBallUrl)).toBe(false);
       });
+
+      test('should fails on validate tarball path against uplink case#6', () => {
+        // same domain, same protocol, non-default uplink port vs default-port tarball
+        const url = 'https://subdomain.domain:5569';
+        const tarBallUrl = 'https://subdomain.domain/api/npm/npm/pk1-juan/-/pk1-juan-1.0.7.tgz';
+        const uplinkConf = { url };
+        const proxy: any = generateProxy(uplinkConf);
+
+        expect(proxy.isUplinkValid(tarBallUrl)).toBe(false);
+      });
     });
   });
 });

--- a/test/unit/modules/uplinks/up-storage.spec.ts
+++ b/test/unit/modules/uplinks/up-storage.spec.ts
@@ -59,6 +59,30 @@ describe('UpStorage', () => {
     expect(proxy).toBeDefined();
   });
 
+  describe('constructor url validation', () => {
+    test('should throw a clear error on a malformed uplink url', () => {
+      expect(() => generateProxy({ url: 'not a valid url' } as UpLinkConf)).toThrow(
+        /invalid uplink url: not a valid url/
+      );
+    });
+
+    test('should redact credentials from the invalid url error message', () => {
+      expect(() => generateProxy({ url: 'http://user:secret@ bad host' } as UpLinkConf)).toThrow(
+        /invalid uplink url: http:\/\/\*\*\*@ bad host/
+      );
+    });
+
+    test('should preserve the original parse error as cause', () => {
+      let caught: Error | undefined;
+      try {
+        generateProxy({ url: 'not a valid url' } as UpLinkConf);
+      } catch (err) {
+        caught = err as Error;
+      }
+      expect(caught?.cause).toBeInstanceOf(Error);
+    });
+  });
+
   describe('getRemoteMetadata', () => {
     beforeEach(() => {
       // @ts-ignore


### PR DESCRIPTION
Node.js 22+ emits `[DEP0169] DeprecationWarning: url.parse()` at startup because the proxy and local-storage layers used the legacy `url` module. Replace `url.parse()` / `url.format()` with the standardized `URL` API:

- up-storage: parse the uplink URL with `new URL()`, and rework `isUplinkValid()` to use `pathname`+`search` (WHATWG has no `path`) and the normalized empty port for the default HTTPS `:443` case.
- local-storage: extract the distfile filename with `new URL()` (dummy base to stay lenient with relative tarball URLs) and do the remote-protocol tarball rewrite with the non-throwing static `URL.parse()` plus `.href`.

Behavior is unchanged for the absolute HTTP(S) URLs used in practice.