### PR TITLE
feat(package-filter): exclude deprecated versions

### DIFF
--- a/.changeset/silent-filter.md
+++ b/.changeset/silent-filter.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/package-filter': minor
+---
+
+feat(package-filter): add excludeDeprecated option

--- a/packages/plugins/package-filter/README.md
+++ b/packages/plugins/package-filter/README.md
@@ -7,8 +7,6 @@
 [![Documentation](https://img.shields.io/badge/Help-Verdaccio?style=flat&logo=Verdaccio&label=Verdaccio&color=cd4000)](https://verdaccio.org/docs)
 [![Discord](https://img.shields.io/badge/Chat-Discord?style=flat&logo=Discord&label=Discord&color=cd4000)](https://discord.com/channels/388674437219745793)
 
-> **Note:** This package is only intended to be used with Verdaccio 6.x.
-
 A built-in Verdaccio filter plugin for controlling which package versions are visible to consumers. It intercepts every manifest response and removes or replaces versions that match configurable rules.
 
 ## Use Cases
@@ -68,6 +66,16 @@ filters:
 ```
 
 When both `minAgeDays` and `dateThreshold` are set, the **earlier** cutoff wins (more versions are filtered).
+
+### Exclude Deprecated Versions
+
+Hide versions whose metadata contains a non-empty `deprecated` notice.
+
+```yaml
+filters:
+  '@verdaccio/package-filter':
+    excludeDeprecated: true
+```
 
 ### Block by Scope
 

--- a/packages/plugins/package-filter/src/config/parser.ts
+++ b/packages/plugins/package-filter/src/config/parser.ts
@@ -67,9 +67,12 @@ export function parseConfig(config: PluginConfig): ParsedConfig {
     minAgeMs = minAgeDays * 24 * 60 * 60 * 1000;
   }
 
+  const excludeDeprecated = config.excludeDeprecated === true;
+
   return {
     dateThreshold,
     minAgeMs,
+    excludeDeprecated,
     blockRules: blockMap,
     allowRules: allowMap,
   };

--- a/packages/plugins/package-filter/src/config/types.ts
+++ b/packages/plugins/package-filter/src/config/types.ts
@@ -20,6 +20,11 @@ export interface PluginConfig {
    * the earlier (more restrictive) date wins.
    */
   minAgeDays?: number;
+  /**
+   * When true, versions whose metadata contains a deprecation notice
+   * will be removed from the manifest.
+   */
+  excludeDeprecated?: boolean;
   block?: ConfigRule[];
   allow?: ConfigRule[];
 }
@@ -35,6 +40,7 @@ export type ParsedRule = ParsedConfigRule | PackageScopeLevel;
 export interface ParsedConfig {
   dateThreshold: Date | null;
   minAgeMs: number | null;
+  excludeDeprecated: boolean;
   blockRules: Map<string, ParsedRule>;
   allowRules: Map<string, ParsedRule>;
 }

--- a/packages/plugins/package-filter/src/filtering/deprecated.ts
+++ b/packages/plugins/package-filter/src/filtering/deprecated.ts
@@ -1,0 +1,45 @@
+import buildDebug from 'debug';
+
+import type { Manifest } from '@verdaccio/types';
+
+import { resolveAllowList } from './matcher';
+import type { MatchResult } from './types';
+
+const debug = buildDebug('verdaccio:plugin:package-filter:filter');
+
+/**
+ * Filter out all package versions that have a deprecation notice.
+ */
+export function filterDeprecatedVersions(
+  manifest: Manifest,
+  allowMatch: MatchResult | undefined
+): Manifest {
+  const { allowAll, whitelistedVersions } = resolveAllowList(allowMatch);
+  if (allowAll) {
+    return manifest;
+  }
+
+  const removedVersions: string[] = [];
+
+  Object.entries(manifest.versions).forEach(([version, versionData]) => {
+    if (whitelistedVersions.includes(version)) {
+      return;
+    }
+
+    if (typeof versionData.deprecated === 'string' && versionData.deprecated.length > 0) {
+      removedVersions.push(version);
+      delete manifest.versions[version];
+    }
+  });
+
+  if (removedVersions.length > 0) {
+    debug(
+      'deprecated filter removed %d versions from %s: %o',
+      removedVersions.length,
+      manifest.name,
+      removedVersions
+    );
+  }
+
+  return manifest;
+}

--- a/packages/plugins/package-filter/src/filtering/matcher.ts
+++ b/packages/plugins/package-filter/src/filtering/matcher.ts
@@ -108,3 +108,17 @@ export function matchRules(
     versions: matchedVersions,
   };
 }
+
+/**
+ * Derive the allow-list outcome from a precomputed allow-rule match:
+ * whether the whole package/scope is allow-listed, and which versions
+ * (if any) are individually whitelisted.
+ */
+export function resolveAllowList(allowMatch: MatchResult | undefined): {
+  allowAll: boolean;
+  whitelistedVersions: string[];
+} {
+  const allowAll =
+    !!allowMatch && (allowMatch.type === MatchType.SCOPE || allowMatch.type === MatchType.PACKAGE);
+  return { allowAll, whitelistedVersions: allowMatch?.versions ?? [] };
+}

--- a/packages/plugins/package-filter/src/filtering/packageVersion.ts
+++ b/packages/plugins/package-filter/src/filtering/packageVersion.ts
@@ -4,7 +4,8 @@ import { Range, satisfies } from 'semver';
 import type { Logger, Manifest } from '@verdaccio/types';
 
 import type { ParsedConfigRule, ParsedRule } from '../config/types';
-import { matchRules } from './matcher';
+import { matchRules, resolveAllowList } from './matcher';
+import type { MatchResult } from './types';
 import { MatchType } from './types';
 
 const debug = buildDebug('verdaccio:plugin:package-filter:filter');
@@ -29,14 +30,11 @@ const debug = buildDebug('verdaccio:plugin:package-filter:filter');
 export function filterBlockedVersions(
   manifest: Manifest,
   blockRules: Map<string, ParsedRule>,
-  allowRules: Map<string, ParsedRule>,
+  allowMatch: MatchResult | undefined,
   logger: Logger
 ): Manifest {
-  const allowMatch = matchRules(manifest, allowRules);
-  if (
-    allowMatch &&
-    (allowMatch.type === MatchType.SCOPE || allowMatch.type === MatchType.PACKAGE)
-  ) {
+  const { allowAll, whitelistedVersions } = resolveAllowList(allowMatch);
+  if (allowAll) {
     // An entire scope or package is whitelisted
     logger.trace({ name: manifest.name }, 'package @{name} is allow-listed, skipping block rules');
     return manifest;
@@ -53,7 +51,6 @@ export function filterBlockedVersions(
     'block rule matched for @{name} (type: @{type})'
   );
 
-  const whitelistedVersions: string[] = allowMatch ? allowMatch.versions : [];
   let blockRule: ParsedConfigRule = {
     versions: [new Range('*')],
     strategy: 'block',

--- a/packages/plugins/package-filter/src/filtering/publishDate.ts
+++ b/packages/plugins/package-filter/src/filtering/publishDate.ts
@@ -2,9 +2,8 @@ import buildDebug from 'debug';
 
 import type { Manifest } from '@verdaccio/types';
 
-import type { ParsedRule } from '../config/types';
-import { matchRules } from './matcher';
-import { MatchType } from './types';
+import { resolveAllowList } from './matcher';
+import type { MatchResult } from './types';
 
 const debug = buildDebug('verdaccio:plugin:package-filter:filter');
 
@@ -14,13 +13,10 @@ const debug = buildDebug('verdaccio:plugin:package-filter:filter');
 export function filterVersionsByPublishDate(
   manifest: Manifest,
   dateThreshold: Date,
-  allowRules: Map<string, ParsedRule>
+  allowMatch: MatchResult | undefined
 ): Manifest {
-  const allowMatch = matchRules(manifest, allowRules);
-  if (
-    allowMatch &&
-    (allowMatch.type === MatchType.SCOPE || allowMatch.type === MatchType.PACKAGE)
-  ) {
+  const { allowAll, whitelistedVersions } = resolveAllowList(allowMatch);
+  if (allowAll) {
     // An entire scope or package is whitelisted
     return manifest;
   }
@@ -31,7 +27,6 @@ export function filterVersionsByPublishDate(
     throw new TypeError(`Time of publication was not provided for package ${name}`);
   }
 
-  const whitelistedVersions: string[] = allowMatch ? allowMatch.versions : [];
   const clearVersions: string[] = [];
 
   Object.keys(versions).forEach((version) => {

--- a/packages/plugins/package-filter/src/packageFilter.ts
+++ b/packages/plugins/package-filter/src/packageFilter.ts
@@ -5,6 +5,8 @@ import type { Logger, Manifest } from '@verdaccio/types';
 
 import { parseConfig } from './config/parser';
 import type { ParsedConfig, PluginConfig } from './config/types';
+import { filterDeprecatedVersions } from './filtering/deprecated';
+import { matchRules } from './filtering/matcher';
 import { filterBlockedVersions } from './filtering/packageVersion';
 import { filterVersionsByPublishDate } from './filtering/publishDate';
 import { jsonLogReplacer } from './utils/jsonUtils';
@@ -61,10 +63,15 @@ export class PackageFilterPlugin
       debug('min age: %d days', minAgeDays);
       this.logger.trace({ minAgeDays }, 'package-filter min age: @{minAgeDays} days');
     }
+    if (this.parsedConfig.excludeDeprecated) {
+      debug('excludeDeprecated enabled');
+      this.logger.trace('package-filter excludeDeprecated is enabled');
+    }
   }
 
   public async filter_metadata(manifest: Readonly<Manifest>): Promise<Manifest> {
-    const { dateThreshold, minAgeMs, blockRules, allowRules } = this.parsedConfig;
+    const { dateThreshold, minAgeMs, excludeDeprecated, blockRules, allowRules } =
+      this.parsedConfig;
     const versionCount = Object.keys(manifest.versions ?? {}).length;
     debug('filtering manifest for %s (%d versions)', manifest.name, versionCount);
     this.logger.trace(
@@ -85,14 +92,20 @@ export class PackageFilterPlugin
     // is nothing this filter can change. Returning the manifest untouched avoids the
     // clone and the cleanup passes below. This matters most for `npm search`, which
     // invokes filter_metadata once per matched package (see issue #5837).
-    if (blockRules.size === 0 && !earliestDateThreshold) {
+    if (blockRules.size === 0 && !excludeDeprecated && !earliestDateThreshold) {
       debug('no filters configured, returning manifest untouched for %s', manifest.name);
       return manifest as Manifest;
     }
 
     let newManifest = getManifestClone(manifest);
+    const allowMatch = matchRules(newManifest, allowRules);
+
     if (blockRules.size > 0) {
-      newManifest = filterBlockedVersions(newManifest, blockRules, allowRules, this.logger);
+      newManifest = filterBlockedVersions(newManifest, blockRules, allowMatch, this.logger);
+    }
+
+    if (excludeDeprecated) {
+      newManifest = filterDeprecatedVersions(newManifest, allowMatch);
     }
 
     if (earliestDateThreshold) {
@@ -105,7 +118,7 @@ export class PackageFilterPlugin
         { name: manifest.name, threshold: earliestDateThreshold.toISOString() },
         'applying date filter for @{name}, cutoff: @{threshold}'
       );
-      newManifest = filterVersionsByPublishDate(newManifest, earliestDateThreshold, allowRules);
+      newManifest = filterVersionsByPublishDate(newManifest, earliestDateThreshold, allowMatch);
     }
 
     const filteredCount = Object.keys(newManifest.versions).length;

--- a/packages/plugins/package-filter/test/manifests.ts
+++ b/packages/plugins/package-filter/test/manifests.ts
@@ -9,6 +9,11 @@ const versionStub: Version = {
   version: '',
 } as Version; // Some properties are omitted on purpose
 
+const deprecatedVersionStub: Version = {
+  ...versionStub,
+  deprecated: 'This version is deprecated, use a newer version',
+} as Version;
+
 export const emptyManifest: Manifest = {} as Manifest;
 
 export const babelTestManifest: Manifest = {
@@ -129,4 +134,112 @@ export const testaccioManifest: Manifest = {
     '2.2.1-next': '2023-03-01T00:00:00.000Z',
   },
   readme: 'It is a testaccio test package',
+};
+
+export const deprecatedManifest: Manifest = {
+  [DIST_TAGS]: { latest: '3.0.0' },
+  _attachments: {},
+  _distfiles: {},
+  _rev: '',
+  _uplinks: {},
+  name: 'deprecated-pkg',
+  versions: {
+    '1.0.0': { ...deprecatedVersionStub, _id: 'deprecated-pkg@1.0.0' },
+    '2.0.0': { ...versionStub, _id: 'deprecated-pkg@2.0.0' },
+    '3.0.0': { ...versionStub, _id: 'deprecated-pkg@3.0.0' },
+  },
+  time: {
+    modified: '2024-01-01T00:00:00.000Z',
+    created: '2020-01-01T00:00:00.000Z',
+    '1.0.0': '2020-01-01T00:00:00.000Z',
+    '2.0.0': '2022-01-01T00:00:00.000Z',
+    '3.0.0': '2024-01-01T00:00:00.000Z',
+  },
+  readme: 'Package with some deprecated versions',
+};
+
+export const emptyDeprecatedManifest: Manifest = {
+  [DIST_TAGS]: { latest: '2.0.0' },
+  _attachments: {},
+  _distfiles: {},
+  _rev: '',
+  _uplinks: {},
+  name: 'empty-deprecated-pkg',
+  versions: {
+    '1.0.0': { ...deprecatedVersionStub, _id: 'empty-deprecated-pkg@1.0.0' },
+    '2.0.0': { ...versionStub, deprecated: '', _id: 'empty-deprecated-pkg@2.0.0' } as Version,
+  },
+  time: {
+    modified: '2023-01-01T00:00:00.000Z',
+    created: '2021-01-01T00:00:00.000Z',
+    '1.0.0': '2021-01-01T00:00:00.000Z',
+    '2.0.0': '2023-01-01T00:00:00.000Z',
+  },
+  readme: 'Package with deprecated version and un-deprecated (empty string) version',
+};
+
+export const latestDeprecatedManifest: Manifest = {
+  [DIST_TAGS]: { latest: '3.0.0' },
+  _attachments: {},
+  _distfiles: {},
+  _rev: '',
+  _uplinks: {},
+  name: 'latest-deprecated-pkg',
+  versions: {
+    '1.0.0': { ...versionStub, _id: 'latest-deprecated-pkg@1.0.0' },
+    '2.0.0': { ...versionStub, _id: 'latest-deprecated-pkg@2.0.0' },
+    '3.0.0': { ...deprecatedVersionStub, _id: 'latest-deprecated-pkg@3.0.0' },
+  },
+  time: {
+    modified: '2024-01-01T00:00:00.000Z',
+    created: '2020-01-01T00:00:00.000Z',
+    '1.0.0': '2020-01-01T00:00:00.000Z',
+    '2.0.0': '2022-01-01T00:00:00.000Z',
+    '3.0.0': '2024-01-01T00:00:00.000Z',
+  },
+  readme: 'Package whose dist-tags.latest points to its newest, deprecated version',
+};
+
+export const allDeprecatedManifest: Manifest = {
+  [DIST_TAGS]: { latest: '2.0.0' },
+  _attachments: {},
+  _distfiles: {},
+  _rev: '',
+  _uplinks: {},
+  name: 'all-deprecated-pkg',
+  versions: {
+    '1.0.0': { ...deprecatedVersionStub, _id: 'all-deprecated-pkg@1.0.0' },
+    '2.0.0': {
+      ...versionStub,
+      deprecated: 'Use @new-scope/pkg instead',
+      _id: 'all-deprecated-pkg@2.0.0',
+    } as Version,
+  },
+  time: {
+    modified: '2023-01-01T00:00:00.000Z',
+    created: '2021-01-01T00:00:00.000Z',
+    '1.0.0': '2021-01-01T00:00:00.000Z',
+    '2.0.0': '2023-01-01T00:00:00.000Z',
+  },
+  readme: 'Entirely deprecated package',
+};
+
+export const scopedDeprecatedManifest: Manifest = {
+  [DIST_TAGS]: { latest: '2.0.0' },
+  _attachments: {},
+  _distfiles: {},
+  _rev: '',
+  _uplinks: {},
+  name: '@myscope/deprecated-lib',
+  versions: {
+    '1.0.0': { ...deprecatedVersionStub, _id: '@myscope/deprecated-lib@1.0.0' },
+    '2.0.0': { ...versionStub, _id: '@myscope/deprecated-lib@2.0.0' },
+  },
+  time: {
+    modified: '2023-01-01T00:00:00.000Z',
+    created: '2021-01-01T00:00:00.000Z',
+    '1.0.0': '2021-01-01T00:00:00.000Z',
+    '2.0.0': '2023-01-01T00:00:00.000Z',
+  },
+  readme: 'Scoped package with deprecated versions',
 };

--- a/packages/plugins/package-filter/test/packageFilter.test.ts
+++ b/packages/plugins/package-filter/test/packageFilter.test.ts
@@ -7,8 +7,13 @@ import type { Manifest } from '@verdaccio/types';
 
 import PackageFilterPlugin from '../src/index';
 import {
+  allDeprecatedManifest,
   babelTestManifest,
+  deprecatedManifest,
+  emptyDeprecatedManifest,
   emptyManifest,
+  latestDeprecatedManifest,
+  scopedDeprecatedManifest,
   testaccioManifest,
   typesNodeManifest,
 } from './manifests';
@@ -680,6 +685,114 @@ describe('PackageFilterPlugin', () => {
         expect(typesResult.versions['2.6.3']._id).toBe('@types/node@1.0.0');
         expect(typesResult.readme).toContain('replaced');
       });
+    });
+  });
+
+  describe('deprecated version filtering', () => {
+    test('excludeDeprecated removes deprecated versions', async function () {
+      const config = { excludeDeprecated: true };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(deprecatedManifest);
+      expect(getVersionKeys(result)).toEqual(['2.0.0', '3.0.0']);
+      expect(getVersionKeys(result)).not.toContain('1.0.0');
+      expect(getLatest(result)).toBe('3.0.0');
+    });
+
+    test('excludeDeprecated removes all versions when all are deprecated', async function () {
+      const config = { excludeDeprecated: true };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(allDeprecatedManifest);
+      expect(getVersionKeys(result)).toEqual([]);
+    });
+
+    test('excludeDeprecated does not affect non-deprecated packages', async function () {
+      const config = { excludeDeprecated: true };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(babelTestManifest);
+      expect(getVersionKeys(result)).toEqual(['1.0.0', '1.5.0', '3.0.0']);
+      expect(getLatest(result)).toBe('3.0.0');
+    });
+
+    test('excludeDeprecated is ignored when set to false', async function () {
+      const config = { excludeDeprecated: false };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(deprecatedManifest);
+      expect(getVersionKeys(result)).toEqual(['1.0.0', '2.0.0', '3.0.0']);
+    });
+
+    test('excludeDeprecated respects allow rules by scope', async function () {
+      const config = {
+        excludeDeprecated: true,
+        allow: [{ scope: '@myscope' }],
+      };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const scopedResult = await plugin.filter_metadata(scopedDeprecatedManifest);
+      expect(getVersionKeys(scopedResult)).toEqual(['1.0.0', '2.0.0']);
+
+      const unscopedResult = await plugin.filter_metadata(deprecatedManifest);
+      expect(getVersionKeys(unscopedResult)).toEqual(['2.0.0', '3.0.0']);
+    });
+
+    test('excludeDeprecated respects allow rules by package', async function () {
+      const config = {
+        excludeDeprecated: true,
+        allow: [{ package: 'deprecated-pkg' }],
+      };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const allowedResult = await plugin.filter_metadata(deprecatedManifest);
+      expect(getVersionKeys(allowedResult)).toEqual(['1.0.0', '2.0.0', '3.0.0']);
+
+      const scopedResult = await plugin.filter_metadata(scopedDeprecatedManifest);
+      expect(getVersionKeys(scopedResult)).toEqual(['2.0.0']);
+    });
+
+    test('excludeDeprecated respects allow rules by version', async function () {
+      const config = {
+        excludeDeprecated: true,
+        allow: [{ package: 'deprecated-pkg', versions: '1.0.0' }],
+      };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(deprecatedManifest);
+      expect(getVersionKeys(result)).toEqual(['1.0.0', '2.0.0', '3.0.0']);
+    });
+
+    test('excludeDeprecated combined with block rules', async function () {
+      const config = {
+        excludeDeprecated: true,
+        block: [{ package: 'deprecated-pkg', versions: '3.0.0' }],
+      };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(deprecatedManifest);
+      expect(getVersionKeys(result)).toEqual(['2.0.0']);
+      expect(getVersionKeys(result)).not.toContain('1.0.0');
+      expect(getVersionKeys(result)).not.toContain('3.0.0');
+    });
+
+    test('excludeDeprecated keeps versions with an empty deprecated string', async function () {
+      const config = { excludeDeprecated: true };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(emptyDeprecatedManifest);
+      expect(getVersionKeys(result)).toEqual(['2.0.0']);
+      expect(getVersionKeys(result)).not.toContain('1.0.0');
+    });
+
+    test('excludeDeprecated reassigns latest when the deprecated version was tagged latest', async function () {
+      const config = { excludeDeprecated: true };
+      const plugin = new PackageFilterPlugin(config, pluginOptions);
+
+      const result = await plugin.filter_metadata(latestDeprecatedManifest);
+      expect(getVersionKeys(result)).toEqual(['1.0.0', '2.0.0']);
+      expect(getVersionKeys(result)).not.toContain('3.0.0');
+      expect(getLatest(result)).toBe('2.0.0');
     });
   });
 

--- a/packages/plugins/package-filter/test/packageVersion.test.ts
+++ b/packages/plugins/package-filter/test/packageVersion.test.ts
@@ -46,9 +46,8 @@ describe('filterBlockedVersions', () => {
     const manifest = createManifest(['1.0.0', '2.0.0']);
     // A rule with empty versions array — defensive guard
     const blockRules = new Map<string, any>([['test-pkg', { versions: [], strategy: 'block' }]]);
-    const allowRules = new Map();
 
-    const result = filterBlockedVersions(manifest, blockRules, allowRules, logger);
+    const result = filterBlockedVersions(manifest, blockRules, undefined, logger);
 
     expect(Object.keys(result.versions)).toEqual(['1.0.0', '2.0.0']);
   });

--- a/packages/plugins/package-filter/test/parser.test.ts
+++ b/packages/plugins/package-filter/test/parser.test.ts
@@ -9,6 +9,7 @@ describe('parseConfig', () => {
     expect(result.allowRules.size).toBe(0);
     expect(result.dateThreshold).toBeNull();
     expect(result.minAgeMs).toBeNull();
+    expect(result.excludeDeprecated).toBe(false);
   });
 
   test('parses scope block rule', () => {
@@ -51,6 +52,11 @@ describe('parseConfig', () => {
   test('parses minAgeDays', () => {
     const result = parseConfig({ minAgeDays: 30 });
     expect(result.minAgeMs).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  test('parses excludeDeprecated only when explicitly enabled', () => {
+    expect(parseConfig({ excludeDeprecated: true }).excludeDeprecated).toBe(true);
+    expect(parseConfig({ excludeDeprecated: false }).excludeDeprecated).toBe(false);
   });
 
   describe('error handling', () => {

--- a/packages/plugins/package-filter/test/publishDate.test.ts
+++ b/packages/plugins/package-filter/test/publishDate.test.ts
@@ -23,9 +23,8 @@ function createManifest(overrides: Partial<Manifest> = {}): Manifest {
 describe('filterVersionsByPublishDate', () => {
   test('throws when manifest has no time property', () => {
     const manifest = createManifest({ time: undefined });
-    const allowRules = new Map();
 
-    expect(() => filterVersionsByPublishDate(manifest, new Date('2024-01-01'), allowRules)).toThrow(
+    expect(() => filterVersionsByPublishDate(manifest, new Date('2024-01-01'), undefined)).toThrow(
       'Time of publication was not provided for package test-pkg'
     );
   });
@@ -36,9 +35,8 @@ describe('filterVersionsByPublishDate', () => {
         // '1.0.0' is missing
       },
     });
-    const allowRules = new Map();
 
-    expect(() => filterVersionsByPublishDate(manifest, new Date('2024-01-01'), allowRules)).toThrow(
+    expect(() => filterVersionsByPublishDate(manifest, new Date('2024-01-01'), undefined)).toThrow(
       'Time of publication was not provided for package test-pkg, version 1.0.0'
     );
   });


### PR DESCRIPTION
## Context

This aligns the `8.x` package-filter plugin with the `excludeDeprecated` feature already available on `master`.

References:

- #6028 - original `excludeDeprecated` implementation by @davidus27
- #6139 - master-side package-filter parity/performance follow-up

## Changes

- Adds the `excludeDeprecated` config option to `@verdaccio/package-filter`.
- Filters package versions whose metadata contains a non-empty `deprecated` notice.
- Preserves allow-list behavior for scopes, packages, and individual versions.
- Reuses the precomputed allow-rule match across block, date, and deprecated filters.
- Keeps the existing `8.x` search fast path and conditional manifest cleanup behavior.
- Documents `excludeDeprecated` in the package README.
- Removes the stale README note saying this package is only intended for Verdaccio 6.x.
- Adds a minor changeset for `@verdaccio/package-filter`.

## Tests

- `CI=true pnpm --filter @verdaccio/package-filter test`
- `CI=true pnpm --filter @verdaccio/package-filter build`
- `CI=true pnpm --filter @verdaccio/package-filter type-check`
