### PR TITLE
fix(local-storage-legacy): confine storage file paths to the storage root

### DIFF
--- a/.changeset/local-storage-legacy-path-traversal-guard.md
+++ b/.changeset/local-storage-legacy-path-traversal-guard.md
@@ -1,0 +1,11 @@
+---
+'@verdaccio/local-storage-legacy': patch
+---
+
+fix: confine local-storage-legacy file paths to the storage root
+
+Harden the legacy local-storage plugin against path traversal. Package and
+tarball names are now resolved against the configured storage root and rejected
+if the resulting path would escape it, on top of the existing filename
+sanitization. This mirrors the same guard in `@verdaccio/local-storage`; there
+is no observable change for legitimate package and tarball names.

--- a/packages/plugins/local-storage-legacy/src/local-fs.ts
+++ b/packages/plugins/local-storage-legacy/src/local-fs.ts
@@ -331,7 +331,13 @@ export default class LocalFS {
   }
 
   private _getStorage(fileName = ''): string {
-    const storagePath: string = path.join(this.path, sanitize(fileName));
+    // Keep the resolved path within the storage root.
+    const storageRoot: string = path.resolve(this.path);
+    const storagePath: string = path.resolve(storageRoot, sanitize(fileName));
+
+    if (storagePath !== storageRoot && !storagePath.startsWith(storageRoot + path.sep)) {
+      throw fSError(noSuchFile, 404);
+    }
 
     return storagePath;
   }

--- a/packages/plugins/local-storage-legacy/tests/local-fs.test.ts
+++ b/packages/plugins/local-storage-legacy/tests/local-fs.test.ts
@@ -7,8 +7,17 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { readFile, unlockFile } from '@verdaccio/file-locking';
 import type { Logger, Package } from '@verdaccio/types';
 
+import sanitize from 'sanitize-filename';
+
 import LocalDriver, { fSError, fileExist, noSuchFile, resourceNotAvailable } from '../src/local-fs';
 import pkg from './__fixtures__/pkg';
+
+// Wrap the real sanitizer so individual tests can force a traversal sequence
+// through it and prove the _getStorage containment barrier catches it on its own.
+vi.mock('sanitize-filename', async (importOriginal) => {
+  const actual: any = await importOriginal();
+  return { default: vi.fn(actual.default) };
+});
 
 vi.mock('@verdaccio/file-locking', () => ({
   readFile: vi.fn(),
@@ -447,6 +456,44 @@ describe('Local FS test', () => {
       // Verify the stream was created (it doesn't throw synchronously)
       expect(writeStream).toBeDefined();
       writeStream.abort();
+    });
+  });
+
+  describe('_getStorage() path-traversal barrier', () => {
+    const storageRoot = path.join('./_storage', 'guard-pkg');
+    // _getStorage is private; reach it directly to assert the containment barrier.
+    const getStorage = (localFs: LocalDriver, name: string): string =>
+      (localFs as any)._getStorage(name);
+
+    test('resolves a legitimate name under the storage root', () => {
+      const localFs = new LocalDriver(storageRoot, logger);
+      const resolved = getStorage(localFs, pkgFileName);
+
+      expect(resolved).toBe(path.join(path.resolve(storageRoot), pkgFileName));
+      expect(resolved.startsWith(path.resolve(storageRoot) + path.sep)).toBe(true);
+    });
+
+    test('confines traversal sequences to the storage root', () => {
+      const localFs = new LocalDriver(storageRoot, logger);
+      const resolved = getStorage(localFs, '../../etc/passwd');
+
+      // sanitize-filename strips the separators, so the name cannot escape the root
+      expect(resolved.startsWith(path.resolve(storageRoot) + path.sep)).toBe(true);
+      expect(resolved).not.toContain(`${path.sep}etc${path.sep}passwd`);
+    });
+
+    test('rejects a path that escapes the storage root with a plain not-found', () => {
+      // Force the sanitizer to leak a traversal sequence to exercise the barrier alone.
+      vi.mocked(sanitize).mockReturnValueOnce(`..${path.sep}..${path.sep}escape`);
+      const localFs = new LocalDriver(storageRoot, logger);
+
+      expect.assertions(2);
+      try {
+        getStorage(localFs, 'anything');
+      } catch (err: any) {
+        expect(err.code).toBe(noSuchFile);
+        expect(err.status ?? err.statusCode).toBe(404);
+      }
     });
   });
 });


### PR DESCRIPTION
## What

Hardens path handling in the `@verdaccio/local-storage-legacy` plugin. Package and
tarball names are now resolved against the configured storage root and kept
confined to it, on top of the existing filename sanitization. There is no
observable change for legitimate package and tarball names.

`_getStorage` is the single point every file access in this plugin goes through,
so the guard lives there.

## Changes

- Resolve and confine the composed path to the storage root in `LocalFS._getStorage`.
- Unit tests covering the resolution and confinement behavior.
- Changeset (`patch`) for `@verdaccio/local-storage-legacy`.

## Notes

Keeps parity with the same guard in `@verdaccio/local-storage` on `master`.
