### PR TITLE
fix: apply package access controls to the `starredByUser` endpoint

### DIFF
--- a/.changeset/stars-endpoint-access-control.md
+++ b/.changeset/stars-endpoint-access-control.md
@@ -1,0 +1,10 @@
+---
+'verdaccio': patch
+---
+
+fix: apply package access controls to the `starredByUser` endpoint
+
+The `GET /-/_view/starredByUser` view did not enforce the configured package
+access policy when listing a user's starred packages. Results are now filtered
+through `auth.allow_access`, so the response only includes packages the
+requesting client is authorized to see.

--- a/src/api/endpoint/api/stars.ts
+++ b/src/api/endpoint/api/stars.ts
@@ -55,7 +55,9 @@ export default function (route: Router, auth: Auth, storage: Storage, config: Co
 
         Promise.all(starredPackages.map(allowedFor)).then(
           (results) => {
-            const filteredPackages: Version[] = starredPackages.filter((_pkg, index) => results[index]);
+            const filteredPackages: Version[] = starredPackages.filter(
+              (_pkg, index) => results[index]
+            );
             debug(`found ${filteredPackages.length} accessible packages for user: ${key}`);
             res.status(HTTP_STATUS.OK);
             next({

--- a/src/api/endpoint/api/stars.ts
+++ b/src/api/endpoint/api/stars.ts
@@ -45,7 +45,8 @@ export default function (route: Router, auth: Auth, storage: Storage, config: Co
               req.remote_user,
               (accessErr, allowed): void => {
                 if (accessErr) {
-                  if (accessErr.status && String(accessErr.status).match(/^4\d\d$/)) {
+                  const status = accessErr.status ?? accessErr.statusCode;
+                  if (status && String(status).match(/^4\d\d$/)) {
                     // auth plugin returns 4xx user error,
                     // that's equivalent of !allowed basically
                     return resolve(false);

--- a/src/api/endpoint/api/stars.ts
+++ b/src/api/endpoint/api/stars.ts
@@ -2,9 +2,10 @@ import createDebug from 'debug';
 import type { Response, Router } from 'express';
 import _ from 'lodash';
 
+import type { Auth } from '@verdaccio/auth';
 import { errorUtils } from '@verdaccio/core';
-import { STARS_API_ENDPOINTS } from '@verdaccio/middleware';
-import type { Version } from '@verdaccio/types';
+import { STARS_API_ENDPOINTS, rateLimit } from '@verdaccio/middleware';
+import type { Config, Version } from '@verdaccio/types';
 
 import { HTTP_STATUS, USERS } from '../../../lib/constants';
 import type Storage from '../../../lib/storage';
@@ -12,9 +13,10 @@ import type { $NextFunctionVer, $RequestExtend } from '../../../types';
 
 const debug = createDebug('verdaccio:api:stars');
 
-export default function (route: Router, storage: Storage): void {
+export default function (route: Router, auth: Auth, storage: Storage, config: Config): void {
   route.get(
     STARS_API_ENDPOINTS.get_user_starred_packages,
+    rateLimit(config?.userRateLimit),
     (req: $RequestExtend, res: Response, next: $NextFunctionVer): void => {
       const query = req.query as { key?: string };
       if (typeof query?.key === 'undefined' || typeof query?.key !== 'string') {
@@ -22,7 +24,7 @@ export default function (route: Router, storage: Storage): void {
         return next(errorUtils.getBadRequest('missing query key username'));
       }
 
-      const key = query.key;
+      const key = query.key.replace(/['"]+/g, '');
       debug(`get user starred packages for user: ${key}`);
 
       storage.getLocalDatabase((err, localPackages: Version[]) => {
@@ -31,18 +33,39 @@ export default function (route: Router, storage: Storage): void {
           return next(err);
         }
 
-        const filteredPackages: Version[] = localPackages.filter((localPackage: Version) => {
+        const starredPackages: Version[] = localPackages.filter((localPackage: Version) => {
           debug(`checking package: ${localPackage?.name}`);
-          return _.keys(localPackage[USERS]).includes(key.toString().replace(/['"]+/g, ''));
+          return _.keys(localPackage[USERS]).includes(key);
         });
 
-        debug(`found ${filteredPackages.length} packages for user: ${key}`);
-        res.status(HTTP_STATUS.OK);
-        next({
-          rows: filteredPackages.map((filteredPackage: Version) => ({
-            value: filteredPackage.name,
-          })),
-        });
+        const allowedFor = (localPackage: Version): Promise<boolean> =>
+          new Promise((resolve) => {
+            auth.allow_access(
+              { packageName: localPackage.name },
+              req.remote_user,
+              (accessErr, allowed): void => {
+                if (accessErr) {
+                  debug(`access check failed for %o: %o`, localPackage.name, accessErr.message);
+                  return resolve(false);
+                }
+                resolve(Boolean(allowed));
+              }
+            );
+          });
+
+        Promise.all(starredPackages.map(allowedFor)).then(
+          (results) => {
+            const filteredPackages: Version[] = starredPackages.filter((_pkg, index) => results[index]);
+            debug(`found ${filteredPackages.length} accessible packages for user: ${key}`);
+            res.status(HTTP_STATUS.OK);
+            next({
+              rows: filteredPackages.map((filteredPackage: Version) => ({
+                value: filteredPackage.name,
+              })),
+            });
+          },
+          (accessErr) => next(accessErr)
+        );
       });
     }
   );

--- a/src/api/endpoint/api/stars.ts
+++ b/src/api/endpoint/api/stars.ts
@@ -39,14 +39,18 @@ export default function (route: Router, auth: Auth, storage: Storage, config: Co
         });
 
         const allowedFor = (localPackage: Version): Promise<boolean> =>
-          new Promise((resolve) => {
+          new Promise((resolve, reject) => {
             auth.allow_access(
               { packageName: localPackage.name },
               req.remote_user,
               (accessErr, allowed): void => {
                 if (accessErr) {
-                  debug(`access check failed for %o: %o`, localPackage.name, accessErr.message);
-                  return resolve(false);
+                  if (accessErr.status && String(accessErr.status).match(/^4\d\d$/)) {
+                    // auth plugin returns 4xx user error,
+                    // that's equivalent of !allowed basically
+                    return resolve(false);
+                  }
+                  return reject(accessErr);
                 }
                 resolve(Boolean(allowed));
               }

--- a/src/api/endpoint/index.ts
+++ b/src/api/endpoint/index.ts
@@ -63,7 +63,7 @@ export default function (config: Config, auth: Auth, storage: Storage) {
   distTags(app, auth, storage);
   publish(app, auth, storage, config);
   ping(app);
-  stars(app, storage);
+  stars(app, auth, storage, config);
   v1Search(app, auth, storage, config);
   token(app, auth, storage, config);
   pkg(app, auth, storage, config);

--- a/test/unit/modules/api/config/plugins/verdaccio-access-error.js
+++ b/test/unit/modules/api/config/plugins/verdaccio-access-error.js
@@ -1,0 +1,18 @@
+import { errorUtils } from '@verdaccio/core';
+
+export default function () {
+  return {
+    allow_access(user, pkg, callback) {
+      if (!user.name) {
+        if (pkg.name.includes('401')) {
+          return callback(errorUtils.getUnauthorized('auth access failure'));
+        }
+        if (pkg.name.includes('403')) {
+          return callback(errorUtils.getForbidden('auth access failure'));
+        }
+        return callback(errorUtils.getInternalError('auth access failure'));
+      }
+      callback(null, false);
+    },
+  };
+};

--- a/test/unit/modules/api/config/plugins/verdaccio-access-error.js
+++ b/test/unit/modules/api/config/plugins/verdaccio-access-error.js
@@ -15,4 +15,4 @@ export default function () {
       callback(null, false);
     },
   };
-};
+}

--- a/test/unit/modules/api/config/star-access-error.yaml
+++ b/test/unit/modules/api/config/star-access-error.yaml
@@ -1,0 +1,29 @@
+plugins: ./plugins
+
+auth:
+  access-error: {}
+  htpasswd:
+    file: ./htpasswd-star-access-error
+web:
+  enable: true
+  title: verdaccio
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+log: { type: stdout, format: pretty, level: info }
+
+packages:
+  '@*/*':
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+  '**':
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+
+_debug: true

--- a/test/unit/modules/api/config/star-acl.yaml
+++ b/test/unit/modules/api/config/star-acl.yaml
@@ -1,0 +1,30 @@
+auth:
+  htpasswd:
+    file: ./htpasswd-star-acl
+web:
+  enable: true
+  title: verdaccio
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+log: { type: stdout, format: pretty, level: info }
+
+packages:
+  'private-*':
+    access: jota_token
+    publish: jota_token
+    unpublish: jota_token
+  '@*/*':
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+  '**':
+    access: $all
+    publish: $authenticated
+    unpublish: $authenticated
+    proxy: npmjs
+
+_debug: true

--- a/test/unit/modules/api/star.spec.ts
+++ b/test/unit/modules/api/star.spec.ts
@@ -123,25 +123,22 @@ describe('star', () => {
   test.each([
     [HTTP_STATUS.UNAUTHORIZED, 'access-error-401-demo'],
     [HTTP_STATUS.FORBIDDEN, 'access-error-403-demo'],
-  ])(
-    'should hide starred package when access check returns %s',
-    async (_statusCode, pkgName) => {
-      const userLogged = 'jota_token';
-      nock('https://registry.npmjs.org').get(`/${pkgName}`).reply(404);
-      const app = await initializeServer('star-access-error.yaml', (config) => {
-        config.plugins = path.join(__dirname, 'config', 'plugins');
-      });
-      const token = await getNewToken(app, { name: userLogged, password: 'secretPass' });
-      await publishStarredPackage(app, pkgName, userLogged, token);
+  ])('should hide starred package when access check returns %s', async (_statusCode, pkgName) => {
+    const userLogged = 'jota_token';
+    nock('https://registry.npmjs.org').get(`/${pkgName}`).reply(404);
+    const app = await initializeServer('star-access-error.yaml', (config) => {
+      config.plugins = path.join(__dirname, 'config', 'plugins');
+    });
+    const token = await getNewToken(app, { name: userLogged, password: 'secretPass' });
+    await publishStarredPackage(app, pkgName, userLogged, token);
 
-      const resp = await supertest(app)
-        .get(`/-/_view/starredByUser?key=%22${userLogged}%22`)
-        .set('Accept', HEADERS.JSON)
-        .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
-        .expect(HTTP_STATUS.OK);
-      expect(resp.body.rows).toEqual([]);
-    }
-  );
+    const resp = await supertest(app)
+      .get(`/-/_view/starredByUser?key=%22${userLogged}%22`)
+      .set('Accept', HEADERS.JSON)
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.OK);
+    expect(resp.body.rows).toEqual([]);
+  });
 
   test('should fail when starred package access check returns a server error', async () => {
     const userLogged = 'jota_token';

--- a/test/unit/modules/api/star.spec.ts
+++ b/test/unit/modules/api/star.spec.ts
@@ -60,6 +60,48 @@ describe('star', () => {
     expect(resp.body.rows).toEqual([{ value: 'foo' }, { value: 'pkg-1' }, { value: 'pkg-2' }]);
   });
 
+  test('should only list starred packages the caller is allowed to access', async () => {
+    const userLogged = 'jota_token';
+    const privatePkg = 'private-demo';
+    const publicPkg = 'public-demo';
+    nock('https://registry.npmjs.org').get(`/${publicPkg}`).reply(404);
+    const app = await initializeServer('star-acl.yaml');
+    const token = await getNewToken(app, { name: userLogged, password: 'secretPass' });
+    await publishVersion(app, privatePkg, '1.0.0', undefined, token).expect(HTTP_STATUS.CREATED);
+    await publishVersion(app, publicPkg, '1.0.0', undefined, token).expect(HTTP_STATUS.CREATED);
+
+    for (const pkgName of [privatePkg, publicPkg]) {
+      const manifest = await getPackage(app, token, pkgName);
+      await starPackage(
+        app,
+        {
+          _rev: manifest.body._rev,
+          _id: manifest.body.id,
+          name: pkgName,
+          users: { [userLogged]: true },
+        },
+        token
+      ).expect(HTTP_STATUS.OK);
+    }
+
+    const authed = await supertest(app)
+      .get(`/-/_view/starredByUser?key=%22${userLogged}%22`)
+      .set('Accept', HEADERS.JSON)
+      .set('authorization', `Bearer ${token}`)
+      .expect(HTTP_STATUS.OK);
+    expect(authed.body.rows).toEqual(
+      expect.arrayContaining([{ value: privatePkg }, { value: publicPkg }])
+    );
+
+    const anon = await supertest(app)
+      .get(`/-/_view/starredByUser?key=%22${userLogged}%22`)
+      .set('Accept', HEADERS.JSON)
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.OK);
+    expect(anon.body.rows).toEqual([{ value: publicPkg }]);
+    expect(anon.body.rows).not.toContainEqual({ value: privatePkg });
+  });
+
   test.each([['foo']])('should requires parameters', async (pkgName) => {
     const userLogged = 'jota_token';
     nock('https://registry.npmjs.org').get(`/${pkgName}`).reply(404);

--- a/test/unit/modules/api/star.spec.ts
+++ b/test/unit/modules/api/star.spec.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import nock from 'nock';
 import supertest from 'supertest';
 import { beforeEach, describe, expect, test } from 'vitest';
@@ -100,6 +102,62 @@ describe('star', () => {
       .expect(HTTP_STATUS.OK);
     expect(anon.body.rows).toEqual([{ value: publicPkg }]);
     expect(anon.body.rows).not.toContainEqual({ value: privatePkg });
+  });
+
+  async function publishStarredPackage(app, pkgName: string, userLogged: string, token: string) {
+    await publishVersion(app, pkgName, '1.0.0', undefined, token).expect(HTTP_STATUS.CREATED);
+
+    const manifest = await getPackage(app, token, pkgName);
+    await starPackage(
+      app,
+      {
+        _rev: manifest.body._rev,
+        _id: manifest.body.id,
+        name: pkgName,
+        users: { [userLogged]: true },
+      },
+      token
+    ).expect(HTTP_STATUS.OK);
+  }
+
+  test.each([
+    [HTTP_STATUS.UNAUTHORIZED, 'access-error-401-demo'],
+    [HTTP_STATUS.FORBIDDEN, 'access-error-403-demo'],
+  ])(
+    'should hide starred package when access check returns %s',
+    async (_statusCode, pkgName) => {
+      const userLogged = 'jota_token';
+      nock('https://registry.npmjs.org').get(`/${pkgName}`).reply(404);
+      const app = await initializeServer('star-access-error.yaml', (config) => {
+        config.plugins = path.join(__dirname, 'config', 'plugins');
+      });
+      const token = await getNewToken(app, { name: userLogged, password: 'secretPass' });
+      await publishStarredPackage(app, pkgName, userLogged, token);
+
+      const resp = await supertest(app)
+        .get(`/-/_view/starredByUser?key=%22${userLogged}%22`)
+        .set('Accept', HEADERS.JSON)
+        .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+        .expect(HTTP_STATUS.OK);
+      expect(resp.body.rows).toEqual([]);
+    }
+  );
+
+  test('should fail when starred package access check returns a server error', async () => {
+    const userLogged = 'jota_token';
+    const pkgName = 'access-error-500-demo';
+    nock('https://registry.npmjs.org').get(`/${pkgName}`).reply(404);
+    const app = await initializeServer('star-access-error.yaml', (config) => {
+      config.plugins = path.join(__dirname, 'config', 'plugins');
+    });
+    const token = await getNewToken(app, { name: userLogged, password: 'secretPass' });
+    await publishStarredPackage(app, pkgName, userLogged, token);
+
+    await supertest(app)
+      .get(`/-/_view/starredByUser?key=%22${userLogged}%22`)
+      .set('Accept', HEADERS.JSON)
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.INTERNAL_ERROR);
   });
 
   test.each([['foo']])('should requires parameters', async (pkgName) => {


### PR DESCRIPTION
The `GET /-/_view/starredByUser` view did not enforce the configured package
access policy when listing a user's starred packages. Results are now filtered
through `auth.allow_access`, so the response only includes packages the
requesting client is authorized to see.