### PR TITLE
fix(ui-theme): type check errors

### DIFF
--- a/.changeset/legal-coats-attend.md
+++ b/.changeset/legal-coats-attend.md
@@ -1,5 +1,5 @@
 ---
-"@verdaccio/ui-theme": patch
+'@verdaccio/ui-theme': patch
 ---
 
 fix(ui-theme): type check errors

--- a/.changeset/legal-coats-attend.md
+++ b/.changeset/legal-coats-attend.md
@@ -1,0 +1,5 @@
+---
+"@verdaccio/ui-theme": patch
+---
+
+fix(ui-theme): type check errors

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "lint": "oxlint --max-warnings 28",
     "lint:fix": "oxlint --fix",
     "test": "pnpm --filter \"./packages/**\" test",
+    "type-check": "pnpm --filter \"./packages/**\" run type-check",
     "e2e:ui:start": "node packages/verdaccio/bin/verdaccio --config ./scripts/e2e-ui-config.yaml",
     "e2e:ui:run": "cypress run",
     "e2e:ui:open": "cypress open",

--- a/packages/plugins/ui-theme/src/components/Support/Support.tsx
+++ b/packages/plugins/ui-theme/src/components/Support/Support.tsx
@@ -62,10 +62,10 @@ const Support = () => {
           </span>
           <ul style={{ padding: '10px 0' }}>{linkElements}</ul>
           <div>
-            <Typography variant="div">{`Spread the voice, make the difference today.`}</Typography>
+            <Typography variant="inherit">{`Spread the voice, make the difference today.`}</Typography>
           </div>
           <div style={{ padding: '10px 0', fontWeight: 600 }}>
-            <Typography variant="div">{`Att: Verdaccio Lead Mantainer, Juan P.`}</Typography>
+            <Typography variant="inherit">{`Att: Verdaccio Lead Mantainer, Juan P.`}</Typography>
           </div>
         </Grid>
       </Grid>

--- a/packages/plugins/ui-theme/src/i18n/config.ts
+++ b/packages/plugins/ui-theme/src/i18n/config.ts
@@ -23,9 +23,9 @@ i18n
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
     // in case window.VEDACCIO_LANGUAGE is undefined,it will fall back to 'en-US'
-    lng: window?.__VERDACCIO_BASENAME_UI_OPTIONS?.language || DEFAULT_LANGUAGE,
+    lng: (window as any)?.__VERDACCIO_BASENAME_UI_OPTIONS?.language || DEFAULT_LANGUAGE,
     fallbackLng: DEFAULT_LANGUAGE,
-    whitelist: [...listLanguagesAsString],
+    supportedLngs: [...listLanguagesAsString],
     load: 'currentOnly',
     react: {
       useSuspense: false,

--- a/packages/plugins/ui-theme/tsconfig.build.json
+++ b/packages/plugins/ui-theme/tsconfig.build.json
@@ -4,7 +4,7 @@
     "outDir": "./build",
     "skipLibCheck": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
@@ -12,10 +12,9 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "checkJs": false,
-    "baseUrl": ".",
     "paths": {
-      "verdaccio-ui/components/*": ["src/components/*"],
-      "verdaccio-ui/utils/*": ["src/utils/*"]
+      "verdaccio-ui/components/*": ["./src/components/*"],
+      "verdaccio-ui/utils/*": ["./src/utils/*"]
     }
   },
   "include": ["src/**/*.ts", "types/*.d.ts", "i18n/**/*.json"],

--- a/packages/plugins/ui-theme/tsconfig.json
+++ b/packages/plugins/ui-theme/tsconfig.json
@@ -9,10 +9,9 @@
     "allowJs": true,
     "sourceMap": true,
     "checkJs": false,
-    "baseUrl": ".",
     "paths": {
-      "verdaccio-ui/components/*": ["src/components/*"],
-      "verdaccio-ui/utils/*": ["src/utils/*"]
+      "verdaccio-ui/components/*": ["./src/components/*"],
+      "verdaccio-ui/utils/*": ["./src/utils/*"]
     }
   },
   "include": ["src", "types/*.d.ts", "src/i18n/**/*.json"],

--- a/packages/plugins/ui-theme/types/vite-env.d.ts
+++ b/packages/plugins/ui-theme/types/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/plugins/ui-theme/vitest.config.mjs
+++ b/packages/plugins/ui-theme/vitest.config.mjs
@@ -15,14 +15,14 @@ export default defineConfig({
 
   resolve: {
     alias: {
-      'verdaccio-ui/components': path.resolve(__dirname, './src/components'),
-      'verdaccio-ui/utils': path.resolve(__dirname, './src/utils'),
-      'verdaccio-ui/providers': path.resolve(__dirname, './src/providers'),
+      'verdaccio-ui/components': path.resolve(import.meta.dirname, './src/components'),
+      'verdaccio-ui/utils': path.resolve(import.meta.dirname, './src/utils'),
+      'verdaccio-ui/providers': path.resolve(import.meta.dirname, './src/providers'),
       // Swap @verdaccio/ui-i18n for a Vite-native loader that uses import.meta.glob
       // instead of the CJS require()-based implementation in the published package.
-      '@verdaccio/ui-i18n': path.resolve(__dirname, './src/i18n/loadTranslationFile.ts'),
+      '@verdaccio/ui-i18n': path.resolve(import.meta.dirname, './src/i18n/loadTranslationFile.ts'),
       // react-markdown v9 is ESM-only, mock it for Node.js 18 compatibility
-      'react-markdown': path.resolve(__dirname, './vitest/react-markdown-mock.js'),
+      'react-markdown': path.resolve(import.meta.dirname, './vitest/react-markdown-mock.js'),
     },
   },
 


### PR DESCRIPTION
Fixes the following type-check errors

`tsconfig.build.json`:

<img width="775" height="469" alt="image" src="https://github.com/user-attachments/assets/8df56f49-e26b-4247-abac-78f4170fe1ef" />

`Support.tsx`:

<img width="747" height="106" alt="image" src="https://github.com/user-attachments/assets/42f3c6d8-4dec-43cf-91e9-c3ea70efd2c2" />

`i18n/config.ts`:
https://www.i18next.com/misc/migration-guide#removed-deprecated

<img width="973" height="193" alt="image" src="https://github.com/user-attachments/assets/7af320ec-c110-402b-978b-7dcb1bd0c633" />

`i18n/loadTranslationFile.ts`:
`import.meta.glob` is a Vite API, so I added `types/vite-env.d.ts`

<img width="679" height="110" alt="image" src="https://github.com/user-attachments/assets/2588de5f-1201-4986-98a8-653932622be6" />
