### PR TITLE
fix(ui): keep homepage action icon legible on hover

### DIFF
--- a/.changeset/fuzzy-icons-hover.md
+++ b/.changeset/fuzzy-icons-hover.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+fix(ui): keep the homepage action icon legible on hover

--- a/packages/ui-components/src/components/ActionBar/ActionBar.test.tsx
+++ b/packages/ui-components/src/components/ActionBar/ActionBar.test.tsx
@@ -49,6 +49,13 @@ describe('<ActionBar /> component', () => {
     });
   });
 
+  test('should use the default color variant for the homepage button', async () => {
+    renderWithRouteDetail(<ActionBar packageMeta={defaultPackageMeta} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('HomeIcon').closest('button')).toHaveClass('MuiFab-default');
+    });
+  });
+
   test('should not render if data is missing', async () => {
     renderWithRouteDetail(<ActionBar packageMeta={undefined} />);
     await waitFor(() => {

--- a/packages/ui-components/src/components/ActionBar/ActionBarAction.tsx
+++ b/packages/ui-components/src/components/ActionBar/ActionBarAction.tsx
@@ -47,7 +47,7 @@ const ActionBarAction: React.FC<ActionBarActionProps> = ({ type, link, action })
       return (
         <Tooltip title={t('action-bar-action.visit-home-page') as string}>
           <LinkExternal to={link} variant="button">
-            <Fab color="primary" size="small">
+            <Fab size="small">
               <HomeIcon />
             </Fab>
           </LinkExternal>


### PR DESCRIPTION


https://github.com/user-attachments/assets/1479070f-e780-466b-af28-cb5eb21b146d

<img width="304" height="108" alt="Screenshot 2026-08-17 at 23 18 23" src="https://github.com/user-attachments/assets/151863ee-df07-4665-9278-0956453eb023" />

<img width="315" height="93" alt="Screenshot 2026-08-17 at 23 18 32" src="https://github.com/user-attachments/assets/585a7c5d-4ed0-499b-b7ba-55f344b9353b" />


Summary
- keep the homepage action on the default Fab color variant
- align its hover contrast with the other action buttons
- add regression coverage and a patch changeset

Testing
- `/opt/homebrew/bin/pnpm --filter @verdaccio/ui-components test -- ActionBar.test.tsx`
- `/opt/homebrew/bin/pnpm --filter @verdaccio/ui-components type-check`
- `/opt/homebrew/bin/pnpm lint`
- `/opt/homebrew/bin/pnpm format:check`
- `/opt/homebrew/bin/pnpm --filter @verdaccio/ui-components exec vite build`

---

My OCD forced me to fix it 😅