### PR TITLE
fix: lower the default legacy auth cache

### DIFF
--- a/.changeset/legacy-auth-cache-ttl.md
+++ b/.changeset/legacy-auth-cache-ttl.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/auth': patch
+'@verdaccio/config': patch
+---
+
+Disable the legacy auth cache by default; it must now be opted in via `server.legacyAuthCache.enabled: true`. While enabled, changed or revoked credentials stay valid until the cached entry expires, so the default TTL is 30 seconds (down from 5 minutes) and remains configurable via `server.legacyAuthCache.ttlMs`. Concurrent requests for the same token still share a single cache write from the leader request instead of each re-writing the entry.

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -572,12 +572,11 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
       }
 
       const { user, password } = credentials;
-      const completeAuth = (err: VerdaccioError | null, user?: RemoteUser): void => {
+      const applyAuthResult = (err: VerdaccioError | null, user?: RemoteUser): void => {
         if (!err && user) {
           req.remote_user = credentials.tokenKey
             ? { ...user, token: { key: credentials.tokenKey } }
             : user;
-          this.setLegacyAuthCacheEntry(cacheKey, req.remote_user);
           debug('generating a remote user');
           next();
         } else {
@@ -586,20 +585,27 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
           next(err || errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
         }
       };
-      if (this.enqueueLegacyAuthCacheWaiter(cacheKey, completeAuth)) {
+      // concurrent requests for the same token wait for the in-flight one
+      if (this.enqueueLegacyAuthCacheWaiter(cacheKey, applyAuthResult)) {
         return;
       }
 
       debug('authenticating %o', user);
+      const onAuthComplete = (err: VerdaccioError | null, user?: RemoteUser): void => {
+        // only the leader writes the cache; waiters just reuse its result
+        if (!err && user) {
+          this.setLegacyAuthCacheEntry(
+            cacheKey,
+            credentials.tokenKey ? { ...user, token: { key: credentials.tokenKey } } : user
+          );
+        }
+        applyAuthResult(err, user);
+        this.resolveLegacyAuthCacheWaiters(cacheKey, err, user);
+      };
       try {
-        this.authenticate(user, password, (err, user): void => {
-          completeAuth(err, user);
-          this.resolveLegacyAuthCacheWaiters(cacheKey, err, user);
-        });
+        this.authenticate(user, password, onAuthComplete);
       } catch (err: any) {
-        const authError = errorUtils.getInternalError(err?.message);
-        completeAuth(authError);
-        this.resolveLegacyAuthCacheWaiters(cacheKey, authError);
+        onAuthComplete(errorUtils.getInternalError(err?.message));
       }
     } else {
       // we force npm client to ask again with basic authentication
@@ -647,12 +653,13 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
   }
 
   private isLegacyAuthCacheEnabled(): boolean {
-    return this.config.server?.legacyAuthCache?.enabled !== false;
+    // opt-in: disabled unless explicitly turned on via config
+    return this.config.server?.legacyAuthCache?.enabled === true;
   }
 
   private getLegacyAuthCacheTtlMs(): number {
     const ttlMs = this.config.server?.legacyAuthCache?.ttlMs;
-    return typeof ttlMs === 'number' && ttlMs > 0 ? ttlMs : 5 * 60 * 1000;
+    return typeof ttlMs === 'number' && ttlMs > 0 ? ttlMs : 30 * 1000;
   }
 
   private getLegacyAuthCacheMaxEntries(): number {

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -661,7 +661,10 @@ describe('AuthTest', () => {
 
           test('should cache a successful legacy auth token', async () => {
             const payload = 'juan:password';
-            const config: Config = new AppConfig({ ...authProfileConf });
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
             config.checkSecretKey(TEST_SECRET);
             const auth = new Auth(config, logger);
             await auth.init();
@@ -685,7 +688,10 @@ describe('AuthTest', () => {
 
           test('should not cache basic auth in legacy auth mode', async () => {
             const payload = 'juan:password';
-            const config: Config = new AppConfig({ ...authProfileConf });
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
             config.checkSecretKey(TEST_SECRET);
             const auth = new Auth(config, logger);
             await auth.init();
@@ -708,7 +714,10 @@ describe('AuthTest', () => {
 
           test('should share an in-flight legacy auth token verification', async () => {
             const payload = 'juan:password';
-            const config: Config = new AppConfig({ ...authProfileConf });
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
             config.checkSecretKey(TEST_SECRET);
             const auth = new Auth(config, logger);
             await auth.init();
@@ -739,7 +748,10 @@ describe('AuthTest', () => {
 
           test('should clear in-flight legacy auth token verification when authenticate throws', async () => {
             const payload = 'juan:password';
-            const config: Config = new AppConfig({ ...authProfileConf });
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
             config.checkSecretKey(TEST_SECRET);
             const auth = new Auth(config, logger);
             await auth.init();
@@ -764,7 +776,10 @@ describe('AuthTest', () => {
 
           test('should authenticate again when the legacy auth token changes', async () => {
             const payload = 'juan:password';
-            const config: Config = new AppConfig({ ...authProfileConf });
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
             config.checkSecretKey(TEST_SECRET);
             const auth = new Auth(config, logger);
             await auth.init();
@@ -787,12 +802,9 @@ describe('AuthTest', () => {
             authenticateSpy.mockRestore();
           });
 
-          test('should allow disabling the legacy auth token cache', async () => {
+          test('should not cache the legacy auth token by default', async () => {
             const payload = 'juan:password';
-            const config: Config = new AppConfig({
-              ...authProfileConf,
-              server: { legacyAuthCache: { enabled: false } },
-            });
+            const config: Config = new AppConfig({ ...authProfileConf });
             config.checkSecretKey(TEST_SECRET);
             const auth = new Auth(config, logger);
             await auth.init();

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -136,6 +136,14 @@ server:
   # Allow `req.ip` to resolve properly when Verdaccio is behind a proxy or load-balancer
   # https://expressjs.com/en/guide/behind-proxies.html
   # trustProxy: '127.0.0.1'
+  # Cache successful legacy (Bearer) auth token validations to reduce load on the
+  # auth backend (basic-auth requests are never cached). Disabled by default:
+  # while enabled, changed or revoked credentials stay valid until the cached
+  # entry expires (ttlMs). Enable only if you understand that trade-off.
+  # legacyAuthCache:
+  #   enabled: true
+  #   ttlMs: 30000      # how long a validation is cached, in ms (default 30s)
+  #   maxEntries: 1000  # max cached tokens before the oldest are evicted
 
 # https://verdaccio.org/docs/configuration#offline-publish
 # publish:

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -132,6 +132,14 @@ server:
   # Allow `req.ip` to resolve properly when Verdaccio is behind a proxy or load-balancer
   # https://expressjs.com/en/guide/behind-proxies.html
   # trustProxy: '127.0.0.1'
+  # Cache successful legacy (Bearer) auth token validations to reduce load on the
+  # auth backend (basic-auth requests are never cached). Disabled by default:
+  # while enabled, changed or revoked credentials stay valid until the cached
+  # entry expires (ttlMs). Enable only if you understand that trade-off.
+  # legacyAuthCache:
+  #   enabled: true
+  #   ttlMs: 30000      # how long a validation is cached, in ms (default 30s)
+  #   maxEntries: 1000  # max cached tokens before the oldest are evicted
 
 # https://verdaccio.org/docs/configuration#offline-publish
 # publish:

--- a/packages/config/src/serverSettings.ts
+++ b/packages/config/src/serverSettings.ts
@@ -8,8 +8,8 @@ export default {
   // deprecated
   keepAliveTimeout: 60,
   legacyAuthCache: {
-    enabled: true,
+    enabled: false,
     maxEntries: 1000,
-    ttlMs: 5 * 60 * 1000,
+    ttlMs: 30 * 1000,
   },
 };

--- a/packages/config/test/config.spec.ts
+++ b/packages/config/test/config.spec.ts
@@ -82,9 +82,9 @@ describe('check basic content parsed file', () => {
     expect(config.server).toBeDefined();
     expect(config.server.dotfiles).toEqual('ignore');
     expect(config.server.legacyAuthCache).toEqual({
-      enabled: true,
+      enabled: false,
       maxEntries: 1000,
-      ttlMs: 300000,
+      ttlMs: 30000,
     });
     // hideStaticLogs is not set in default config, defaults to true at runtime
     expect(config.server.hideStaticLogs).toBeUndefined();
@@ -106,17 +106,27 @@ describe('check basic content parsed file', () => {
     checkDefaultConfPackages(config);
   });
 
-  test('should keep legacy auth cache enabled when partially configured', () => {
+  test('should keep legacy auth cache disabled by default when partially configured', () => {
     const config = new Config({
       ...getDefaultConfig(),
       server: { legacyAuthCache: { maxEntries: 50 } },
     });
 
     expect(config.server.legacyAuthCache).toEqual({
-      enabled: true,
+      enabled: false,
       maxEntries: 50,
-      ttlMs: 300000,
+      ttlMs: 30000,
     });
+  });
+
+  test('should keep default rateLimit fields when partially overridden', () => {
+    const config = new Config({
+      ...getDefaultConfig(),
+      server: { rateLimit: { max: 100 } },
+    });
+
+    // a partial rateLimit override keeps the default windowMs instead of dropping it
+    expect(config.server.rateLimit).toEqual({ windowMs: 1000, max: 100 });
   });
 });
 


### PR DESCRIPTION
## What

The legacy auth cache (added in #6133) is now **disabled by default** — opt in via `server.legacyAuthCache.enabled: true`. When enabled, the default TTL is lowered to **30 seconds**.

## Why

Reduce the window in which changed or revoked credentials stay valid, following up on #6133. The cache is off unless explicitly turned on, and the TTL stays configurable via `server.legacyAuthCache.ttlMs`.

## Changes

- `@verdaccio/config`: default `legacyAuthCache.enabled` → `false`, `ttlMs` → `30 * 1000`.
- `@verdaccio/auth`: cache is opt-in (`enabled === true`); only the leader request writes the cache while concurrent requests for the same token reuse its result.
- `default.yaml`: documented commented `server.legacyAuthCache` block.
