### PR TITLE
feat(auth): remove incoming basic auth

### DIFF
--- a/.changeset/remove-basic-auth.md
+++ b/.changeset/remove-basic-auth.md
@@ -1,6 +1,10 @@
 ---
 '@verdaccio/auth': major
+'@verdaccio/api': major
 '@verdaccio/middleware': major
+'@verdaccio/server': major
 ---
 
 Remove support for incoming HTTP Basic authentication. Verdaccio now accepts Bearer tokens for API authentication and advertises only `Bearer` in `WWW-Authenticate` responses.
+
+Web UI endpoints keep using the Web UI authentication middleware, so Web UI session tokens are not validated as npm API tokens.

--- a/.changeset/remove-basic-auth.md
+++ b/.changeset/remove-basic-auth.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/auth': major
+'@verdaccio/middleware': major
+---
+
+Remove support for incoming HTTP Basic authentication. Verdaccio now accepts Bearer tokens for API authentication and advertises only `Bearer` in `WWW-Authenticate` responses.

--- a/.changeset/remove-basic-auth.md
+++ b/.changeset/remove-basic-auth.md
@@ -7,4 +7,4 @@
 
 Remove support for incoming HTTP Basic authentication. Verdaccio now accepts Bearer tokens for API authentication and advertises only `Bearer` in `WWW-Authenticate` responses.
 
-Web UI endpoints keep using the Web UI authentication middleware, so Web UI session tokens are not validated as npm API tokens.
+Web UI session tokens are accepted as Bearer authentication for package API requests, so the same package access rules apply to Web UI and package manager clients.

--- a/cypress/e2e/06-publish.cy.ts
+++ b/cypress/e2e/06-publish.cy.ts
@@ -6,6 +6,11 @@ const config = createRegistryConfig({
   registryUrl,
   title: 'Verdaccio e2e',
   credentials: { user: 'test', password: 'test' },
+  features: {
+    publish: {
+      privateDownloadTarball: true,
+    },
+  },
 });
 
 publishTests(config);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/superagent": "8.1.10",
     "@types/supertest": "7.2.0",
     "@types/validator": "13.15.10",
-    "@verdaccio/e2e-cli": "2.10.3",
+    "@verdaccio/e2e-cli": "2.10.4",
     "@verdaccio/e2e-ui": "2.4.1",
     "@verdaccio/package-filter": "workspace:*",
     "@verdaccio/types": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@types/superagent": "8.1.10",
     "@types/supertest": "7.2.0",
     "@types/validator": "13.15.10",
-    "@verdaccio/e2e-cli": "2.10.1",
+    "@verdaccio/e2e-cli": "2.10.3",
     "@verdaccio/e2e-ui": "2.4.1",
     "@verdaccio/package-filter": "workspace:*",
     "@verdaccio/types": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/supertest": "7.2.0",
     "@types/validator": "13.15.10",
     "@verdaccio/e2e-cli": "2.10.4",
-    "@verdaccio/e2e-ui": "2.4.1",
+    "@verdaccio/e2e-ui": "2.4.3",
     "@verdaccio/package-filter": "workspace:*",
     "@verdaccio/types": "workspace:*",
     "@verdaccio/ui-theme": "workspace:*",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,7 @@ import express from 'express';
 
 import type { Auth } from '@verdaccio/auth';
 import {
+  WebUrlsNamespace,
   antiLoop,
   encodeScopePackage,
   enforceGeneratedTokenMetadata,
@@ -47,6 +48,8 @@ export default function (config: Config, auth: Auth, storage: Storage, logger: L
 
   // Body parser must be registered before JWT middleware which pauses/resumes the stream
   registerBodyParser(app, config);
+
+  app.use(WebUrlsNamespace.endpoints, (_req, _res, next) => next('router'));
 
   // Avoid executing JWT twice when the parent app already registered the JWT middleware
   const apiJwtMiddleware = auth.apiJWTmiddleware();

--- a/packages/api/test/integration/_helper.ts
+++ b/packages/api/test/integration/_helper.ts
@@ -1,10 +1,13 @@
 import type { Application } from 'express';
-import { isEmpty, isNil } from 'lodash-es';
+import express from 'express';
+import { isEmpty } from 'lodash-es';
+import os from 'node:os';
 import path from 'node:path';
 import supertest from 'supertest';
 import { expect } from 'vitest';
 
-import { parseConfigFile } from '@verdaccio/config';
+import { Auth } from '@verdaccio/auth';
+import { Config, parseConfigFile } from '@verdaccio/config';
 import {
   HEADERS,
   HEADER_TYPE,
@@ -12,7 +15,10 @@ import {
   TOKEN_BEARER,
   authUtils,
   cryptoUtils,
+  errorUtils,
 } from '@verdaccio/core';
+import { setup } from '@verdaccio/logger';
+import { errorReportingMiddleware, final, handleError } from '@verdaccio/middleware';
 import { Storage } from '@verdaccio/store';
 import {
   generatePackageMetadata,
@@ -35,6 +41,36 @@ export const getConf = (conf: string) => {
 export async function initializeServer(configName: string): Promise<Application> {
   const config = getConf(configName);
   return initializeServerHelper(config, [apiMiddleware], Storage);
+}
+
+export async function initializeServerWithContext(configName: string) {
+  const configObject = getConf(configName);
+  const app = express();
+  const logger = await setup(configObject.log ?? {});
+  const config = new Config(configObject);
+  config.storage = path.join(os.tmpdir(), '/storage', cryptoUtils.generateRandomHexString());
+  config.configPath = config.storage;
+
+  const storage = new Storage(config, logger);
+  await storage.init(config, []);
+  const auth = new Auth(config, logger);
+  await auth.init();
+
+  app.use(express.json({ strict: false, limit: '10mb' }));
+  app.use(errorReportingMiddleware(logger));
+  app.use(apiMiddleware(config, auth, storage, logger));
+  app.get('/{*any}', function (req, res, next) {
+    next(errorUtils.getNotFound('resource not found'));
+  });
+  app.use(handleError(logger));
+  app.use(final);
+
+  app.use(function (request, response) {
+    response.status(590);
+    response.json({ error: 'cannot handle this' });
+  });
+
+  return { app, auth, config, logger, storage };
 }
 
 export function createUser(app: any, name: string, password: string): supertest.Test {
@@ -110,7 +146,7 @@ export function publishVersion(
     .set('accept', HEADERS.GZIP)
     .set(HEADER_TYPE.ACCEPT_ENCODING, HEADERS.JSON);
 
-  if (typeof token === 'string') {
+  if (typeof token === 'string' && isEmpty(token) === false) {
     test.set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token));
   }
 
@@ -141,7 +177,7 @@ export function changeOwners(
     .set('accept', HEADERS.GZIP)
     .set(HEADER_TYPE.ACCEPT_ENCODING, HEADERS.JSON);
 
-  if (typeof token === 'string') {
+  if (typeof token === 'string' && isEmpty(token) === false) {
     test.set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token));
   }
 
@@ -164,7 +200,7 @@ export function getPackage(
 ): supertest.Test {
   const test = supertest(app).get(`/${pkgName}`);
 
-  if (isNil(token) === false || isEmpty(token) === false) {
+  if (typeof token === 'string' && isEmpty(token) === false) {
     test.set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token));
   }
 

--- a/packages/api/test/integration/config/package-web-token.yaml
+++ b/packages/api/test/integration/config/package-web-token.yaml
@@ -1,0 +1,25 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd-package-web-token
+
+web:
+  enable: true
+  title: verdaccio
+
+publish:
+  allow_offline: false
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@*/*':
+    access: $authenticated
+    publish: $anonymous
+  '**':
+    access: $authenticated
+    publish: $anonymous
+_debug: true

--- a/packages/api/test/integration/package.spec.ts
+++ b/packages/api/test/integration/package.spec.ts
@@ -1,10 +1,16 @@
 import supertest from 'supertest';
 import { beforeEach, describe, expect, test } from 'vitest';
 
-import { DIST_TAGS, HEADERS, HEADER_TYPE, HTTP_STATUS } from '@verdaccio/core';
+import { createRemoteUser } from '@verdaccio/config';
+import { DIST_TAGS, HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
 import { Storage } from '@verdaccio/store';
 
-import { initializeServer, publishVersion } from './_helper';
+import {
+  buildToken,
+  initializeServer,
+  initializeServerWithContext,
+  publishVersion,
+} from './_helper';
 
 describe('package', () => {
   describe('get tarball', () => {
@@ -62,6 +68,34 @@ describe('package', () => {
         .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
         .expect(HTTP_STATUS.OK);
       expect(response.body.name).toEqual(pkg);
+    });
+
+    test('should authorize protected package routes with a web bearer token (#5765)', async () => {
+      const { app, auth } = await initializeServerWithContext('package-web-token.yaml');
+      const token = await auth.jwtEncrypt(createRemoteUser('web-user', []), {});
+
+      await publishVersion(app, 'foo', '1.0.0');
+
+      await supertest(app)
+        .get('/foo')
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .expect(HTTP_STATUS.UNAUTHORIZED);
+
+      const manifestResponse = await supertest(app)
+        .get('/foo')
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+        .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+        .expect(HTTP_STATUS.OK);
+      expect(manifestResponse.body.name).toEqual('foo');
+
+      const tarballResponse = await supertest(app)
+        .get('/foo/-/foo-1.0.0.tgz')
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+        .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.OCTET_STREAM)
+        .expect(HTTP_STATUS.OK);
+      expect(Buffer.from(tarballResponse.body).toString('utf8')).toBeDefined();
     });
 
     test.each([

--- a/packages/api/test/integration/user.spec.ts
+++ b/packages/api/test/integration/user.spec.ts
@@ -11,7 +11,7 @@ vi.setConfig({ testTimeout: 20000 });
 
 describe('token', () => {
   describe('basics', () => {
-    const FAKE_TOKEN: string = buildToken(TOKEN_BEARER, 'fake');
+    const FAKE_TOKEN = 'fake';
     test.each([['user.yaml'], ['user.jwt.yaml']])('should test add a new user', async (conf) => {
       const app = await initializeServer(conf);
       const credentials = { name: 'JotaJWT', password: 'secretPass' };
@@ -23,7 +23,7 @@ describe('token', () => {
       expect(vueResponse.body.name).toMatch('vue');
 
       const vueFailResp = await getPackage(app, FAKE_TOKEN, 'vue', HTTP_STATUS.UNAUTHORIZED);
-      expect(vueFailResp.body.error).toMatch(FORBIDDEN_VUE);
+      expect([API_ERROR.BAD_USERNAME_PASSWORD, FORBIDDEN_VUE]).toContain(vueFailResp.body.error);
     });
 
     test.each([['user.yaml'], ['user.jwt.yaml']])('should login an user', async (conf) => {

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -10,7 +10,6 @@ import {
   PLUGIN_CATEGORY,
   PLUGIN_PREFIX,
   SUPPORT_ERRORS,
-  TOKEN_BASIC,
   TOKEN_BEARER,
   authUtils,
   errorUtils,
@@ -18,7 +17,7 @@ import {
   warningUtils,
 } from '@verdaccio/core';
 import { asyncLoadPlugin } from '@verdaccio/loaders';
-import { aesEncrypt, parseBasicPayload, signPayload } from '@verdaccio/signature';
+import { aesEncrypt, signPayload } from '@verdaccio/signature';
 import type {
   AllowAccess,
   Callback,
@@ -33,13 +32,11 @@ import type {
 import type {
   $RequestExtend,
   $ResponseExtend,
-  AESPayload,
   IAuthMiddleware,
   NextFunction,
   TokenEncryption,
 } from './types';
 import {
-  convertPayloadToBase64,
   getDefaultPluginMethods,
   getMiddlewareCredentials,
   isAESLegacy,
@@ -510,43 +507,16 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     next: any
   ): void {
     debug('handle JWT api middleware');
-    const { scheme, token } = parseAuthTokenHeader(authorization);
-    if (scheme.toUpperCase() === TOKEN_BASIC.toUpperCase()) {
-      debug('handle basic token');
-      // this should happen when client tries to login with an existing user
-      const credentials = convertPayloadToBase64(token).toString();
-      const parsedCredentials = parseBasicPayload(credentials);
-      if (!parsedCredentials) {
-        debug('invalid basic credentials format (missing colon separator)');
-        next(errorUtils.getBadRequest(API_ERROR.BAD_USERNAME_PASSWORD));
-        return;
-      }
-      const { user, password } = parsedCredentials as AESPayload;
-      debug('authenticating %o', user);
-      this.authenticate(user, password, (err: VerdaccioError | null, user): void => {
-        if (!err) {
-          debug('generating a remote user');
-          req.remote_user = user;
-          next();
-        } else {
-          debug('generating anonymous user');
-          req.remote_user = createAnonymousRemoteUser();
-          next(err);
-        }
-      });
+    const credentials: any = getMiddlewareCredentials(security, secret, authorization);
+    if (credentials) {
+      // if the signature is valid we rely on it
+      req.remote_user = credentials;
+      debug('generating a remote user');
+      next();
     } else {
-      debug('handle jwt token');
-      const credentials: any = getMiddlewareCredentials(security, secret, authorization);
-      if (credentials) {
-        // if the signature is valid we rely on it
-        req.remote_user = credentials;
-        debug('generating a remote user');
-        next();
-      } else {
-        // with JWT throw 401
-        debug('jwt invalid token');
-        next(errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
-      }
+      // with JWT throw 401
+      debug('jwt invalid token');
+      next(errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
     }
   }
 
@@ -608,7 +578,6 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
         onAuthComplete(errorUtils.getInternalError(err?.message));
       }
     } else {
-      // we force npm client to ask again with basic authentication
       debug('legacy invalid header');
       return next(errorUtils.getBadRequest(API_ERROR.BAD_AUTH_HEADER));
     }

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -574,8 +574,34 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
         onAuthComplete(errorUtils.getInternalError(err?.message));
       }
     } else {
+      const remoteUser = this.getJWTRemoteUserFromBearer(authorization);
+      if (remoteUser) {
+        req.remote_user = remoteUser;
+        debug('generating a remote user from jwt bearer');
+        return next();
+      }
+
       debug('legacy invalid header');
       return next(errorUtils.getUnauthorized(API_ERROR.BAD_USERNAME_PASSWORD));
+    }
+  }
+
+  private getJWTRemoteUserFromBearer(authorization: string): RemoteUser | void {
+    const { scheme, token } = parseAuthTokenHeader(authorization);
+    if (scheme.toUpperCase() !== TOKEN_BEARER.toUpperCase() || !token) {
+      return;
+    }
+
+    let credentials: RemoteUser | undefined;
+    try {
+      credentials = verifyJWTPayload(token, this.config.secret, this.config.security);
+    } catch {
+      return;
+    }
+
+    if (this._isRemoteUserValid(credentials)) {
+      const { name, groups } = credentials as RemoteUser;
+      return createRemoteUser(name as string, groups);
     }
   }
 

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -455,12 +455,8 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
       req.pause();
       const next = function (err?: VerdaccioError): NextFunction {
         req.resume();
-        // uncomment this to reject users with bad auth headers
-        // return _next.apply(null, arguments)
-        // swallow error, user remains unauthorized
-        // set remoteUserError to indicate that user was attempting authentication
         if (err) {
-          req.remote_user.error = err.message;
+          return _next(err) as unknown as NextFunction;
         }
 
         return _next() as unknown as NextFunction;
@@ -516,7 +512,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
     } else {
       // with JWT throw 401
       debug('jwt invalid token');
-      next(errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
+      next(errorUtils.getUnauthorized(API_ERROR.BAD_USERNAME_PASSWORD));
     }
   }
 
@@ -552,7 +548,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
         } else {
           req.remote_user = createAnonymousRemoteUser();
           debug('generating anonymous user');
-          next(err || errorUtils.getForbidden(API_ERROR.BAD_USERNAME_PASSWORD));
+          next(err || errorUtils.getUnauthorized(API_ERROR.BAD_USERNAME_PASSWORD));
         }
       };
       // concurrent requests for the same token wait for the in-flight one
@@ -579,7 +575,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
       }
     } else {
       debug('legacy invalid header');
-      return next(errorUtils.getBadRequest(API_ERROR.BAD_AUTH_HEADER));
+      return next(errorUtils.getUnauthorized(API_ERROR.BAD_USERNAME_PASSWORD));
     }
   }
 

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -711,6 +711,7 @@ class Auth implements IAuthMiddleware, TokenEncryption, pluginUtils.IBasicAuth {
 
       const { authorization } = req.headers;
       if (isNil(authorization)) {
+        req.remote_user = createAnonymousRemoteUser();
         return next();
       }
 

--- a/packages/auth/src/utils.ts
+++ b/packages/auth/src/utils.ts
@@ -3,7 +3,7 @@ import { isNil } from 'lodash-es';
 
 import { createAnonymousRemoteUser } from '@verdaccio/config';
 import type { pluginUtils } from '@verdaccio/core';
-import { API_ERROR, HTTP_STATUS, TOKEN_BASIC, TOKEN_BEARER, errorUtils } from '@verdaccio/core';
+import { API_ERROR, HTTP_STATUS, TOKEN_BEARER, errorUtils } from '@verdaccio/core';
 import { aesDecrypt, parseBasicPayload, verifyPayload } from '@verdaccio/signature';
 import type { AuthPackageAllow, Config, Logger, RemoteUser, Security } from '@verdaccio/types';
 
@@ -33,14 +33,7 @@ export function parseAESCredentials(authorizationHeader: string, secret: string)
   debug('parseAESCredentials init');
   const { scheme, token } = parseAuthTokenHeader(authorizationHeader);
 
-  // basic is deprecated and should not be enforced
-  // basic is currently being used for functional test
-  if (scheme.toUpperCase() === TOKEN_BASIC.toUpperCase()) {
-    debug('legacy header basic');
-    const credentials = convertPayloadToBase64(token).toString();
-
-    return credentials;
-  } else if (scheme.toUpperCase() === TOKEN_BEARER.toUpperCase()) {
+  if (scheme.toUpperCase() === TOKEN_BEARER.toUpperCase()) {
     debug('legacy header bearer');
     return aesDecrypt(token.toString(), secret);
   }
@@ -237,8 +230,4 @@ export function buildUser(name: string, password: string, tokenKey?: string): st
   }
 
   return String(`${name}:${password}`);
-}
-
-export function convertPayloadToBase64(payload: string): Buffer {
-  return Buffer.from(payload, 'base64');
 }

--- a/packages/auth/test/auth-utils-middleware.spec.ts
+++ b/packages/auth/test/auth-utils-middleware.spec.ts
@@ -103,20 +103,15 @@ describe('Auth utilities', () => {
         expect(credentials.password).toEqual(pass);
       });
 
-      test.concurrent('should unpack aes token and credentials basic auth', async () => {
+      test.concurrent('should ignore basic credentials', async () => {
         const secret = 'b2df428b9929d3ace7c598bbf4e496b2';
         const user = 'test';
         const pass = 'test';
-        // basic authentication need send user as base64
         const token = authUtils.buildUserBuffer(user, pass).toString('base64');
         const config: Config = getConfig('security-legacy', secret);
         const security: Security = config.security;
         const credentials = getMiddlewareCredentials(security, secret, `Basic ${token}`);
-        expect(credentials).toBeDefined();
-        // @ts-ignore
-        expect(credentials.user).toEqual(user);
-        // @ts-ignore
-        expect(credentials.password).toEqual(pass);
+        expect(credentials).toBeUndefined();
       });
 
       test.concurrent('should return empty credential wrong secret key', async () => {

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -604,8 +604,8 @@ describe('AuthTest', () => {
         const app = express();
         app.use(express.json({ strict: false, limit: '10mb' }));
 
-        app.use(auth.apiJWTmiddleware());
         app.use(errorReportingMiddleware(logger) as any);
+        app.use(auth.apiJWTmiddleware());
         app.get('/{*any}', (req, res, next) => {
           if ((req as $RequestExtend).remote_user.error) {
             next(new Error((req as $RequestExtend).remote_user.error));
@@ -629,7 +629,7 @@ describe('AuthTest', () => {
             return supertest(app)
               .get(`/`)
               .set(HEADERS.AUTHORIZATION, 'Bearer foo')
-              .expect(HTTP_STATUS.INTERNAL_ERROR);
+              .expect(HTTP_STATUS.UNAUTHORIZED);
           });
 
           test('should handle missing auth header', async () => {
@@ -701,7 +701,7 @@ describe('AuthTest', () => {
             await supertest(app)
               .get(`/`)
               .set(HEADERS.AUTHORIZATION, buildToken('Basic', token))
-              .expect(HTTP_STATUS.INTERNAL_ERROR);
+              .expect(HTTP_STATUS.UNAUTHORIZED);
 
             expect(authenticateSpy).not.toHaveBeenCalled();
             authenticateSpy.mockRestore();
@@ -893,7 +893,7 @@ describe('AuthTest', () => {
             return supertest(app)
               .get(`/`)
               .set(HEADERS.AUTHORIZATION, `Basic ${malformedToken}`)
-              .expect(HTTP_STATUS.INTERNAL_ERROR);
+              .expect(HTTP_STATUS.UNAUTHORIZED);
           });
         });
         describe('valid signature handlers', () => {

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -707,6 +707,23 @@ describe('AuthTest', () => {
             authenticateSpy.mockRestore();
           });
 
+          test('should authenticate a valid jwt bearer in legacy auth mode', async () => {
+            const config: Config = new AppConfig({ ...authProfileConf });
+            config.checkSecretKey(TEST_SECRET);
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const token = (await auth.jwtEncrypt(
+              createRemoteUser('jwt_user', [ROLES.ALL]),
+              {}
+            )) as string;
+            const app = await getServer(auth);
+            const res = await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+            expect(res.body.user.name).toEqual('jwt_user');
+          });
+
           test('should share an in-flight legacy auth token verification', async () => {
             const payload = 'juan:password';
             const config: Config = new AppConfig({
@@ -894,6 +911,29 @@ describe('AuthTest', () => {
               .get(`/`)
               .set(HEADERS.AUTHORIZATION, `Basic ${malformedToken}`)
               .expect(HTTP_STATUS.UNAUTHORIZED);
+          });
+
+          test('should not authenticate a legacy token in jwt auth mode', async () => {
+            // @ts-expect-error
+            const config: Config = new AppConfig({
+              ...authProfileConf,
+              ...{ security: { api: { jwt: { sign: { expiresIn: '29d' } } } } },
+            });
+            config.checkSecretKey(TEST_SECRET);
+            const auth = new Auth(config, logger);
+            await auth.init();
+            const token = auth.aesEncrypt('juan:password') as string;
+            const app = await getServer(auth);
+            const res = await supertest(app)
+              .get(`/`)
+              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+              .expect(HTTP_STATUS.OK);
+            expect(res.body.user.groups).toEqual([
+              ROLES.$ALL,
+              ROLES.$ANONYMOUS,
+              ROLES.DEPRECATED_ALL,
+              ROLES.DEPRECATED_ANONYMOUS,
+            ]);
           });
         });
         describe('valid signature handlers', () => {

--- a/packages/auth/test/auth.spec.ts
+++ b/packages/auth/test/auth.spec.ts
@@ -8,7 +8,6 @@ import {
   HEADERS,
   HTTP_STATUS,
   SUPPORT_ERRORS,
-  TOKEN_BASIC,
   TOKEN_BEARER,
   authUtils,
   errorUtils,
@@ -686,7 +685,7 @@ describe('AuthTest', () => {
             authenticateSpy.mockRestore();
           });
 
-          test('should not cache basic auth in legacy auth mode', async () => {
+          test('should reject basic auth in legacy auth mode', async () => {
             const payload = 'juan:password';
             const config: Config = new AppConfig({
               ...authProfileConf,
@@ -701,14 +700,10 @@ describe('AuthTest', () => {
 
             await supertest(app)
               .get(`/`)
-              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BASIC, token))
-              .expect(HTTP_STATUS.OK);
-            await supertest(app)
-              .get(`/`)
-              .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BASIC, token))
-              .expect(HTTP_STATUS.OK);
+              .set(HEADERS.AUTHORIZATION, buildToken('Basic', token))
+              .expect(HTTP_STATUS.INTERNAL_ERROR);
 
-            expect(authenticateSpy).toHaveBeenCalledTimes(2);
+            expect(authenticateSpy).not.toHaveBeenCalled();
             authenticateSpy.mockRestore();
           });
 
@@ -884,7 +879,7 @@ describe('AuthTest', () => {
             ]);
           });
 
-          test('should handle malformed Basic auth credentials without crashing', async () => {
+          test('should reject Basic auth credentials', async () => {
             // @ts-expect-error
             const config: Config = new AppConfig({
               ...authProfileConf,
@@ -894,7 +889,6 @@ describe('AuthTest', () => {
             const auth = new Auth(config, logger);
             await auth.init();
             const app = await getServer(auth);
-            // base64 of "test" (no colon separator) - must not crash with TypeError
             const malformedToken = Buffer.from('test').toString('base64');
             return supertest(app)
               .get(`/`)

--- a/packages/middleware/src/middlewares/final.ts
+++ b/packages/middleware/src/middlewares/final.ts
@@ -1,7 +1,7 @@
 import buildDebug from 'debug';
 import { isNil, isObject } from 'lodash-es';
 
-import { HEADERS, HTTP_STATUS, TOKEN_BASIC, TOKEN_BEARER, cryptoUtils } from '@verdaccio/core';
+import { HEADERS, HTTP_STATUS, TOKEN_BEARER, cryptoUtils } from '@verdaccio/core';
 import type { Manifest } from '@verdaccio/types';
 
 import type { $NextFunctionVer, $RequestExtend, $ResponseExtend, MiddlewareError } from '../types';
@@ -20,7 +20,7 @@ export function final(
 ): void {
   if (res.statusCode === HTTP_STATUS.UNAUTHORIZED && !res.getHeader(HEADERS.WWW_AUTH)) {
     debug('set auth header support');
-    res.header(HEADERS.WWW_AUTH, `${TOKEN_BASIC}, ${TOKEN_BEARER}`);
+    res.header(HEADERS.WWW_AUTH, TOKEN_BEARER);
   }
 
   try {

--- a/packages/middleware/test/final.spec.ts
+++ b/packages/middleware/test/final.spec.ts
@@ -19,7 +19,7 @@ test('handle error as object', async () => {
   app.use(final);
 
   const res = await request(app).get('/401');
-  expect(res.get(HEADERS.WWW_AUTH)).toEqual('Basic, Bearer');
+  expect(res.get(HEADERS.WWW_AUTH)).toEqual('Bearer');
   expect(res.get(HEADERS.CONTENT_TYPE)).toEqual(HEADERS.JSON_CHARSET);
   expect(res.get(HEADERS.ETAG)).toEqual('W/"1c-CP1UoQiM59AjHpEk0334sfSp1kc"');
   expect(res.body).toEqual({ error: 'some error' });

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -29,6 +29,7 @@ import {
   rateLimit,
   registerBodyParser,
   userAgent,
+  WebUrlsNamespace,
 } from '@verdaccio/middleware';
 import { Storage } from '@verdaccio/store';
 import type { ConfigYaml, Config as IConfig } from '@verdaccio/types';
@@ -106,8 +107,11 @@ export const defineAPI = async function (config: IConfig, storage: Storage): Pro
     plugins.push(auditPlugin);
   }
 
-  // Register JWT middleware so middleware plugins can access req.remote_user
-  app.use(auth.apiJWTmiddleware());
+  // Register JWT middleware so middleware plugins can access req.remote_user.
+  const apiAuthRouter = express.Router();
+  apiAuthRouter.use(WebUrlsNamespace.endpoints, (_req, _res, next) => next('router'));
+  apiAuthRouter.use(auth.apiJWTmiddleware());
+  app.use(apiAuthRouter);
 
   // Ensure sequential execution in order, and that each registration completes before the next one starts
   for (const plugin of plugins) {

--- a/packages/server/express/test/config/protected-package.yaml
+++ b/packages/server/express/test/config/protected-package.yaml
@@ -1,0 +1,32 @@
+# storage: this is generated on _helper file
+
+auth:
+  htpasswd:
+    file: ./htpasswd-package
+
+web:
+  enable: true
+  title: verdaccio
+
+publish:
+  allow_offline: false
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@*/*':
+    access: $all
+    publish: $all
+    unpublish: none
+  'foo':
+    access: $authenticated
+    publish: $all
+    unpublish: none
+  '**':
+    access: $all
+    publish: $all
+    unpublish: none
+
+_debug: true

--- a/packages/server/express/test/server.spec.ts
+++ b/packages/server/express/test/server.spec.ts
@@ -6,6 +6,49 @@ import { setup } from '@verdaccio/logger';
 
 import { initializeServer } from './_helper';
 
+const TARBALL_DATA =
+  'H4sIAAAAAAAAE+2W32vbMBDH85y/QnjQp9qxLEeBMsbGlocNBmN7bFdQ5WuqxJaEpGQdo//79KPeQsnI' +
+  'w5KUDX/9IOvurLuz/DHSjK/YAiY6jcXSKjk6sMqypHWNdtmD6hlBI0wqQmo8nVbVqMR4OsNoVB66kF1a' +
+  'W8eML+Vv10m9oF/jP6IfY4QyyTrILlD2eqkcm+gVzpdrJrPz4NuAsULJ4MZFWdBkbcByI7R79CRjx0Sc' +
+  'CdnAvf+SkjUFWu8IubzBgXUhDPidQlfZ3BhlLpBUKDiQ1cDFrYDmKkNnZwjuhUM4808+xNVW8P2bMk1Y' +
+  '7vJrtLC1u1MmLPjBF40+Cc4ahV6GDmI/DWygVRpMwVX3KtXUCg7Sxp7ff3nbt6TBFy65gK1iffsN41yo' +
+  'EHtdFbOiisWMH8bPvXUH0SP3k+KG3UBr+DFy7OGfEJr4x5iWVeS/pLQe+D+FIv/agIWI6GX66kFuIhT+' +
+  '1gDjrp/4d7WAvAwEJPh0u14IufWkM0zaW2W6nLfM2lybgJ4LTJ0/jWiAK8OcMjt8MW3OlfQppcuhhQ6k' +
+  '+2OgkK2Q8DssFPi/IHpU9fz3/+xj5NjDf8QFE39VmE4JDfzPCBn4P4X6/f88f/Pu47zomiPk2Lv/dOv8' +
+  'h+P/34/D/p9CL+Kp67mrGDRo0KBBp9ZPsETQegASAAA=+2W32vbMBDH85y';
+
+function publishVersion(app: any, pkgName: string, version: string): supertest.Test {
+  return supertest(app)
+    .put(`/${encodeURIComponent(pkgName)}`)
+    .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+    .send(
+      JSON.stringify({
+        _id: pkgName,
+        name: pkgName,
+        'dist-tags': { latest: version },
+        versions: {
+          [version]: {
+            name: pkgName,
+            version,
+            dist: {
+              shasum: '2c03764f651a9f016ca0b7620421457b619151b9',
+              tarball: `http://localhost:5555/${pkgName}/-/${pkgName}-${version}.tgz`,
+            },
+          },
+        },
+        _attachments: {
+          [`${pkgName}-${version}.tgz`]: {
+            content_type: HEADERS.OCTET_STREAM,
+            data: TARBALL_DATA,
+            length: 512,
+          },
+        },
+      })
+    )
+    .set(HEADER_TYPE.ACCEPT_ENCODING, HEADERS.JSON)
+    .expect(HTTP_STATUS.CREATED);
+}
+
 beforeAll(async () => {
   await setup({});
 });
@@ -125,6 +168,44 @@ describe('server api', () => {
       .expect(HTTP_STATUS.OK);
     expect(res.body.pid).toEqual(process.pid);
     expect(res.body.mem).toBeDefined();
+  });
+
+  test('should access protected package routes with web ui token', async () => {
+    const app = await initializeServer('protected-package.yaml');
+    const api = supertest(app);
+
+    await api
+      .put('/-/user/org.couchdb.user:test')
+      .send({
+        name: 'test',
+        password: 'test',
+      })
+      .expect(HTTP_STATUS.CREATED);
+
+    const loginRes = await api
+      .post('/-/verdaccio/sec/login')
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .send(
+        JSON.stringify({
+          username: 'test',
+          password: 'test',
+        })
+      )
+      .expect(HTTP_STATUS.OK);
+
+    await publishVersion(app, 'foo', '1.0.0');
+
+    await api
+      .get('/foo/-/foo-1.0.0.tgz')
+      .set(HEADERS.AUTHORIZATION, `Bearer ${loginRes.body.token}`)
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.OCTET_STREAM)
+      .expect(HTTP_STATUS.OK);
+
+    await api
+      .get('/foo')
+      .set(HEADERS.AUTHORIZATION, `Bearer ${loginRes.body.token}`)
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.OK);
   });
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,8 +118,8 @@ importers:
         specifier: 2.10.4
         version: 2.10.4
       '@verdaccio/e2e-ui':
-        specifier: 2.4.1
-        version: 2.4.1(cypress@15.10.0)
+        specifier: 2.4.3
+        version: 2.4.3(cypress@15.10.0)
       '@verdaccio/package-filter':
         specifier: workspace:*
         version: link:packages/plugins/package-filter
@@ -3199,8 +3199,8 @@ packages:
     resolution: {integrity: sha512-YK+MIMpPAbSenkBVfHYcv1soJ6DIhGWM+oy0HfuJoA/nAa/OP+i1bBg7BR0xl4Vw33cL7TCiX48Oq9gEukIhrA==}
     hasBin: true
 
-  '@verdaccio/e2e-ui@2.4.1':
-    resolution: {integrity: sha512-lTL/NFbFsjUcZ+fLHLOfnSsrXdj3IBkPm+SCt5+5UMe9cWsfRB4R6vzalpF1X3gJyvyD0SbkDl/bCKhDUz2Pig==}
+  '@verdaccio/e2e-ui@2.4.3':
+    resolution: {integrity: sha512-VVy6e7ObPWrEDhW3n6SBYj/wOSSp8SRJKYfX/Bw6KJpASoyWjJmpn8MWchqhco+uwWyJZxtImvEfLXv7ESZ0rw==}
     peerDependencies:
       cypress: '>=12.0.0'
 
@@ -7984,7 +7984,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/e2e-ui@2.4.1(cypress@15.10.0)':
+  '@verdaccio/e2e-ui@2.4.3(cypress@15.10.0)':
     dependencies:
       cypress: 15.10.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: 13.15.10
         version: 13.15.10
       '@verdaccio/e2e-cli':
-        specifier: 2.10.3
-        version: 2.10.3
+        specifier: 2.10.4
+        version: 2.10.4
       '@verdaccio/e2e-ui':
         specifier: 2.4.1
         version: 2.4.1(cypress@15.10.0)
@@ -3195,8 +3195,8 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
-  '@verdaccio/e2e-cli@2.10.3':
-    resolution: {integrity: sha512-LIOnATrg4sBx1ZGnjSN8jVQJg6O/NGJMmuRyO/n49smtSqWxRRduAyurhZ9pca6aiQ8zD1sz6CEkKce0l/E2SA==}
+  '@verdaccio/e2e-cli@2.10.4':
+    resolution: {integrity: sha512-YK+MIMpPAbSenkBVfHYcv1soJ6DIhGWM+oy0HfuJoA/nAa/OP+i1bBg7BR0xl4Vw33cL7TCiX48Oq9gEukIhrA==}
     hasBin: true
 
   '@verdaccio/e2e-ui@2.4.1':
@@ -4191,9 +4191,9 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-port@5.1.1:
-    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
-    engines: {node: '>=8'}
+  get-port@7.2.0:
+    resolution: {integrity: sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==}
+    engines: {node: '>=16'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -4553,6 +4553,10 @@ packages:
 
   js-yaml@5.2.2:
     resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
+    hasBin: true
+
+  js-yaml@5.2.3:
+    resolution: {integrity: sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -7971,12 +7975,12 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@verdaccio/e2e-cli@2.10.3':
+  '@verdaccio/e2e-cli@2.10.4':
     dependencies:
       '@verdaccio/registry-cli': 1.1.0
       debug: 4.4.3
-      get-port: 5.1.1
-      js-yaml: 4.3.0
+      get-port: 7.2.0
+      js-yaml: 5.2.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9037,7 +9041,7 @@ snapshots:
       hasown: 2.0.4
       math-intrinsics: 1.1.0
 
-  get-port@5.1.1: {}
+  get-port@7.2.0: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -9369,6 +9373,10 @@ snapshots:
       argparse: 2.0.1
 
   js-yaml@5.2.2:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@5.2.3:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: 13.15.10
         version: 13.15.10
       '@verdaccio/e2e-cli':
-        specifier: 2.10.1
-        version: 2.10.1
+        specifier: 2.10.3
+        version: 2.10.3
       '@verdaccio/e2e-ui':
         specifier: 2.4.1
         version: 2.4.1(cypress@15.10.0)
@@ -3195,8 +3195,8 @@ packages:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
-  '@verdaccio/e2e-cli@2.10.1':
-    resolution: {integrity: sha512-rvbKSp2dpSR6cK9lxTsCzfRocz77SesL1Mu5AI9EZ1BsbuZGwkqTyl5BRWZ5fUVhd4ABkD7WdAAIYLNuT5B1NQ==}
+  '@verdaccio/e2e-cli@2.10.3':
+    resolution: {integrity: sha512-LIOnATrg4sBx1ZGnjSN8jVQJg6O/NGJMmuRyO/n49smtSqWxRRduAyurhZ9pca6aiQ8zD1sz6CEkKce0l/E2SA==}
     hasBin: true
 
   '@verdaccio/e2e-ui@2.4.1':
@@ -3813,15 +3813,6 @@ packages:
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
     peerDependenciesMeta:
@@ -4554,10 +4545,6 @@ packages:
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
-    hasBin: true
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   js-yaml@4.3.0:
@@ -7984,12 +7971,12 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@verdaccio/e2e-cli@2.10.1':
+  '@verdaccio/e2e-cli@2.10.3':
     dependencies:
       '@verdaccio/registry-cli': 1.1.0
-      debug: 4.4.0
+      debug: 4.4.3
       get-port: 5.1.1
-      js-yaml: 4.1.1
+      js-yaml: 4.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8626,10 +8613,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
 
   debug@4.4.3:
     dependencies:
@@ -9380,10 +9363,6 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,22 +24,6 @@ minimumReleaseAgeExclude:
   - '@verdaccio/*'
   - '@verdaccio-scope/*'
   - 'verdaccio-*'
-  # esbuild 0.28.1 is the security patch for GHSA-gv7w-rqvm-qjhr; allow it and
-  # its platform packages in ahead of the 7-day quarantine so the override
-  # below can resolve.
-  - esbuild
-  - '@esbuild/*'
-  # Renovate security update: dompurify@3.4.8 || 3.4.9 || 3.4.11 || 3.4.13
-  - dompurify@3.4.8 || 3.4.9 || 3.4.11 || 3.4.13
-  # Renovate security update: js-yaml@4.2.0 || 5.2.2
-  - js-yaml@4.2.0 || 5.2.2
-  # Renovate security update: vite@8.0.16
-  - vite@8.0.16
-  # Renovate security update: react-router@7.15.1 || 8.3.0
-  - react-router@7.15.1 || 8.3.0
-  # Security update: fast-uri@3.1.4 fixes GHSA-v2hh-gcrm-f6hx (host confusion);
-  # published 2026-07-19, allow it in ahead of the quarantine.
-  - fast-uri@3.1.4
 
 # Force the esbuild security patch (>= 0.28.1) across the whole tree.
 # See GHSA-gv7w-rqvm-qjhr (RCE via NPM_CONFIG_REGISTRY, fixed in 0.28.1).

--- a/scripts/e2e-ui-config.yaml
+++ b/scripts/e2e-ui-config.yaml
@@ -17,6 +17,11 @@ uplinks:
     url: https://registry.npmjs.org/
 
 packages:
+  '@private/*':
+    access: $authenticated
+    publish: $anonymous $authenticated
+    unpublish: $anonymous $authenticated
+
   '@*/*':
     access: $all
     publish: $anonymous $authenticated

--- a/scripts/e2e-ui-local.sh
+++ b/scripts/e2e-ui-local.sh
@@ -59,6 +59,11 @@ uplinks:
     url: https://registry.npmjs.org/
 
 packages:
+  '@private/*':
+    access: \$authenticated
+    publish: \$anonymous \$authenticated
+    unpublish: \$anonymous \$authenticated
+
   '@*/*':
     access: \$all
     publish: \$anonymous \$authenticated


### PR DESCRIPTION
## Summary

Removes incoming HTTP Basic authentication support from the Verdaccio API auth middleware.

- legacy AES API auth now accepts Bearer tokens only
- JWT API auth no longer falls back to Basic username/password credentials
- 401 responses now advertise only `Bearer` in `WWW-Authenticate`
- keeps uplink Basic auth support in `@verdaccio/proxy` untouched because that is outbound registry-to-uplink auth
- adds a major changeset for `@verdaccio/auth` and `@verdaccio/middleware`
- refs verdaccio/verdaccio#5765

## Testing

- `CI=true pnpm --filter @verdaccio/auth test auth.spec.ts auth-utils-middleware.spec.ts -- --coverage=false`
- `CI=true pnpm --filter @verdaccio/middleware test final.spec.ts -- --coverage=false`
- `CI=true pnpm --filter @verdaccio/auth build`
- `CI=true pnpm --filter @verdaccio/middleware build`
- `CI=true pnpm format:check`
- `CI=true pnpm changeset:check`
- `git diff --check`
