### PR TITLE
Fix: Fallback to the default auth/apiJWTmiddleware if a plugin doesn't authenticate a `remote_user`.

### DIFF
--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -428,13 +428,16 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     debug('jwt middleware');
     const plugins = this.plugins.slice(0);
     const helpers = { createAnonymousRemoteUser, createRemoteUser };
+
+    const handlers: any[] = [];
+
     for (const plugin of plugins) {
       if (plugin.apiJWTmiddleware) {
-        return plugin.apiJWTmiddleware(helpers);
+        handlers.push(plugin.apiJWTmiddleware(helpers));
       }
     }
 
-    return (req: $RequestExtend, res: $ResponseExtend, _next: NextFunction) => {
+    handlers.push((req: $RequestExtend, res: $ResponseExtend, _next: NextFunction) => {
       req.pause();
       const next = function (err?: VerdaccioError): NextFunction {
         req.resume();
@@ -479,6 +482,34 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
         debug('api middleware using JWT auth token');
         this.handleJWTAPIMiddleware(req, security, secret, authorization, next);
       }
+    });
+
+    return (req: $RequestExtend, res: $ResponseExtend, _next: NextFunction) => {
+      const middleware = handlers.slice(0);
+      const next = (err?: VerdaccioError): void => {
+        if (err) {
+          if (isNil(req.remote_user)) {
+            const remoteUser = createAnonymousRemoteUser();
+            req.remote_user = remoteUser;
+            res.locals.remote_user = remoteUser;
+          }
+          req.remote_user.error = err.message;
+          return _next();
+        }
+
+        if (isNil(req.remote_user) === false) {
+          return _next();
+        }
+
+        const handler = middleware.shift();
+        if (typeof handler !== 'function') {
+          return _next();
+        }
+
+        return handler(req, res, next);
+      };
+
+      return next();
     };
   }
 

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -11,6 +11,7 @@ import {
   TOKEN_BEARER,
   authUtils,
   errorUtils,
+  API_ERROR,
 } from '@verdaccio/core';
 import { logger, setup } from '@verdaccio/logger';
 import { errorReportingMiddleware, final, handleError } from '@verdaccio/middleware';
@@ -735,6 +736,85 @@ describe('AuthTest', () => {
           });
         });
         describe('valid signature handlers', () => {
+          test('should continue to the built-in middleware when plugin does not resolve the user', async () => {
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              security: { api: { jwt: { sign: { expiresIn: '29d' } } } },
+            } as any);
+            config.checkSecretKey(secret);
+            const auth = new Auth(config, logger);
+            await auth.init();
+
+            const pluginMiddleware = vi.fn((req, _res, next) => {
+              expect(req.remote_user).toBeUndefined();
+              next();
+            });
+
+            auth.plugins.unshift({
+              apiJWTmiddleware: () => pluginMiddleware,
+            } as any);
+
+            const app = await getServer(auth);
+            const res = await supertest(app).get(`/`).expect(HTTP_STATUS.OK);
+
+            expect(pluginMiddleware).toHaveBeenCalledTimes(1);
+            expect(res.body.user.groups).toEqual([
+              ROLES.$ALL,
+              ROLES.$ANONYMOUS,
+              ROLES.DEPRECATED_ALL,
+              ROLES.DEPRECATED_ANONYMOUS,
+            ]);
+          });
+
+          test('should stop the chain when plugin authenticates the user', async () => {
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              security: { api: { jwt: { sign: { expiresIn: '29d' } } } },
+            } as any);
+            config.checkSecretKey(secret);
+            const auth = new Auth(config, logger);
+            await auth.init();
+
+            const pluginMiddleware = vi.fn((req, _res, next) => {
+              req.remote_user = createRemoteUser('plugin-user', ['plugin-group']);
+              next();
+            });
+
+            auth.plugins.unshift({
+              apiJWTmiddleware: () => pluginMiddleware,
+            } as any);
+
+            const app = await getServer(auth);
+            const res = await supertest(app).get(`/`).expect(HTTP_STATUS.OK);
+
+            expect(pluginMiddleware).toHaveBeenCalledTimes(1);
+            expect(res.body.user.name).toEqual('plugin-user');
+            expect(res.body.user.real_groups).toEqual(['plugin-group']);
+          });
+
+          test('should forward plugin middleware errors', async () => {
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              security: { api: { jwt: { sign: { expiresIn: '29d' } } } },
+            } as any);
+            config.checkSecretKey(secret);
+            const auth = new Auth(config, logger);
+            await auth.init();
+
+            const pluginMiddleware = vi.fn((_req, _res, next) => {
+              next(errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
+            });
+
+            auth.plugins.unshift({
+              apiJWTmiddleware: () => pluginMiddleware,
+            } as any);
+
+            const app = await getServer(auth);
+            await supertest(app).get(`/`).expect(HTTP_STATUS.INTERNAL_ERROR);
+
+            expect(pluginMiddleware).toHaveBeenCalledTimes(1);
+          });
+
           test('should handle valid auth token', async () => {
             const config: Config = new AppConfig(
               // @ts-expect-error


### PR DESCRIPTION
I am using [verdaccio-api-token](https://github.com/practical-at/verdaccio-api-token) but that implementation expects the default implementation for `apiJWTmiddleware` to be called if itself doesn't set `req.remote_user`.

This is (no longer?) the case. So I created this PR to call all the `apiJWTmiddleware` handlers until one either sets the `req.remote_user` or has an error.

I think that #5697 may have introduced this issue.