### PR TITLE
perf(auth): cache legacy auth token validation

### DIFF
--- a/.changeset/legacy-auth-cache.md
+++ b/.changeset/legacy-auth-cache.md
@@ -1,0 +1,9 @@
+---
+'@verdaccio/auth': patch
+'@verdaccio/config': patch
+'@verdaccio/types': patch
+---
+
+Cache successful legacy AES token authentication for a short configurable window.
+
+The cache is enabled by default under `server.legacyAuthCache` and avoids running password verification, including bcrypt-backed htpasswd verification, for every request that reuses the same legacy token. Concurrent requests for the same token now share one in-flight authentication result. The cache can be tuned or disabled with `server.legacyAuthCache.enabled`, `server.legacyAuthCache.maxEntries`, and `server.legacyAuthCache.ttlMs`.

--- a/.changeset/middleware-audit-deps.md
+++ b/.changeset/middleware-audit-deps.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/middleware': patch
+---
+
+Update `express-rate-limit` to 8.6.0 and refresh transitive audit fixes for `fast-uri` and `ip-address`.

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -591,10 +591,16 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
       }
 
       debug('authenticating %o', user);
-      this.authenticate(user, password, (err, user): void => {
-        completeAuth(err, user);
-        this.resolveLegacyAuthCacheWaiters(cacheKey, err, user);
-      });
+      try {
+        this.authenticate(user, password, (err, user): void => {
+          completeAuth(err, user);
+          this.resolveLegacyAuthCacheWaiters(cacheKey, err, user);
+        });
+      } catch (err: any) {
+        const authError = errorUtils.getInternalError(err?.message);
+        completeAuth(authError);
+        this.resolveLegacyAuthCacheWaiters(cacheKey, authError);
+      }
     } else {
       // we force npm client to ask again with basic authentication
       debug('legacy invalid header');
@@ -656,6 +662,11 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
 
   private getLegacyAuthCacheKey(authorization: string): string | void {
     if (!this.isLegacyAuthCacheEnabled()) {
+      return;
+    }
+
+    const { scheme } = parseAuthTokenHeader(authorization);
+    if (scheme.toUpperCase() !== TOKEN_BEARER.toUpperCase()) {
       return;
     }
 

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -1,5 +1,6 @@
 import buildDebug from 'debug';
 import { filter, isEmpty, isNil, isUndefined } from 'lodash-es';
+import { createHash } from 'node:crypto';
 import { HTPasswd } from 'verdaccio-htpasswd';
 
 import { createAnonymousRemoteUser, createRemoteUser } from '@verdaccio/config';
@@ -48,6 +49,21 @@ import {
 } from './utils';
 
 const debug = buildDebug('verdaccio:auth');
+type LegacyAuthCacheEntry = {
+  expiresAt: number;
+  user: RemoteUser;
+};
+
+type LegacyAuthCacheWaiter = (err: VerdaccioError | null, user?: RemoteUser) => void;
+
+function cloneRemoteUser(user: RemoteUser): RemoteUser {
+  return {
+    ...user,
+    groups: user.groups ? [...user.groups] : user.groups,
+    real_groups: user.real_groups ? [...user.real_groups] : user.real_groups,
+    token: user.token ? { ...user.token } : user.token,
+  };
+}
 
 class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
   public config: Config;
@@ -55,6 +71,8 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
   public logger: Logger;
   public plugins: pluginUtils.Auth<Config>[];
   public options: { legacyMergeConfigs: boolean };
+  private legacyAuthCache: Map<string, LegacyAuthCacheEntry>;
+  private legacyAuthCacheWaiters: Map<string, LegacyAuthCacheWaiter[]>;
 
   public constructor(config: Config, logger: Logger, options = { legacyMergeConfigs: false }) {
     this.config = config;
@@ -62,6 +80,8 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     this.logger = logger;
     this.plugins = [];
     this.options = options;
+    this.legacyAuthCache = new Map();
+    this.legacyAuthCacheWaiters = new Map();
     if (!this.secret) {
       throw new TypeError('secret it is required value on initialize the auth class');
     }
@@ -543,25 +563,142 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     const credentials: any = getMiddlewareCredentials(security, secret, authorization);
     debug('api middleware credentials %o', credentials?.name);
     if (credentials) {
+      const cacheKey = this.getLegacyAuthCacheKey(authorization);
+      const cachedUser = this.getLegacyAuthCacheEntry(cacheKey);
+      if (cachedUser) {
+        req.remote_user = cachedUser;
+        debug('generating cached remote user');
+        return next();
+      }
+
       const { user, password } = credentials;
-      debug('authenticating %o', user);
-      this.authenticate(user, password, (err, user): void => {
-        if (!err) {
+      const completeAuth = (err: VerdaccioError | null, user?: RemoteUser): void => {
+        if (!err && user) {
           req.remote_user = credentials.tokenKey
             ? { ...user, token: { key: credentials.tokenKey } }
             : user;
+          this.setLegacyAuthCacheEntry(cacheKey, req.remote_user);
           debug('generating a remote user');
           next();
         } else {
           req.remote_user = createAnonymousRemoteUser();
           debug('generating anonymous user');
-          next(err);
+          next(err || errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
         }
+      };
+      if (this.enqueueLegacyAuthCacheWaiter(cacheKey, completeAuth)) {
+        return;
+      }
+
+      debug('authenticating %o', user);
+      this.authenticate(user, password, (err, user): void => {
+        completeAuth(err, user);
+        this.resolveLegacyAuthCacheWaiters(cacheKey, err, user);
       });
     } else {
       // we force npm client to ask again with basic authentication
       debug('legacy invalid header');
       return next(errorUtils.getBadRequest(API_ERROR.BAD_AUTH_HEADER));
+    }
+  }
+
+  private enqueueLegacyAuthCacheWaiter(
+    cacheKey: string | void,
+    waiter: LegacyAuthCacheWaiter
+  ): boolean {
+    if (!cacheKey) {
+      return false;
+    }
+
+    const waiters = this.legacyAuthCacheWaiters.get(cacheKey);
+    if (!waiters) {
+      this.legacyAuthCacheWaiters.set(cacheKey, []);
+      return false;
+    }
+
+    waiters.push(waiter);
+    return true;
+  }
+
+  private resolveLegacyAuthCacheWaiters(
+    cacheKey: string | void,
+    err: VerdaccioError | null,
+    user?: RemoteUser
+  ): void {
+    if (!cacheKey) {
+      return;
+    }
+
+    const waiters = this.legacyAuthCacheWaiters.get(cacheKey);
+    this.legacyAuthCacheWaiters.delete(cacheKey);
+    if (!waiters) {
+      return;
+    }
+
+    for (const waiter of waiters) {
+      waiter(err, user);
+    }
+  }
+
+  private isLegacyAuthCacheEnabled(): boolean {
+    return this.config.server?.legacyAuthCache?.enabled !== false;
+  }
+
+  private getLegacyAuthCacheTtlMs(): number {
+    const ttlMs = this.config.server?.legacyAuthCache?.ttlMs;
+    return typeof ttlMs === 'number' && ttlMs > 0 ? ttlMs : 5 * 60 * 1000;
+  }
+
+  private getLegacyAuthCacheMaxEntries(): number {
+    const maxEntries = this.config.server?.legacyAuthCache?.maxEntries;
+    return typeof maxEntries === 'number' && maxEntries > 0 ? maxEntries : 1000;
+  }
+
+  private getLegacyAuthCacheKey(authorization: string): string | void {
+    if (!this.isLegacyAuthCacheEnabled()) {
+      return;
+    }
+
+    return createHash('sha256').update(authorization).digest('hex');
+  }
+
+  private getLegacyAuthCacheEntry(cacheKey: string | void): RemoteUser | void {
+    if (!cacheKey) {
+      return;
+    }
+
+    const entry = this.legacyAuthCache.get(cacheKey);
+    if (!entry) {
+      return;
+    }
+
+    if (entry.expiresAt <= Date.now()) {
+      this.legacyAuthCache.delete(cacheKey);
+      return;
+    }
+
+    this.legacyAuthCache.delete(cacheKey);
+    this.legacyAuthCache.set(cacheKey, entry);
+    return cloneRemoteUser(entry.user);
+  }
+
+  private setLegacyAuthCacheEntry(cacheKey: string | void, user: RemoteUser): void {
+    if (!cacheKey) {
+      return;
+    }
+
+    this.legacyAuthCache.set(cacheKey, {
+      expiresAt: Date.now() + this.getLegacyAuthCacheTtlMs(),
+      user: cloneRemoteUser(user),
+    });
+
+    const maxEntries = this.getLegacyAuthCacheMaxEntries();
+    while (this.legacyAuthCache.size > maxEntries) {
+      const oldestKey = this.legacyAuthCache.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      this.legacyAuthCache.delete(oldestKey);
     }
   }
 

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -658,6 +658,112 @@ describe('AuthTest', () => {
             expect(res.body.user.name).toEqual('juan');
           });
 
+          test('should cache a successful legacy auth token', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({ ...authProfileConf });
+            config.checkSecretKey(TEST_SECRET);
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate');
+            const token = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+            const res = await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+
+            expect(res.body.user.name).toEqual('juan');
+            expect(authenticateSpy).toHaveBeenCalledTimes(1);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should share an in-flight legacy auth token verification', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({ ...authProfileConf });
+            config.checkSecretKey(TEST_SECRET);
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi
+              .spyOn(auth, 'authenticate')
+              .mockImplementation((_username, _password, cb): void => {
+                setTimeout(() => cb(null, createRemoteUser('juan', ['test'])), 10);
+              });
+            const token = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            const [firstResponse, secondResponse] = await Promise.all([
+              supertest(app)
+                .get(`/`)
+                .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+                .expect(HTTP_STATUS.OK),
+              supertest(app)
+                .get(`/`)
+                .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+                .expect(HTTP_STATUS.OK),
+            ]);
+
+            expect(firstResponse.body.user.name).toEqual('juan');
+            expect(secondResponse.body.user.name).toEqual('juan');
+            expect(authenticateSpy).toHaveBeenCalledTimes(1);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should authenticate again when the legacy auth token changes', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({ ...authProfileConf });
+            config.checkSecretKey(TEST_SECRET);
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate');
+            const firstToken = auth.aesEncrypt(payload) as string;
+            const secondToken = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, firstToken))
+              .expect(HTTP_STATUS.OK);
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, secondToken))
+              .expect(HTTP_STATUS.OK);
+
+            expect(firstToken).not.toEqual(secondToken);
+            expect(authenticateSpy).toHaveBeenCalledTimes(2);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should allow disabling the legacy auth token cache', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: false } },
+            });
+            config.checkSecretKey(TEST_SECRET);
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate');
+            const token = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+
+            expect(authenticateSpy).toHaveBeenCalledTimes(2);
+            authenticateSpy.mockRestore();
+          });
+
           test('should handle invalid auth token', async () => {
             const payload = 'juan:password';
             const config: Config = new AppConfig({ ...authPluginFailureConf });

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -8,6 +8,7 @@ import {
   HEADERS,
   HTTP_STATUS,
   SUPPORT_ERRORS,
+  TOKEN_BASIC,
   TOKEN_BEARER,
   authUtils,
   errorUtils,
@@ -682,6 +683,29 @@ describe('AuthTest', () => {
             authenticateSpy.mockRestore();
           });
 
+          test('should not cache basic auth in legacy auth mode', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({ ...authProfileConf });
+            config.checkSecretKey(TEST_SECRET);
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate');
+            const token = Buffer.from(payload).toString('base64');
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BASIC, token))
+              .expect(HTTP_STATUS.OK);
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BASIC, token))
+              .expect(HTTP_STATUS.OK);
+
+            expect(authenticateSpy).toHaveBeenCalledTimes(2);
+            authenticateSpy.mockRestore();
+          });
+
           test('should share an in-flight legacy auth token verification', async () => {
             const payload = 'juan:password';
             const config: Config = new AppConfig({ ...authProfileConf });
@@ -710,6 +734,31 @@ describe('AuthTest', () => {
             expect(firstResponse.body.user.name).toEqual('juan');
             expect(secondResponse.body.user.name).toEqual('juan');
             expect(authenticateSpy).toHaveBeenCalledTimes(1);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should clear in-flight legacy auth token verification when authenticate throws', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({ ...authProfileConf });
+            config.checkSecretKey(TEST_SECRET);
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate').mockImplementation((): void => {
+              throw new TypeError('plugin group error: invalid type for function');
+            });
+            const token = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.INTERNAL_ERROR);
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.INTERNAL_ERROR);
+
+            expect(authenticateSpy).toHaveBeenCalledTimes(2);
             authenticateSpy.mockRestore();
           });
 

--- a/packages/config/src/builder.ts
+++ b/packages/config/src/builder.ts
@@ -66,6 +66,10 @@ export default class ConfigBuilder {
     return this;
   }
 
+  public addLegacyAuthCache(legacyAuthCache: NonNullable<ServerSettingsConf['legacyAuthCache']>) {
+    return this.addServer({ legacyAuthCache });
+  }
+
   public addStorage(storage: string | object) {
     if (typeof storage === 'string') {
       this.config.storage = storage;

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -70,7 +70,7 @@ class Config implements AppConfig {
     debug('config path: %s', this.configPath);
     this.plugins = config.plugins;
     this.security = merge(defaultSecurity, config.security);
-    this.server = { ...defaultServerSettings, ...config.server };
+    this.server = merge({}, defaultServerSettings, config.server);
     this.flags = {
       changePassword: config.flags?.changePassword ?? false,
       webLogin: config.flags?.webLogin ?? false,

--- a/packages/config/src/serverSettings.ts
+++ b/packages/config/src/serverSettings.ts
@@ -7,4 +7,9 @@ export default {
   },
   // deprecated
   keepAliveTimeout: 60,
+  legacyAuthCache: {
+    enabled: true,
+    maxEntries: 1000,
+    ttlMs: 5 * 60 * 1000,
+  },
 };

--- a/packages/config/test/builder.spec.ts
+++ b/packages/config/test/builder.spec.ts
@@ -153,6 +153,17 @@ describe('Config builder', () => {
     expect(config.getConfig().listen).toEqual({ 0: 'localhost:4873' });
   });
 
+  test('should add legacy auth cache server configuration', () => {
+    const config = ConfigBuilder.build().addLegacyAuthCache({
+      enabled: false,
+      maxEntries: 50,
+      ttlMs: 10000,
+    });
+    expect(config.getConfig().server).toEqual({
+      legacyAuthCache: { enabled: false, maxEntries: 50, ttlMs: 10000 },
+    });
+  });
+
   test('should add https configuration', () => {
     const config = ConfigBuilder.build().addHttps({
       key: '/path/to/key.pem',

--- a/packages/config/test/config.spec.ts
+++ b/packages/config/test/config.spec.ts
@@ -81,6 +81,11 @@ describe('check basic content parsed file', () => {
     // server settings
     expect(config.server).toBeDefined();
     expect(config.server.dotfiles).toEqual('ignore');
+    expect(config.server.legacyAuthCache).toEqual({
+      enabled: true,
+      maxEntries: 1000,
+      ttlMs: 300000,
+    });
     // hideStaticLogs is not set in default config, defaults to true at runtime
     expect(config.server.hideStaticLogs).toBeUndefined();
   };
@@ -99,6 +104,19 @@ describe('check basic content parsed file', () => {
     expect(config.storage).toBe('/verdaccio/storage/data');
     expect(config.auth.htpasswd.file).toBe('/verdaccio/storage/htpasswd');
     checkDefaultConfPackages(config);
+  });
+
+  test('should keep legacy auth cache enabled when partially configured', () => {
+    const config = new Config({
+      ...getDefaultConfig(),
+      server: { legacyAuthCache: { maxEntries: 50 } },
+    });
+
+    expect(config.server.legacyAuthCache).toEqual({
+      enabled: true,
+      maxEntries: 50,
+      ttlMs: 300000,
+    });
   });
 });
 

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -266,6 +266,11 @@ export type ServerSettingsConf = {
   // express-rate-limit settings
   rateLimit: RateLimit;
   keepAliveTimeout?: number;
+  legacyAuthCache?: {
+    enabled?: boolean;
+    maxEntries?: number;
+    ttlMs?: number;
+  };
   /**
    * Plugins should be prefixed verdaccio-XXXXXX by default.
    * To override the default prefix, use this property without `-`

--- a/packages/middleware/package.json
+++ b/packages/middleware/package.json
@@ -44,7 +44,7 @@
     "@verdaccio/url": "workspace:14.0.0-next-9.24",
     "debug": "4.4.3",
     "express": "5.2.1",
-    "express-rate-limit": "8.5.2",
+    "express-rate-limit": "8.6.0",
     "lodash-es": "4.18.1",
     "lru-cache": "11.5.0"
   },
@@ -57,8 +57,8 @@
     "@verdaccio/logger": "workspace:9.0.0-next-9.24",
     "@verdaccio/types": "workspace:14.0.0-next-9.11",
     "http-errors": "2.0.1",
-    "supertest": "7.1.4",
     "rimraf": "6.1.3",
+    "supertest": "7.1.4",
     "vite": "8.1.5",
     "vitest": "4.1.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,8 +691,8 @@ importers:
         specifier: 5.2.1
         version: 5.2.1
       express-rate-limit:
-        specifier: 8.5.2
-        version: 8.5.2(express@5.2.1)
+        specifier: 8.6.0
+        version: 8.6.0(express@5.2.1)
       lodash-es:
         specifier: 4.18.1
         version: 4.18.1
@@ -4080,8 +4080,8 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.5.2:
-    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+  express-rate-limit@8.6.0:
+    resolution: {integrity: sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -4118,8 +4118,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4426,8 +4426,8 @@ packages:
   inline-style-parser@0.2.2:
     resolution: {integrity: sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ==}
 
-  ip-address@10.2.0:
-    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+  ip-address@10.4.0:
+    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -8162,7 +8162,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8916,10 +8916,13 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.5.2(express@5.2.1):
+  express-rate-limit@8.6.0(express@5.2.1):
     dependencies:
+      debug: 4.4.3
       express: 5.2.1
-      ip-address: 10.2.0
+      ip-address: 10.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   express@5.2.1:
     dependencies:
@@ -8984,7 +8987,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -9315,7 +9318,7 @@ snapshots:
 
   inline-style-parser@0.2.2: {}
 
-  ip-address@10.2.0: {}
+  ip-address@10.4.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
### Summary

Adds a short-lived in-memory cache for successful legacy AES token authentication. This avoids re-running password verification, including bcrypt-backed htpasswd verification, on every authenticated request that reuses the same legacy token.

The cache is enabled by default and configurable under:

```yaml
server:
  legacyAuthCache:
    enabled: true
    maxEntries: 1000
    ttlMs: 300000
```

Concurrent requests using the same token share the same in-flight authentication result, reducing bcrypt contention during parallel publish workloads. The cache is bounded by TTL and max entry count, and can be disabled with `server.legacyAuthCache.enabled: false`.

Also updates `express-rate-limit` and refreshes transitive audit fixes for `fast-uri` and `ip-address`.