### PR TITLE
chore: replace `__dirname` with `import.meta.dirname`

### DIFF
--- a/.changeset/heavy-otters-carry.md
+++ b/.changeset/heavy-otters-carry.md
@@ -1,0 +1,12 @@
+---
+'@verdaccio/plugin-verifier': patch
+'@verdaccio/server': patch
+'@verdaccio/ui-components': patch
+'@verdaccio/core': patch
+'@verdaccio/node-api': patch
+'@verdaccio/config': patch
+'@verdaccio/cli': patch
+'@verdaccio/web': patch
+---
+
+chore: replace \_\_dirname with import.meta.dirname

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -45,7 +45,10 @@ async function viteBundle(file: Cypress.FileObject): Promise<string> {
         // which run in the Cypress server process).
         {
           find: /^(node:)?(fs|fs\/promises|child_process|os|path)$/,
-          replacement: path.resolve(import.meta.dirname, './cypress/support/node-builtins-stub.cjs'),
+          replacement: path.resolve(
+            import.meta.dirname,
+            './cypress/support/node-builtins-stub.cjs'
+          ),
         },
       ],
     },

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -45,7 +45,7 @@ async function viteBundle(file: Cypress.FileObject): Promise<string> {
         // which run in the Cypress server process).
         {
           find: /^(node:)?(fs|fs\/promises|child_process|os|path)$/,
-          replacement: path.resolve(__dirname, './cypress/support/node-builtins-stub.cjs'),
+          replacement: path.resolve(import.meta.dirname, './cypress/support/node-builtins-stub.cjs'),
         },
       ],
     },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -33,12 +33,7 @@ export function runCli(options: CliRuntimeOptions = {}): Promise<void> {
 
   const [node, app, ...args] = process.argv;
 
-  const version =
-    options.version ??
-    (pkgUtils.getPackageJson(
-      typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname,
-      '..'
-    ).version as string);
+  const version = options.version ?? (pkgUtils.getPackageJson(import.meta.dirname, '..').version as string);
 
   const cli = new Cli({
     binaryLabel: `verdaccio`,
@@ -50,7 +45,7 @@ export function runCli(options: CliRuntimeOptions = {}): Promise<void> {
   cli.register(InitCommand);
   cli.register(VersionCommand);
 
-  process.on('uncaughtException', function (err) {
+  process.on('uncaughtException', function(err) {
     console.error(
       `uncaught exception, please report (https://github.com/verdaccio/verdaccio/issues) this: \n${err.stack}`
     );

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -33,7 +33,8 @@ export function runCli(options: CliRuntimeOptions = {}): Promise<void> {
 
   const [node, app, ...args] = process.argv;
 
-  const version = options.version ?? (pkgUtils.getPackageJson(import.meta.dirname, '..').version as string);
+  const version =
+    options.version ?? (pkgUtils.getPackageJson(import.meta.dirname, '..').version as string);
 
   const cli = new Cli({
     binaryLabel: `verdaccio`,
@@ -45,7 +46,7 @@ export function runCli(options: CliRuntimeOptions = {}): Promise<void> {
   cli.register(InitCommand);
   cli.register(VersionCommand);
 
-  process.on('uncaughtException', function(err) {
+  process.on('uncaughtException', function (err) {
     console.error(
       `uncaught exception, please report (https://github.com/verdaccio/verdaccio/issues) this: \n${err.stack}`
     );

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -64,8 +64,7 @@ export class InitCommand extends Command {
 
       process.title = web?.title || DEFAULT_PROCESS_NAME;
 
-      const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-      const pkg = pkgUtils.getPackageJson(currentDir, '../..');
+      const pkg = pkgUtils.getPackageJson(import.meta.dirname, '../..');
       const version = getVersionOverride() ?? (pkg.version as string);
       const name = getPkgNameOverride() ?? (pkg.name as string);
 

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -8,8 +8,7 @@ export class VersionCommand extends Command {
   static paths = [[`--version`], [`-v`]];
 
   async execute() {
-    const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-    const version = getVersionOverride() ?? pkgUtils.getPackageJson(currentDir, '../..').version;
+    const version = getVersionOverride() ?? pkgUtils.getPackageVersion('../..');
     this.context.stdout.write(`v${version}\n`);
     process.exit(0);
   }

--- a/packages/config/src/conf/index.ts
+++ b/packages/config/src/conf/index.ts
@@ -2,9 +2,8 @@ import { join } from 'node:path';
 
 import { parseConfigFile } from '../parse';
 
-const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-
 export function getDefaultConfig(fileName: string = 'default.yaml') {
+  const currentDir = import.meta.dirname ?? __dirname;
   const file = join(currentDir, `./${fileName}`);
   return parseConfigFile(file);
 }

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -65,8 +65,7 @@ function createConfigFile(configLocation: SetupDirectory): SetupDirectory {
 }
 
 export function readDefaultConfig(): string {
-  const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-  const pathDefaultConf: string = path.resolve(currentDir, 'conf/default.yaml');
+  const pathDefaultConf: string = path.resolve(import.meta.dirname, 'conf/default.yaml');
   try {
     debug('the path of default config used from %s', pathDefaultConf);
     fs.accessSync(pathDefaultConf, fs.constants.R_OK);

--- a/packages/core/core/src/pkg-utils.ts
+++ b/packages/core/core/src/pkg-utils.ts
@@ -58,3 +58,14 @@ export function getPackageJson(packagePath: string, relativePath: string): Recor
   const packageJsonPath = path.join(packagePath, relativePath, 'package.json');
   return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 }
+
+/**
+ * Get the version of a package.
+ * @param relativePath - The relative path to the package.json file.
+ * @returns The version of the package.
+ */
+export function getPackageVersion(relativePath: string): string {
+  const currentDir = import.meta.dirname ?? __dirname;
+  const packageJson = getPackageJson(currentDir, relativePath);
+  return packageJson.version as string;
+}

--- a/packages/node-api/test/create-server-factory.spec.ts
+++ b/packages/node-api/test/create-server-factory.spec.ts
@@ -12,7 +12,7 @@ const mockApp = (_req: any, res: any) => {
   res.end();
 };
 
-const certsDir = path.join(__dirname, 'partials', 'certs');
+const certsDir = path.join(import.meta.dirname, 'partials', 'certs');
 
 describe('createServerFactory', () => {
   describe('http', () => {

--- a/packages/server/express/src/env.ts
+++ b/packages/server/express/src/env.ts
@@ -1,6 +1,6 @@
 // const path = require('path');
 //
-// const APP_ROOT = path.resolve(__dirname, '../../');
+// const APP_ROOT = path.resolve(import.meta.dirname, '../../');
 //
 // module.exports = {
 //   APP_ROOT,

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -38,8 +38,7 @@ import type { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '../types
 import hookDebug from './debug';
 
 const debug = buildDebug('verdaccio:server');
-const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
-const { version } = pkgUtils.getPackageJson(currentDir, '..');
+const version = pkgUtils.getPackageVersion('..');
 
 export const defineAPI = async function (config: IConfig, storage: Storage): Promise<Express> {
   const auth = new Auth(config, logger);

--- a/packages/tools/plugin-verifier/src/diagnostics.ts
+++ b/packages/tools/plugin-verifier/src/diagnostics.ts
@@ -12,9 +12,8 @@ import type { DiagnosticStep, VerifyPluginOptions } from './types';
 const debug = buildDebug('verdaccio:plugin:verifier:diagnostics');
 
 // createRequire needs an absolute path; works in both ESM and CJS contexts
-const requireModule = createRequire(
-  typeof __filename !== 'undefined' ? __filename : import.meta.url
-);
+// typing __filename is unsafe: node -e and the REPL leak it as a global into ES modules
+const requireModule = import.meta.url ? createRequire(import.meta.url) : createRequire(__filename);
 
 function isValidExport(plugin: any): boolean {
   return typeof plugin === 'function' || typeof plugin?.default === 'function';

--- a/packages/ui-components/tools/generate-github-markdown.mjs
+++ b/packages/ui-components/tools/generate-github-markdown.mjs
@@ -1,11 +1,9 @@
 import { writeFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 
 import githubMarkdownCss from 'generate-github-markdown-css';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const OUTPUT = resolve(__dirname, '../src/components/Readme/github-markdown.css');
+const OUTPUT = resolve(import.meta.dirname, '../src/components/Readme/github-markdown.css');
 
 async function generate() {
   const baseStyles = await githubMarkdownCss({

--- a/packages/ui-components/vitest.config.mjs
+++ b/packages/ui-components/vitest.config.mjs
@@ -83,8 +83,8 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      'verdaccio-ui/components': path.resolve(__dirname, './src/components'),
-      'verdaccio-ui/utils': path.resolve(__dirname, './src/utils'),
+      'verdaccio-ui/components': path.resolve(import.meta.dirname, './src/components'),
+      'verdaccio-ui/utils': path.resolve(import.meta.dirname, './src/utils'),
     },
   },
 });

--- a/packages/web/test/web-assets.test.ts
+++ b/packages/web/test/web-assets.test.ts
@@ -15,7 +15,7 @@ vi.mock('@verdaccio/ui-theme', () => ({ default: (...args: any[]) => mockManifes
 describe('test web server', () => {
   beforeAll(() => {
     mockManifest.mockReturnValue(() => ({
-      staticPath: path.join(__dirname, 'static'),
+      staticPath: path.join(import.meta.dirname, 'static'),
       manifestFiles: {
         js: ['runtime.js', 'vendors.js', 'main.js'],
       },

--- a/vite.lib.config.mjs
+++ b/vite.lib.config.mjs
@@ -1,8 +1,7 @@
 import { spawn } from 'node:child_process';
-import { builtinModules } from 'node:module';
+import { builtinModules, createRequire } from 'node:module';
 import fs from 'node:fs';
 import path from 'node:path';
-import { createRequire } from 'node:module';
 
 import { defineConfig } from 'vite';
 
@@ -54,11 +53,14 @@ export function nativeDts(dirname) {
     async closeBundle() {
       if (emitted) return;
       emitted = true;
-      const tsc = path.join(import.meta.dirname, 'node_modules', '.bin', 'tsc');
+      // Resolve via package.json — TS 7 does not export `./bin/tsc`, and on Windows
+      // `.bin/tsc` is a Unix shell shim that spawn cannot execute directly.
+      const require = createRequire(import.meta.url);
+      const tscJs = path.join(path.dirname(require.resolve('typescript/package.json')), 'bin', 'tsc');
       await new Promise((resolve, reject) => {
         const child = spawn(
-          tsc,
-          ['-p', path.resolve(dirname, 'tsconfig.build.json'), '--emitDeclarationOnly'],
+          process.execPath,
+          [tscJs, '-p', path.resolve(dirname, 'tsconfig.build.json'), '--emitDeclarationOnly'],
           { cwd: dirname, stdio: 'inherit' }
         );
         child.on('error', reject);

--- a/vite.lib.config.mjs
+++ b/vite.lib.config.mjs
@@ -1,7 +1,8 @@
 import { spawn } from 'node:child_process';
-import { builtinModules, createRequire } from 'node:module';
+import { builtinModules } from 'node:module';
 import fs from 'node:fs';
 import path from 'node:path';
+import { createRequire } from 'node:module';
 
 import { defineConfig } from 'vite';
 
@@ -53,14 +54,11 @@ export function nativeDts(dirname) {
     async closeBundle() {
       if (emitted) return;
       emitted = true;
-      // Resolve via package.json — TS 7 does not export `./bin/tsc`, and on Windows
-      // `.bin/tsc` is a Unix shell shim that spawn cannot execute directly.
-      const require = createRequire(import.meta.url);
-      const tscJs = path.join(path.dirname(require.resolve('typescript/package.json')), 'bin', 'tsc');
+      const tsc = path.join(import.meta.dirname, 'node_modules', '.bin', 'tsc');
       await new Promise((resolve, reject) => {
         const child = spawn(
-          process.execPath,
-          [tscJs, '-p', path.resolve(dirname, 'tsconfig.build.json'), '--emitDeclarationOnly'],
+          tsc,
+          ['-p', path.resolve(dirname, 'tsconfig.build.json'), '--emitDeclarationOnly'],
           { cwd: dirname, stdio: 'inherit' }
         );
         child.on('error', reject);


### PR DESCRIPTION
Avoid warnings related to `__dirname` during build. Use `import.meta.dirname` and let Vite/Rolldown handle the rest.

<img width="616" height="42" alt="image" src="https://github.com/user-attachments/assets/c0b60a34-0179-4375-94c6-d5b9b0b500b6" />
