### PR TITLE
perf(auth): backport legacy auth cache to 8.x

### DIFF
--- a/.changeset/legacy-auth-cache-6x.md
+++ b/.changeset/legacy-auth-cache-6x.md
@@ -1,0 +1,7 @@
+---
+'@verdaccio/auth': patch
+'@verdaccio/config': patch
+'@verdaccio/types': patch
+---
+
+Add an opt-in cache for successful legacy AES token authentication. Enable it with `server.legacyAuthCache.enabled: true`; when enabled, the default TTL is 15 seconds and concurrent requests for the same legacy bearer token share the same in-flight authentication result.

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -1,5 +1,6 @@
 import buildDebug from 'debug';
 import _ from 'lodash';
+import { createHash } from 'node:crypto';
 import { HTPasswd } from 'verdaccio-htpasswd';
 
 import { createAnonymousRemoteUser, createRemoteUser } from '@verdaccio/config';
@@ -47,6 +48,21 @@ import {
 } from './utils';
 
 const debug = buildDebug('verdaccio:auth');
+type LegacyAuthCacheEntry = {
+  expiresAt: number;
+  user: RemoteUser;
+};
+
+type LegacyAuthCacheWaiter = (err: VerdaccioError | null, user?: RemoteUser) => void;
+
+function cloneRemoteUser(user: RemoteUser): RemoteUser {
+  return {
+    ...user,
+    groups: user.groups ? [...user.groups] : user.groups,
+    real_groups: user.real_groups ? [...user.real_groups] : user.real_groups,
+    token: user.token ? { ...user.token } : user.token,
+  };
+}
 
 class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
   public config: Config;
@@ -54,6 +70,8 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
   public logger: Logger;
   public plugins: pluginUtils.Auth<Config>[];
   public options: { legacyMergeConfigs: boolean };
+  private legacyAuthCache: Map<string, LegacyAuthCacheEntry>;
+  private legacyAuthCacheWaiters: Map<string, LegacyAuthCacheWaiter[]>;
 
   public constructor(config: Config, logger: Logger, options = { legacyMergeConfigs: false }) {
     this.config = config;
@@ -61,6 +79,8 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     this.logger = logger;
     this.plugins = [];
     this.options = options;
+    this.legacyAuthCache = new Map();
+    this.legacyAuthCacheWaiters = new Map();
     if (!this.secret) {
       throw new TypeError('secret it is required value on initialize the auth class');
     }
@@ -546,23 +566,157 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     const credentials: any = getMiddlewareCredentials(security, secret, authorization);
     debug('api middleware credentials %o', credentials?.name);
     if (credentials) {
+      const cacheKey = this.getLegacyAuthCacheKey(authorization);
+      const cachedUser = this.getLegacyAuthCacheEntry(cacheKey);
+      if (cachedUser) {
+        req.remote_user = cachedUser;
+        debug('generating cached remote user');
+        return next();
+      }
+
       const { user, password, tokenKey } = credentials;
-      debug('authenticating %o', user);
-      this.authenticate(user, password, (err, user): void => {
-        if (!err) {
+      const applyAuthResult = (err: VerdaccioError | null, user?: RemoteUser): void => {
+        if (!err && user) {
           req.remote_user = tokenKey ? { ...user, token: { key: tokenKey } } : user;
           debug('generating a remote user');
           next();
         } else {
           req.remote_user = createAnonymousRemoteUser();
           debug('generating anonymous user');
-          next(err);
+          next(err || errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
         }
-      });
+      };
+
+      if (this.enqueueLegacyAuthCacheWaiter(cacheKey, applyAuthResult)) {
+        return;
+      }
+
+      debug('authenticating %o', user);
+      const onAuthComplete = (err: VerdaccioError | null, user?: RemoteUser): void => {
+        if (!err && user) {
+          this.setLegacyAuthCacheEntry(
+            cacheKey,
+            tokenKey ? { ...user, token: { key: tokenKey } } : user
+          );
+        }
+        applyAuthResult(err, user);
+        this.resolveLegacyAuthCacheWaiters(cacheKey, err, user);
+      };
+
+      try {
+        this.authenticate(user, password, onAuthComplete);
+      } catch (err: any) {
+        onAuthComplete(errorUtils.getInternalError(err?.message));
+      }
     } else {
       // we force npm client to ask again with basic authentication
       debug('legacy invalid header');
       return next(errorUtils.getBadRequest(API_ERROR.BAD_AUTH_HEADER));
+    }
+  }
+
+  private enqueueLegacyAuthCacheWaiter(
+    cacheKey: string | void,
+    waiter: LegacyAuthCacheWaiter
+  ): boolean {
+    if (!cacheKey) {
+      return false;
+    }
+
+    const waiters = this.legacyAuthCacheWaiters.get(cacheKey);
+    if (!waiters) {
+      this.legacyAuthCacheWaiters.set(cacheKey, []);
+      return false;
+    }
+
+    waiters.push(waiter);
+    return true;
+  }
+
+  private resolveLegacyAuthCacheWaiters(
+    cacheKey: string | void,
+    err: VerdaccioError | null,
+    user?: RemoteUser
+  ): void {
+    if (!cacheKey) {
+      return;
+    }
+
+    const waiters = this.legacyAuthCacheWaiters.get(cacheKey);
+    this.legacyAuthCacheWaiters.delete(cacheKey);
+    if (!waiters) {
+      return;
+    }
+
+    for (const waiter of waiters) {
+      waiter(err, user);
+    }
+  }
+
+  private isLegacyAuthCacheEnabled(): boolean {
+    return this.config.server?.legacyAuthCache?.enabled === true;
+  }
+
+  private getLegacyAuthCacheTtlMs(): number {
+    const ttlMs = this.config.server?.legacyAuthCache?.ttlMs;
+    return typeof ttlMs === 'number' && ttlMs > 0 ? ttlMs : 15 * 1000;
+  }
+
+  private getLegacyAuthCacheMaxEntries(): number {
+    const maxEntries = this.config.server?.legacyAuthCache?.maxEntries;
+    return typeof maxEntries === 'number' && maxEntries > 0 ? maxEntries : 1000;
+  }
+
+  private getLegacyAuthCacheKey(authorization: string): string | void {
+    if (!this.isLegacyAuthCacheEnabled()) {
+      return;
+    }
+
+    const { scheme } = parseAuthTokenHeader(authorization);
+    if (scheme.toUpperCase() !== TOKEN_BEARER.toUpperCase()) {
+      return;
+    }
+
+    return createHash('sha256').update(authorization).digest('hex');
+  }
+
+  private getLegacyAuthCacheEntry(cacheKey: string | void): RemoteUser | void {
+    if (!cacheKey) {
+      return;
+    }
+
+    const entry = this.legacyAuthCache.get(cacheKey);
+    if (!entry) {
+      return;
+    }
+
+    if (entry.expiresAt <= Date.now()) {
+      this.legacyAuthCache.delete(cacheKey);
+      return;
+    }
+
+    this.legacyAuthCache.delete(cacheKey);
+    this.legacyAuthCache.set(cacheKey, entry);
+    return cloneRemoteUser(entry.user);
+  }
+
+  private setLegacyAuthCacheEntry(cacheKey: string | void, user: RemoteUser): void {
+    if (!cacheKey) {
+      return;
+    }
+
+    this.legacyAuthCache.set(cacheKey, {
+      expiresAt: Date.now() + this.getLegacyAuthCacheTtlMs(),
+      user: cloneRemoteUser(user),
+    });
+
+    const maxEntries = this.getLegacyAuthCacheMaxEntries();
+    while (this.legacyAuthCache.size > maxEntries) {
+      const oldestKey = this.legacyAuthCache.keys().next().value;
+      if (!oldestKey) {
+        break;
+      }
+      this.legacyAuthCache.delete(oldestKey);
     }
   }
 

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -8,6 +8,7 @@ import {
   HEADERS,
   HTTP_STATUS,
   SUPPORT_ERRORS,
+  TOKEN_BASIC,
   TOKEN_BEARER,
   authUtils,
   errorUtils,
@@ -658,6 +659,172 @@ describe('AuthTest', () => {
               .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
               .expect(HTTP_STATUS.OK);
             expect(res.body.user.name).toEqual('juan');
+          });
+
+          test('should cache a successful legacy auth token when enabled', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
+            config.checkSecretKey('35fabdd29b820d39125e76e6d85cc294');
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate');
+            const token = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+            const res = await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+
+            expect(res.body.user.name).toEqual('juan');
+            expect(authenticateSpy).toHaveBeenCalledTimes(1);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should not cache the legacy auth token by default', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({ ...authProfileConf });
+            config.checkSecretKey('35fabdd29b820d39125e76e6d85cc294');
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate');
+            const token = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+
+            expect(authenticateSpy).toHaveBeenCalledTimes(2);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should not cache basic auth in legacy auth mode', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
+            config.checkSecretKey('35fabdd29b820d39125e76e6d85cc294');
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate');
+            const token = Buffer.from(payload).toString('base64');
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BASIC, token))
+              .expect(HTTP_STATUS.OK);
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BASIC, token))
+              .expect(HTTP_STATUS.OK);
+
+            expect(authenticateSpy).toHaveBeenCalledTimes(2);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should share an in-flight legacy auth token verification', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
+            config.checkSecretKey('35fabdd29b820d39125e76e6d85cc294');
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi
+              .spyOn(auth, 'authenticate')
+              .mockImplementation((_username, _password, cb): void => {
+                setTimeout(() => cb(null, createRemoteUser('juan', ['test'])), 10);
+              });
+            const token = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            const [firstResponse, secondResponse] = await Promise.all([
+              supertest(app)
+                .get(`/`)
+                .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+                .expect(HTTP_STATUS.OK),
+              supertest(app)
+                .get(`/`)
+                .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+                .expect(HTTP_STATUS.OK),
+            ]);
+
+            expect(firstResponse.body.user.name).toEqual('juan');
+            expect(secondResponse.body.user.name).toEqual('juan');
+            expect(authenticateSpy).toHaveBeenCalledTimes(1);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should clear in-flight legacy auth token verification when authenticate throws', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
+            config.checkSecretKey('35fabdd29b820d39125e76e6d85cc294');
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate').mockImplementation((): void => {
+              throw new TypeError('plugin group error: invalid type for function');
+            });
+            const token = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.INTERNAL_ERROR);
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.INTERNAL_ERROR);
+
+            expect(authenticateSpy).toHaveBeenCalledTimes(2);
+            authenticateSpy.mockRestore();
+          });
+
+          test('should authenticate again when the legacy auth token changes', async () => {
+            const payload = 'juan:password';
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              server: { legacyAuthCache: { enabled: true } },
+            });
+            config.checkSecretKey('35fabdd29b820d39125e76e6d85cc294');
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const authenticateSpy = vi.spyOn(auth, 'authenticate');
+            const firstToken = auth.aesEncrypt(payload) as string;
+            const secondToken = auth.aesEncrypt(payload) as string;
+            const app = await getServer(auth);
+
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, firstToken))
+              .expect(HTTP_STATUS.OK);
+            await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, secondToken))
+              .expect(HTTP_STATUS.OK);
+
+            expect(firstToken).not.toEqual(secondToken);
+            expect(authenticateSpy).toHaveBeenCalledTimes(2);
+            authenticateSpy.mockRestore();
           });
 
           test('should handle invalid auth token', async () => {

--- a/packages/config/src/builder.ts
+++ b/packages/config/src/builder.ts
@@ -14,6 +14,7 @@ import type {
   PublishOptions,
   RateLimit,
   Security,
+  ServerSettingsConf,
   UpLinkConf,
   WebConf,
 } from '@verdaccio/types';
@@ -60,6 +61,10 @@ export default class ConfigBuilder {
   public addLogger(log: LoggerConfigItem) {
     this.config.log = log;
     return this;
+  }
+
+  public addLegacyAuthCache(legacyAuthCache: NonNullable<ServerSettingsConf['legacyAuthCache']>) {
+    return this.addServer({ legacyAuthCache });
   }
 
   public addStorage(storage: string | object) {
@@ -118,6 +123,11 @@ export default class ConfigBuilder {
 
   public addUserRateLimit(rateLimit: RateLimit) {
     this.config.userRateLimit = merge(this.config.userRateLimit, rateLimit);
+    return this;
+  }
+
+  public addServer(server: Partial<ServerSettingsConf>) {
+    this.config.server = merge(this.config.server, server);
     return this;
   }
 

--- a/packages/config/src/conf/default.yaml
+++ b/packages/config/src/conf/default.yaml
@@ -126,6 +126,14 @@ server:
   # Allow `req.ip` to resolve properly when Verdaccio is behind a proxy or load-balancer
   # https://expressjs.com/en/guide/behind-proxies.html
   # trustProxy: '127.0.0.1'
+  # Cache successful legacy (Bearer) auth token validations to reduce load on the
+  # auth backend (basic-auth requests are never cached). Disabled by default:
+  # while enabled, changed or revoked credentials stay valid until the cached
+  # entry expires (ttlMs). Enable only if you understand that trade-off.
+  # legacyAuthCache:
+  #   enabled: true
+  #   ttlMs: 15000      # how long a validation is cached, in ms (default 15s)
+  #   maxEntries: 1000  # max cached tokens before the oldest are evicted
 
 # https://verdaccio.org/docs/configuration#offline-publish
 # publish:

--- a/packages/config/src/conf/docker.yaml
+++ b/packages/config/src/conf/docker.yaml
@@ -125,6 +125,14 @@ server:
   # Allow `req.ip` to resolve properly when Verdaccio is behind a proxy or load-balancer
   # https://expressjs.com/en/guide/behind-proxies.html
   # trustProxy: '127.0.0.1'
+  # Cache successful legacy (Bearer) auth token validations to reduce load on the
+  # auth backend (basic-auth requests are never cached). Disabled by default:
+  # while enabled, changed or revoked credentials stay valid until the cached
+  # entry expires (ttlMs). Enable only if you understand that trade-off.
+  # legacyAuthCache:
+  #   enabled: true
+  #   ttlMs: 15000      # how long a validation is cached, in ms (default 15s)
+  #   maxEntries: 1000  # max cached tokens before the oldest are evicted
 
 # https://verdaccio.org/docs/configuration#offline-publish
 # publish:

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -100,7 +100,7 @@ class Config implements AppConfig {
       }),
       config.security
     );
-    this.server = { ...defaultServerSettings, ...config.server };
+    this.server = _.merge({}, defaultServerSettings, config.server);
     this.flags = {
       searchRemote: config.flags?.searchRemote ?? true,
       changePassword: config.flags?.changePassword ?? false,

--- a/packages/config/src/serverSettings.ts
+++ b/packages/config/src/serverSettings.ts
@@ -7,4 +7,9 @@ export default {
   },
   // deprecated
   keepAliveTimeout: 60,
+  legacyAuthCache: {
+    enabled: false,
+    maxEntries: 1000,
+    ttlMs: 15 * 1000,
+  },
 };

--- a/packages/config/test/builder.spec.ts
+++ b/packages/config/test/builder.spec.ts
@@ -153,6 +153,17 @@ describe('Config builder', () => {
     expect(config.getConfig().listen).toEqual({ 0: 'localhost:4873' });
   });
 
+  test('should add legacy auth cache server configuration', () => {
+    const config = ConfigBuilder.build().addLegacyAuthCache({
+      enabled: true,
+      maxEntries: 50,
+      ttlMs: 10000,
+    });
+    expect(config.getConfig().server).toEqual({
+      legacyAuthCache: { enabled: true, maxEntries: 50, ttlMs: 10000 },
+    });
+  });
+
   test('should add https configuration', () => {
     const config = ConfigBuilder.build().addHttps({
       key: '/path/to/key.pem',

--- a/packages/config/test/config.spec.ts
+++ b/packages/config/test/config.spec.ts
@@ -75,6 +75,11 @@ describe('check basic content parsed file', () => {
     expect(config.publish).toBeUndefined();
     expect(config.url_prefix).toBeUndefined();
     expect(config.url_prefix).toBeUndefined();
+    expect(config.server.legacyAuthCache).toEqual({
+      enabled: false,
+      maxEntries: 1000,
+      ttlMs: 15000,
+    });
 
     expect(config.experiments).toBeUndefined();
     expect(config.security).toEqual(defaultSecurity);
@@ -94,6 +99,28 @@ describe('check basic content parsed file', () => {
     expect(config.storage).toBe('/verdaccio/storage/data');
     expect(config.auth.htpasswd.file).toBe('/verdaccio/storage/htpasswd');
     checkDefaultConfPackages(config);
+  });
+
+  test('should keep legacy auth cache disabled by default when partially configured', () => {
+    const config = new Config({
+      ...getDefaultConfig(),
+      server: { legacyAuthCache: { maxEntries: 50 } },
+    });
+
+    expect(config.server.legacyAuthCache).toEqual({
+      enabled: false,
+      maxEntries: 50,
+      ttlMs: 15000,
+    });
+  });
+
+  test('should keep default rateLimit fields when partially overridden', () => {
+    const config = new Config({
+      ...getDefaultConfig(),
+      server: { rateLimit: { max: 100 } },
+    });
+
+    expect(config.server.rateLimit).toEqual({ windowMs: 1000, max: 100 });
   });
 });
 

--- a/packages/core/types/src/configuration.ts
+++ b/packages/core/types/src/configuration.ts
@@ -275,6 +275,11 @@ export type ServerSettingsConf = {
   // express-rate-limit settings
   rateLimit: RateLimit;
   keepAliveTimeout?: number;
+  legacyAuthCache?: {
+    enabled?: boolean;
+    maxEntries?: number;
+    ttlMs?: number;
+  };
   /**
    * Plugins should be prefixed verdaccio-XXXXXX by default.
    * To override the default prefix, use this property without `-`


### PR DESCRIPTION
## Summary

Backports the legacy AES bearer token authentication cache from #6133 and #6134 to the `8.x` package line used by Verdaccio 6.x.

This is an optional feature for specific performance-sensitive cases. The cache is opt-in and remains disabled by default, so existing installations keep their current authentication behavior unless they explicitly enable it:

```yaml
server:
  legacyAuthCache:
    enabled: true
    ttlMs: 15000
    maxEntries: 1000
```

## Details

- Adds a bounded in-memory cache for successful legacy Bearer token authentication.
- Coalesces concurrent requests using the same legacy token so only the leader request performs authentication.
- Keeps Basic auth uncached.
- Uses a 15 second default TTL when the feature is enabled.
- Documents the opt-in configuration in `default.yaml` and `docker.yaml`.
- Uses deep merge for `server` defaults so partial `server.legacyAuthCache` and `server.rateLimit` overrides retain default nested fields.

## Scope

This intentionally ports only the optional auth-cache feature for targeted performance scenarios. It does not include dependency updates from #6133.

## Testing

- `pnpm --filter @verdaccio/auth test auth.spec.ts -- --coverage=false`
- `pnpm --filter @verdaccio/config test config.spec.ts builder.spec.ts -- --coverage=false`
- `pnpm --filter @verdaccio/config test config.spec.ts -- --coverage=false`
- `pnpm --filter @verdaccio/auth run type-check`
- `pnpm --filter @verdaccio/config run type-check`
- `pnpm --filter @verdaccio/types run type-check`
- `git diff --check`
