### PR TITLE
fix: match package acl rules case-insensitively

### DIFF
--- a/.changeset/acl-case-insensitive-matching.md
+++ b/.changeset/acl-case-insensitive-matching.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/core': patch
+---
+
+Match package names case-insensitively in `getMatchedPackagesSpec` so access, publish and unpublish rules apply consistently to every casing of a package name.

--- a/packages/core/core/src/auth-utils.ts
+++ b/packages/core/core/src/auth-utils.ts
@@ -33,7 +33,8 @@ export function getMatchedPackagesSpec(
   packages: PackageList
 ): PackageAccess | void {
   for (const i in packages) {
-    if ((minimatch.makeRe(i) as MMRegExp).exec(pkgName)) {
+    // match case-insensitively, npm package names are case-insensitive
+    if ((minimatch.makeRe(i, { nocase: true }) as MMRegExp).exec(pkgName)) {
       return packages[i];
     }
   }

--- a/packages/core/core/test/auth-utils.spec.ts
+++ b/packages/core/core/test/auth-utils.spec.ts
@@ -95,6 +95,34 @@ describe('Auth Utilities', () => {
       expect(authUtils.getMatchedPackagesSpec('@scope/vue', packages)).toBeUndefined();
     });
 
+    test('should match a rule regardless of package name casing', () => {
+      const packages = {
+        lodash: {
+          access: 'admin',
+          publish: 'admin',
+          proxy: 'custom',
+        },
+        '@scope/*': {
+          access: 'admin',
+          publish: 'admin',
+          proxy: 'custom',
+        },
+        '**': {
+          access: '$all',
+          publish: '$all',
+          proxy: 'npmjs',
+        },
+      };
+      // @ts-expect-error
+      expect(authUtils.getMatchedPackagesSpec('lodash', packages).proxy).toMatch('custom');
+      // @ts-expect-error
+      expect(authUtils.getMatchedPackagesSpec('Lodash', packages).proxy).toMatch('custom');
+      // @ts-expect-error
+      expect(authUtils.getMatchedPackagesSpec('LODASH', packages).proxy).toMatch('custom');
+      // @ts-expect-error
+      expect(authUtils.getMatchedPackagesSpec('@Scope/Pkg', packages).proxy).toMatch('custom');
+    });
+
     test('should return multiple uplinks in given order', () => {
       const packages = {
         react: {


### PR DESCRIPTION
Match package names case-insensitively when resolving `packages:` access, publish and unpublish rules, so a rule applies consistently to every casing of a package name.

Includes a test and a changeset.