### PR TITLE
feat: expose legacy auth cache config

### DIFF
--- a/.changeset/legacy-auth-cache-types.md
+++ b/.changeset/legacy-auth-cache-types.md
@@ -1,0 +1,5 @@
+---
+'verdaccio': minor
+---
+
+Update internal Verdaccio types to include the optional `server.legacyAuthCache` configuration used by the 8.x auth and config packages.

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@verdaccio/e2e-cli": "2.10.2",
     "@verdaccio/e2e-ui": "2.4.2",
     "@verdaccio/test-helper": "4.1.0",
-    "@verdaccio/types": "13.0.5",
+    "@verdaccio/types": "13.0.6",
     "@vitest/coverage-v8": "4.1.8",
     "cross-env": "10.1.0",
     "cypress": "15.16.0",

--- a/test/unit/modules/config/config.spec.ts
+++ b/test/unit/modules/config/config.spec.ts
@@ -58,6 +58,11 @@ const checkDefaultConfPackages = (config) => {
   expect(config.publish).toBeUndefined();
   expect(config.url_prefix).toBeUndefined();
   expect(config.url_prefix).toBeUndefined();
+  expect(config.server.legacyAuthCache).toEqual({
+    enabled: false,
+    maxEntries: 1000,
+    ttlMs: 15000,
+  });
   expect(config.security).toEqual({
     api: { legacy: true, migrateToSecureLegacySignature: false },
     web: { sign: { expiresIn: '1h' }, verify: {} },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2198,6 +2198,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@verdaccio/types@npm:13.0.6":
+  version: 13.0.6
+  resolution: "@verdaccio/types@npm:13.0.6"
+  checksum: 10c0/4336a5e42bc49d2c06472ae2837e486dbb1325b6d6c356a7060f9ccc6bf15db60e521d332a662c399077528a1cf1881d6000d5df062384a5be373e5d32da9579
+  languageName: node
+  linkType: hard
+
 "@verdaccio/ui-theme@npm:9.0.0-next-9.26":
   version: 9.0.0-next-9.26
   resolution: "@verdaccio/ui-theme@npm:9.0.0-next-9.26"
@@ -8253,7 +8260,7 @@ __metadata:
     "@verdaccio/streams": "npm:10.3.0"
     "@verdaccio/tarball": "npm:13.1.2"
     "@verdaccio/test-helper": "npm:4.1.0"
-    "@verdaccio/types": "npm:13.0.5"
+    "@verdaccio/types": "npm:13.0.6"
     "@verdaccio/ui-theme": "npm:9.0.0-next-9.26"
     "@verdaccio/url": "npm:13.1.2"
     "@verdaccio/utils": "npm:8.2.2"


### PR DESCRIPTION
## Summary

Updates Verdaccio 6.x to align with the 8.x packages that include the optional legacy auth cache support from #6143.

The runtime packages already resolve to:

- `@verdaccio/auth@8.1.2`
- `@verdaccio/config@8.2.2`

This PR exposes the optional `server.legacyAuthCache` feature in Verdaccio 6.x by updating the direct `@verdaccio/types` dependency to `13.0.6`, so the 6.x package uses the type definitions that include the new configuration.

## Behavior

The feature remains optional and disabled by default. Existing 6.x installations keep their current authentication behavior unless operators explicitly opt in:

```yaml
server:
  legacyAuthCache:
    enabled: true
    ttlMs: 15000
    maxEntries: 1000
```

## Changes

- Updates `@verdaccio/types` from `13.0.5` to `13.0.6`.
- Updates `yarn.lock`.
- Adds a config test asserting that `server.legacyAuthCache` is exposed with the safe default:
  - `enabled: false`
  - `ttlMs: 15000`
  - `maxEntries: 1000`
- Adds a minor changeset for the 6.x package because this exposes a new optional feature.

## Testing

- `yarn install --check-cache`
- `yarn test test/unit/modules/config/config.spec.ts --coverage=false`
- `yarn test test/unit/modules/auth/auth-utils.spec.ts --coverage=false`
- `yarn run type-check`
- `yarn changeset:check`
- `git diff --check`
