### PR TITLE
fix(ui-components): lint and test warnings

### DIFF
--- a/.changeset/witty-sails-learn.md
+++ b/.changeset/witty-sails-learn.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+fix(ui-components): lint and test warnings

--- a/packages/ui-components/src/sections/Header/Header.tsx
+++ b/packages/ui-components/src/sections/Header/Header.tsx
@@ -29,17 +29,21 @@ const Header: React.FC<Props> = ({
   const { configOptions } = useConfig();
   const { userState, logOutUser } = useAuth();
 
-  // Use a ref to always have the latest token in the interval callback
+  // Use refs to always have the latest token/logout in the interval callback
   const tokenRef = useRef(userState?.token);
+  const logOutUserRef = useRef(logOutUser);
   useEffect(() => {
     tokenRef.current = userState?.token;
   }, [userState?.token]);
+  useEffect(() => {
+    logOutUserRef.current = logOutUser;
+  }, [logOutUser]);
 
   useEffect(() => {
     function checkToken() {
       const token = tokenRef.current;
       if (token && isTokenExpire(token)) {
-        logOutUser?.();
+        logOutUserRef.current?.();
       }
     }
     checkToken();

--- a/packages/ui-components/src/sections/Security/Login.tsx
+++ b/packages/ui-components/src/sections/Security/Login.tsx
@@ -47,13 +47,16 @@ const Login: React.FC = () => {
     formState: { isValid, errors },
   } = form;
 
-  const handleLogin = async (body: { username: string; password: string }) => {
-    try {
-      return await trigger(body);
-    } catch (err) {
-      throw normalizeAuthError(err);
-    }
-  };
+  const handleLogin = useCallback(
+    async (body: { username: string; password: string }) => {
+      try {
+        return await trigger(body);
+      } catch (err) {
+        throw normalizeAuthError(err);
+      }
+    },
+    [trigger]
+  );
 
   const onSuccess = useCallback(() => {
     navigate(`${Route.SUCCESS}?messageType=${MessageType.Login}`);

--- a/packages/ui-components/vitest.config.mjs
+++ b/packages/ui-components/vitest.config.mjs
@@ -83,8 +83,8 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      'verdaccio-ui/components': path.resolve(__dirname, './src/components'),
-      'verdaccio-ui/utils': path.resolve(__dirname, './src/utils'),
+      'verdaccio-ui/components': path.resolve(import.meta.dirname, './src/components'),
+      'verdaccio-ui/utils': path.resolve(import.meta.dirname, './src/utils'),
     },
   },
 });


### PR DESCRIPTION
Fix lint issues:

```bash
$ oxlint --max-warnings 28
Warning: React hook useCallback depends on `handleLogin`, which changes every render
Warning: React Hook useEffect has a missing dependency: 'logOutUser'
```

This makes the automatic logout on token expiry more reliable. Users whose sessions expire should be logged out at/near the expected time. In cases where logOutUser had changed since the interval callback was created, logout could previously fail to trigger correctly; this commit prevents that.

Fix test setup:

```
packages/ui-components test: (!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
packages/ui-components test:   - `__dirname` (vitest.config.mjs:86:47). Use `import.meta.dirname` instead
```