### PR TITLE
fix(api): user name in login message

### DIFF
--- a/.changeset/fifty-walls-taste.md
+++ b/.changeset/fifty-walls-taste.md
@@ -1,0 +1,5 @@
+---
+"@verdaccio/api": patch
+---
+
+fix(api): user name in login message

--- a/.changeset/fifty-walls-taste.md
+++ b/.changeset/fifty-walls-taste.md
@@ -1,5 +1,5 @@
 ---
-"@verdaccio/api": patch
+'@verdaccio/api': patch
 ---
 
 fix(api): user name in login message

--- a/packages/api/src/user.ts
+++ b/packages/api/src/user.ts
@@ -110,7 +110,7 @@ export default function (route: Router, auth: Auth, config: Config, logger: Logg
             res.status(HTTP_STATUS.CREATED);
             res.set(HEADERS.CACHE_CONTROL, HEADERS.NO_CACHE);
 
-            const message = authUtils.getAuthenticatedMessage(req.remote_user.name);
+            const message = authUtils.getAuthenticatedMessage(name);
             debug('login: created user message %o', message);
 
             return next({


### PR DESCRIPTION
Fix message returned after successful login

Before:

```
verdaccio:api:user login: created user message "you are authenticated as 'undefined'"
```

After:

```
verdaccio:api:user login: created user message "you are authenticated as 'mbtools'"
```