### PR TITLE
fix(storage): refresh uplink cache on 304 response

### DIFF
--- a/.changeset/few-zebras-glow.md
+++ b/.changeset/few-zebras-glow.md
@@ -1,0 +1,5 @@
+---
+"@verdaccio/store": patch
+---
+
+fix(storage): refresh uplink cache timestamp on 304 response

--- a/.changeset/few-zebras-glow.md
+++ b/.changeset/few-zebras-glow.md
@@ -1,5 +1,5 @@
 ---
-"@verdaccio/store": patch
+'@verdaccio/store': patch
 ---
 
 fix(storage): refresh uplink cache timestamp on 304 response

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -1714,7 +1714,7 @@ class Storage {
           break;
         }
       } catch (err: any) {
-        const uplinkName = this.uplinks[uplink].uplinkName;
+        const uplinkName = uplink;
         const upLinkMeta = localManifest?._uplinks[uplinkName];
         // A 304 means the uplink confirms our cached manifest is current; refresh fetched timestamp.
         if (

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -1714,6 +1714,18 @@ class Storage {
           break;
         }
       } catch (err: any) {
+        const uplinkName = this.uplinks[uplink].uplinkName;
+        const upLinkMeta = localManifest?._uplinks[uplinkName];
+        if (
+          err.code === HTTP_STATUS.NOT_MODIFIED &&
+          localManifest !== null &&
+          upLinkMeta !== undefined &&
+          validationUtils.isObject(upLinkMeta)
+        ) {
+          syncManifest = updateUpLinkMetadata(uplinkName, localManifest, upLinkMeta.etag);
+          found = true;
+          break;
+        }
         debug('error captured on uplink %o', err.message);
         uplinksErrors.push(err);
         // enforce use next uplink on the list

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -1716,13 +1716,14 @@ class Storage {
       } catch (err: any) {
         const uplinkName = this.uplinks[uplink].uplinkName;
         const upLinkMeta = localManifest?._uplinks[uplinkName];
+        // A 304 means the uplink confirms our cached manifest is current; refresh fetched timestamp.
         if (
           err.code === HTTP_STATUS.NOT_MODIFIED &&
           localManifest !== null &&
-          upLinkMeta !== undefined &&
-          validationUtils.isObject(upLinkMeta)
+          validationUtils.isObject(upLinkMeta) &&
+          typeof (upLinkMeta as any).etag === 'string'
         ) {
-          syncManifest = updateUpLinkMetadata(uplinkName, localManifest, upLinkMeta.etag);
+          syncManifest = updateUpLinkMetadata(uplinkName, localManifest, (upLinkMeta as any).etag);
           found = true;
           break;
         }

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -1715,17 +1715,19 @@ class Storage {
         }
       } catch (err: any) {
         const uplinkName = uplink;
-        const upLinkMeta = localManifest?._uplinks[uplinkName];
+        const upLinkMeta = localManifest?._uplinks?.[uplinkName];
+        const etag = upLinkMeta?.etag;
         // A 304 means the uplink confirms our cached manifest is current; refresh fetched timestamp.
         if (
           err.code === HTTP_STATUS.NOT_MODIFIED &&
           localManifest !== null &&
           validationUtils.isObject(upLinkMeta) &&
-          typeof (upLinkMeta as any).etag === 'string'
+          typeof etag === 'string'
         ) {
-          syncManifest = updateUpLinkMetadata(uplinkName, localManifest, (upLinkMeta as any).etag);
+          syncManifest = updateUpLinkMetadata(uplinkName, localManifest, etag);
+          localManifest = syncManifest;
           found = true;
-          break;
+          continue;
         }
         debug('error captured on uplink %o', err.message);
         uplinksErrors.push(err);

--- a/packages/store/test/fixtures/config/syncMultipleUplinksMetadata.yaml
+++ b/packages/store/test/fixtures/config/syncMultipleUplinksMetadata.yaml
@@ -1,0 +1,11 @@
+uplinks:
+  ver:
+    url: https://fake.verdaccio.org/
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  'foo-multiple':
+    access: $all
+    publish: $authenticated
+    proxy: ver npmjs
+log: { type: stdout, format: pretty, level: warn }

--- a/packages/store/test/storage.spec.ts
+++ b/packages/store/test/storage.spec.ts
@@ -1475,6 +1475,36 @@ describe('storage', () => {
         const cachedManifest = await storage.getPackageLocalMetadata(fooManifest.name);
         expect(cachedManifest._uplinks.ver).toEqual(m._uplinks.ver);
       });
+
+      test('should try the next proxy after a 304 response', async () => {
+        const localManifest = generatePackageMetadata('foo-multiple', '8.0.0');
+        localManifest._uplinks.ver = { etag: 'rev_3333', fetched: 1 };
+
+        nock('https://fake.verdaccio.org')
+          .get('/foo-multiple')
+          .matchHeader('if-none-match', 'rev_3333')
+          .reply(304);
+        nock('https://registry.npmjs.org')
+          .get('/foo-multiple')
+          .reply(200, generateRemotePackageMetadata('foo-multiple', '9.0.0'));
+
+        const config = new Config(
+          configExample(
+            { storage: generateRandomStorage() },
+            './fixtures/config/syncMultipleUplinksMetadata.yaml',
+            import.meta.dirname
+          )
+        );
+        const storage = new Storage(config, logger);
+        await storage.init(config);
+
+        const [manifest] = await storage.syncUplinksMetadata('foo-multiple', localManifest, {
+          retry: { limit: 0 },
+        });
+
+        expect((manifest as Manifest).versions['9.0.0']).toBeDefined();
+        expect((manifest as Manifest)._uplinks.ver.fetched).toBeGreaterThan(1);
+      });
     });
 
     describe('success scenarios', () => {

--- a/packages/store/test/storage.spec.ts
+++ b/packages/store/test/storage.spec.ts
@@ -1450,7 +1450,11 @@ describe('storage', () => {
 
       test('should handle one proxy reply 304', async () => {
         const fooManifest = generatePackageMetadata('foo-no-data', '8.0.0');
-        nock('https://fake.verdaccio.org').get('/foo-no-data').reply(304);
+        fooManifest._uplinks.ver = { etag: 'rev_3333', fetched: 1 };
+        nock('https://fake.verdaccio.org')
+          .get('/foo-no-data')
+          .matchHeader('if-none-match', 'rev_3333')
+          .reply(304);
         const config = new Config(
           configExample(
             {
@@ -1465,7 +1469,9 @@ describe('storage', () => {
         const [manifest] = await storage.syncUplinksMetadata(fooManifest.name, fooManifest, {
           retry: { limit: 0 },
         });
-        expect(manifest).toEqual(fooManifest);
+        expect((manifest as Manifest)._uplinks.ver.fetched).toBeGreaterThan(1);
+        const cachedManifest = await storage.getPackageLocalMetadata(fooManifest.name);
+        expect(cachedManifest._uplinks.ver).toEqual((manifest as Manifest)._uplinks.ver);
       });
     });
 

--- a/packages/store/test/storage.spec.ts
+++ b/packages/store/test/storage.spec.ts
@@ -1469,9 +1469,11 @@ describe('storage', () => {
         const [manifest] = await storage.syncUplinksMetadata(fooManifest.name, fooManifest, {
           retry: { limit: 0 },
         });
-        expect((manifest as Manifest)._uplinks.ver.fetched).toBeGreaterThan(1);
+        expect(manifest).not.toBeNull();
+        const m = manifest as Manifest;
+        expect(m._uplinks.ver.fetched).toBeGreaterThan(1);
         const cachedManifest = await storage.getPackageLocalMetadata(fooManifest.name);
-        expect(cachedManifest._uplinks.ver).toEqual((manifest as Manifest)._uplinks.ver);
+        expect(cachedManifest._uplinks.ver).toEqual(m._uplinks.ver);
       });
     });
 


### PR DESCRIPTION
Fixes issue #6115.

NOT_MODIFIED is now handled as valid response and local data is marked as up to date.