### PR TITLE
fix: tsc `ENOENT` on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - 'docker-examples/**'
       - 'package.json'
       - 'pnpm-workspace.yaml'
+      - 'vite.lib.config.mjs'
 permissions:
   actions: read
   contents: read

--- a/vite.lib.config.mjs
+++ b/vite.lib.config.mjs
@@ -1,8 +1,7 @@
 import { spawn } from 'node:child_process';
-import { builtinModules } from 'node:module';
+import { builtinModules, createRequire } from 'node:module';
 import fs from 'node:fs';
 import path from 'node:path';
-import { createRequire } from 'node:module';
 
 import { defineConfig } from 'vite';
 
@@ -54,11 +53,18 @@ export function nativeDts(dirname) {
     async closeBundle() {
       if (emitted) return;
       emitted = true;
-      const tsc = path.join(import.meta.dirname, 'node_modules', '.bin', 'tsc');
+      // Resolve via package.json — TS 7 does not export `./bin/tsc`, and on Windows
+      // `.bin/tsc` is a Unix shell shim that spawn cannot execute directly.
+      const require = createRequire(import.meta.url);
+      const tscJs = path.join(
+        path.dirname(require.resolve('typescript/package.json')),
+        'bin',
+        'tsc'
+      );
       await new Promise((resolve, reject) => {
         const child = spawn(
-          tsc,
-          ['-p', path.resolve(dirname, 'tsconfig.build.json'), '--emitDeclarationOnly'],
+          process.execPath,
+          [tscJs, '-p', path.resolve(dirname, 'tsconfig.build.json'), '--emitDeclarationOnly'],
           { cwd: dirname, stdio: 'inherit' }
         );
         child.on('error', reject);


### PR DESCRIPTION
Builds failed because `verdaccio:native-dts` spawned `node_modules/.bin/tsc` directly. On Windows that shim is a Unix shell script, so `spawn` hits `ENOENT`.

### Error

<img width="618" height="348" alt="image" src="https://github.com/user-attachments/assets/178036d7-773f-470c-80bb-6eb85462cabb" />

### Fix

Updated `vite.lib.config.mjs` to run TypeScript via `node` and the real `bin/tsc` path (resolved through `typescript/package.json`). The i18n package builds successfully now.

