### PR TITLE
perf(package-filter): avoid unnecessary manifest cleanup

### DIFF
--- a/.changeset/quiet-otters-filter.md
+++ b/.changeset/quiet-otters-filter.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/package-filter': patch
+---
+
+perf(package-filter): skip manifest cleanup when no filter changes a package

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "prepare": "husky",
     "clean": "pnpm --filter \"./packages/**\" run clean",
     "build": "pnpm --filter \"./packages/**\" build",
-    "docker": "docker build -t verdaccio/verdaccio:local . --no-cache",
+    "docker": "docker build -t verdaccio/verdaccio:local-master . --no-cache",
     "docker:test": "docker build -f packages/tools/Dockerfile -t verdaccio/ci-test:local . --no-cache",
     "format": "oxfmt",
     "format:check": "oxfmt --check",

--- a/packages/plugins/package-filter/src/packageFilter.ts
+++ b/packages/plugins/package-filter/src/packageFilter.ts
@@ -79,6 +79,23 @@ export class PackageFilterPlugin
       'package-filter processing @{name} (@{versionCount} versions)'
     );
 
+    let earliestDateThreshold: Date | null = null;
+    if (minAgeMs) {
+      earliestDateThreshold = new Date(Date.now() - minAgeMs);
+    }
+
+    if (dateThreshold && (!earliestDateThreshold || dateThreshold < earliestDateThreshold)) {
+      earliestDateThreshold = dateThreshold;
+    }
+
+    // Fast path: when no filter is configured there is nothing this plugin can
+    // change. Avoid cloning and cleanup for the `npm search` hot path, which
+    // invokes filter_metadata once per matched package.
+    if (blockRules.size === 0 && !excludeDeprecated && !earliestDateThreshold) {
+      debug('no filters configured, returning manifest untouched for %s', manifest.name);
+      return manifest as Manifest;
+    }
+
     let newManifest = getManifestClone(manifest);
     const allowMatch = matchRules(newManifest, allowRules);
 
@@ -88,15 +105,6 @@ export class PackageFilterPlugin
 
     if (excludeDeprecated) {
       newManifest = filterDeprecatedVersions(newManifest, allowMatch);
-    }
-
-    let earliestDateThreshold: Date | null = null;
-    if (minAgeMs) {
-      earliestDateThreshold = new Date(Date.now() - minAgeMs);
-    }
-
-    if (dateThreshold && (!earliestDateThreshold || dateThreshold < earliestDateThreshold)) {
-      earliestDateThreshold = dateThreshold;
     }
 
     if (earliestDateThreshold) {
@@ -112,15 +120,24 @@ export class PackageFilterPlugin
       newManifest = filterVersionsByPublishDate(newManifest, earliestDateThreshold, allowMatch);
     }
 
-    cleanupTags(newManifest);
-    setupLatestTag(newManifest);
-    cleanupTime(newManifest);
-    setupCreatedAndModified(newManifest);
-    cleanupDistFiles(newManifest);
-
     const filteredCount = Object.keys(newManifest.versions).length;
     const removedCount = versionCount - filteredCount;
-    if (filteredCount !== versionCount) {
+    // The cleanup passes only repair inconsistencies introduced by filtering:
+    // orphaned dist-tags/time/_distfiles entries and a `latest` tag pointing at a
+    // removed version. When the filters left the manifest untouched, it is
+    // already consistent, so the passes are skipped.
+    // `readme` changing is the signal that the count-preserving replace strategy
+    // rewrote version content and cleanup still needs to run.
+    const wasModified = removedCount > 0 || newManifest.readme !== manifest.readme;
+    if (wasModified) {
+      cleanupTags(newManifest);
+      setupLatestTag(newManifest);
+      cleanupTime(newManifest);
+      setupCreatedAndModified(newManifest);
+      cleanupDistFiles(newManifest);
+    }
+
+    if (removedCount > 0) {
       debug(
         'filtered %s: %d -> %d versions (%d removed)',
         manifest.name,

--- a/packages/plugins/package-filter/src/utils/manifestUtils.ts
+++ b/packages/plugins/package-filter/src/utils/manifestUtils.ts
@@ -120,9 +120,25 @@ export function setupCreatedAndModified(manifest: Manifest): void {
     return;
   }
 
-  const sortedTimes = times.sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
-  time.created = sortedTimes[0];
-  time.modified = sortedTimes[sortedTimes.length - 1];
+  // Single O(n) pass for the earliest/latest publication time instead of an
+  // O(n log n) sort; the result is identical but cheaper on large manifests.
+  let earliest = times[0];
+  let latest = times[0];
+  let earliestMs = new Date(earliest).getTime();
+  let latestMs = earliestMs;
+  for (let i = 1; i < times.length; i++) {
+    const currentMs = new Date(times[i]).getTime();
+    if (currentMs < earliestMs) {
+      earliestMs = currentMs;
+      earliest = times[i];
+    }
+    if (currentMs > latestMs) {
+      latestMs = currentMs;
+      latest = times[i];
+    }
+  }
+  time.created = earliest;
+  time.modified = latest;
 }
 
 /**

--- a/packages/plugins/package-filter/test/manifestUtils.test.ts
+++ b/packages/plugins/package-filter/test/manifestUtils.test.ts
@@ -148,6 +148,59 @@ describe('setupLatestTag', () => {
 });
 
 describe('setupCreatedAndModified', () => {
+  test('sets created to the earliest and modified to the latest publish time', () => {
+    const manifest = createManifest({
+      time: {
+        '1.0.0': '2020-01-01T00:00:00.000Z',
+        '2.0.0': '2022-06-01T00:00:00.000Z',
+        '3.0.0': '2021-01-01T00:00:00.000Z',
+      },
+    });
+
+    setupCreatedAndModified(manifest);
+
+    expect(manifest.time!.created).toBe('2020-01-01T00:00:00.000Z');
+    expect(manifest.time!.modified).toBe('2022-06-01T00:00:00.000Z');
+  });
+
+  test('is order-independent', () => {
+    const manifest = createManifest({
+      time: {
+        '3.0.0': '2021-01-01T00:00:00.000Z',
+        '1.0.0': '2020-01-01T00:00:00.000Z',
+        '2.0.0': '2022-06-01T00:00:00.000Z',
+      },
+    });
+
+    setupCreatedAndModified(manifest);
+
+    expect(manifest.time!.created).toBe('2020-01-01T00:00:00.000Z');
+    expect(manifest.time!.modified).toBe('2022-06-01T00:00:00.000Z');
+  });
+
+  test('honours millisecond precision', () => {
+    const manifest = createManifest({
+      time: {
+        '1.0.0': '2024-01-01T00:00:00.000Z',
+        '1.0.1': '2024-01-01T00:00:00.123Z',
+      },
+    });
+
+    setupCreatedAndModified(manifest);
+
+    expect(manifest.time!.created).toBe('2024-01-01T00:00:00.000Z');
+    expect(manifest.time!.modified).toBe('2024-01-01T00:00:00.123Z');
+  });
+
+  test('does not set created/modified for an empty time object', () => {
+    const manifest = createManifest({ time: {} });
+
+    setupCreatedAndModified(manifest);
+
+    expect(manifest.time!.created).toBeUndefined();
+    expect(manifest.time!.modified).toBeUndefined();
+  });
+
   test('handles manifest without time property', () => {
     const manifest = createManifest({ time: undefined });
     expect(() => setupCreatedAndModified(manifest)).not.toThrow();

--- a/packages/plugins/package-filter/test/packageFilter.test.ts
+++ b/packages/plugins/package-filter/test/packageFilter.test.ts
@@ -827,6 +827,50 @@ describe('PackageFilterPlugin', () => {
     });
   });
 
+  // `npm search` invokes filter_metadata once per matched package, so the filter
+  // must do as little work as possible for packages it does not actually filter.
+  // See https://github.com/verdaccio/verdaccio/issues/5837
+  describe('search performance', () => {
+    test('returns the same manifest reference when no filters are configured', async function () {
+      const plugin = new PackageFilterPlugin({}, pluginOptions);
+
+      const result = await plugin.filter_metadata(babelTestManifest);
+      expect(result).toBe(babelTestManifest);
+    });
+
+    test('skips the cleanup passes for packages no rule applies to', async function () {
+      const config = {
+        block: [{ package: 'some-other-package', versions: '>1.0.0' }],
+      };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+      const manifestWithOrphans = {
+        ...babelTestManifest,
+        'dist-tags': { latest: '3.0.0', legacy: '9.9.9' },
+        _distfiles: {
+          'orphan.tgz': { url: 'https://registry.npmjs.org/orphan.tgz' },
+        },
+      } as unknown as Manifest;
+
+      const result = await plugin.filter_metadata(manifestWithOrphans);
+
+      expect(getVersionKeys(result)).toEqual(['1.0.0', '1.5.0', '3.0.0']);
+      expect(result['dist-tags']).toHaveProperty('legacy', '9.9.9');
+      expect(result._distfiles).toHaveProperty('orphan.tgz');
+    });
+
+    test('still runs the cleanup passes when a version is removed', async function () {
+      const config = {
+        block: [{ package: '@testaccio/test', versions: '1.7.0' }],
+      };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(testaccioManifest);
+
+      expect(getVersionKeys(result)).not.toContain('1.7.0');
+      expect(result._distfiles).not.toHaveProperty('testaccio-test-1.7.0.tgz');
+    });
+  });
+
   describe('manifest validity', () => {
     test('empty package does not break the plugin', async function () {
       const config = {

--- a/packages/verdaccio/package.json
+++ b/packages/verdaccio/package.json
@@ -21,7 +21,7 @@
     "ge:docs": "typedoc src/index.ts --tsconfig tsconfig.build.json --plugin typedoc-plugin-markdown",
     "build": "vite build",
     "code:docker-build": "vite build",
-    "build:docker": "docker build -t verdaccio/verdaccio:local . --no-cache"
+    "build:docker": "docker build -t verdaccio/verdaccio:local-master . --no-cache"
   },
   "author": {
     "name": "Juan Picado",


### PR DESCRIPTION
## Context

`@verdaccio/package-filter` on `8.x` had a few performance improvements that were missing on `master` after `excludeDeprecated` was added:

- return the original manifest when no filters are configured, avoiding clone and cleanup work in the `npm search` hot path;
- run manifest cleanup only when filtering actually changes the manifest;
- calculate `created` and `modified` in a single O(n) pass instead of sorting all timestamps.

## References

This ports the package-filter performance work that landed on `8.x` but was not present on `master`:

- `dfa2903ee` / #5944 - `perf(package-filter): skip manifest cleanup for packages that are not filtered`

## Changes

- Integrates the fast path with the existing `excludeDeprecated` option, so that filter is still applied when enabled.
- Restores conditional cleanup for `dist-tags`, `time`, `created`/`modified`, and `_distfiles`.
- Changes `setupCreatedAndModified` to a single O(n) pass.
- Adds tests for the search hot path, conditional cleanup, and timestamp calculation.
- Adds a patch changeset for `@verdaccio/package-filter`.
- Includes the existing Docker script changes to use the local `verdaccio/verdaccio:local-master` tag.

## Tests

- `pnpm --filter @verdaccio/package-filter test`
- `pnpm --filter @verdaccio/package-filter build`
