### PR TITLE
fix: limit web UI search results

### DIFF
--- a/.changeset/limit-web-search-results.md
+++ b/.changeset/limit-web-search-results.md
@@ -1,0 +1,5 @@
+---
+'verdaccio': patch
+---
+
+Limit web UI search responses to 20 packages.

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ static/*
 /.yarn/install-state.gz
 .history
 CLAUDE.md
+AGENTS.md
 .claude/settings.json
 .github/*.md
 /.claude

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@types/semver": "7.7.1",
     "@types/supertest": "6.0.3",
     "@verdaccio-scope/verdaccio-auth-foo": "0.0.2",
-    "@verdaccio/e2e-cli": "2.10.2",
+    "@verdaccio/e2e-cli": "2.10.4",
     "@verdaccio/e2e-ui": "2.4.2",
     "@verdaccio/test-helper": "4.1.0",
     "@verdaccio/types": "13.0.6",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@types/supertest": "6.0.3",
     "@verdaccio-scope/verdaccio-auth-foo": "0.0.2",
     "@verdaccio/e2e-cli": "2.10.4",
-    "@verdaccio/e2e-ui": "2.4.2",
+    "@verdaccio/e2e-ui": "2.4.3",
     "@verdaccio/test-helper": "4.1.0",
     "@verdaccio/types": "13.0.6",
     "@vitest/coverage-v8": "4.1.8",

--- a/src/api/web/api/search.ts
+++ b/src/api/web/api/search.ts
@@ -10,6 +10,8 @@ import type Storage from '../../../lib/storage';
 import type { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '../../../types';
 import { wrapPath } from './utils';
 
+const MAX_SEARCH_RESULTS = 20;
+
 function addSearchWebApi(storage: Storage, auth: Auth): Router {
   const route = Router();
   // Search package
@@ -26,29 +28,34 @@ function addSearchWebApi(storage: Storage, auth: Auth): Router {
       const results = indexer.hits;
 
       const getPackageInfo = function (i): void {
+        const continueOrFinish = (): void => {
+          if (packages.length >= MAX_SEARCH_RESULTS || i >= results.length - 1) {
+            next(packages.slice(0, MAX_SEARCH_RESULTS));
+          } else {
+            getPackageInfo(i + 1);
+          }
+        };
+
         storage.getPackage({
           name: results[i].id,
           uplinksLook: false,
           callback: (err, entry: Manifest): void => {
-            if (!err && entry) {
-              auth.allow_access(
-                { packageName: entry.name },
-                req.remote_user,
-                function (err, allowed): void {
-                  if (err || !allowed) {
-                    return;
-                  }
+            if (err || !entry) {
+              continueOrFinish();
+              return;
+            }
 
+            auth.allow_access(
+              { packageName: entry.name },
+              req.remote_user,
+              function (err, allowed): void {
+                if (!err && allowed) {
                   packages.push(entry.versions[entry[DIST_TAGS].latest]);
                 }
-              );
-            }
 
-            if (i >= results.length - 1) {
-              next(packages);
-            } else {
-              getPackageInfo(i + 1);
-            }
+                continueOrFinish();
+              }
+            );
           },
         });
       };

--- a/src/api/web/api/search.ts
+++ b/src/api/web/api/search.ts
@@ -50,7 +50,10 @@ function addSearchWebApi(storage: Storage, auth: Auth): Router {
               req.remote_user,
               function (err, allowed): void {
                 if (!err && allowed) {
-                  packages.push(entry.versions[entry[DIST_TAGS].latest]);
+                  const latestVersion = entry.versions?.[entry[DIST_TAGS]?.latest];
+                  if (latestVersion) {
+                    packages.push(latestVersion);
+                  }
                 }
 
                 continueOrFinish();

--- a/test/unit/modules/web/api.web.search.spec.ts
+++ b/test/unit/modules/web/api.web.search.spec.ts
@@ -4,7 +4,9 @@ import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vite
 import { Auth } from '@verdaccio/auth';
 import { errorUtils, HEADERS, HEADER_TYPE, HTTP_STATUS } from '@verdaccio/core';
 import { generatePackageMetadata } from '@verdaccio/test-helper';
+import type { Manifest } from '@verdaccio/types';
 
+import Storage from '../../../../src/lib/storage';
 import { setup } from '../../../../src/lib/logger';
 import { createWebApp, seedPackages } from './__helper';
 
@@ -125,5 +127,29 @@ describe('web endpoint: search', () => {
 
     expect(res.body).toHaveLength(2);
     expect(res.body.map((pkg) => pkg.name)).not.toContain('vortexmango-1');
+  });
+
+  test('should skip a package without a valid latest version', async () => {
+    await publishSearchPackages(app, 'brokenmanifest', 3);
+    const originalGetPackage = Storage.prototype.getPackage;
+    vi.spyOn(Storage.prototype, 'getPackage').mockImplementation(function (options) {
+      if (options.name === 'brokenmanifest-1') {
+        options.callback(null, {
+          name: options.name,
+          versions: {},
+          'dist-tags': { latest: '1.0.0' },
+        } as Manifest);
+        return;
+      }
+
+      originalGetPackage.call(this, options);
+    });
+
+    const res = await request(app)
+      .get('/-/verdaccio/data/search/brokenmanifest')
+      .expect(HTTP_STATUS.OK);
+
+    expect(res.body).toHaveLength(2);
+    expect(res.body.every(Boolean)).toBe(true);
   });
 });

--- a/test/unit/modules/web/api.web.search.spec.ts
+++ b/test/unit/modules/web/api.web.search.spec.ts
@@ -1,12 +1,25 @@
 import request from 'supertest';
-import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from 'vitest';
 
-import { HTTP_STATUS } from '@verdaccio/core';
+import { Auth } from '@verdaccio/auth';
+import { errorUtils, HEADERS, HEADER_TYPE, HTTP_STATUS } from '@verdaccio/core';
+import { generatePackageMetadata } from '@verdaccio/test-helper';
 
 import { setup } from '../../../../src/lib/logger';
 import { createWebApp, seedPackages } from './__helper';
 
 setup({});
+
+async function publishSearchPackages(app, prefix: string, count: number): Promise<void> {
+  for (let index = 0; index < count; index++) {
+    const packageName = `${prefix}-${index}`;
+    await request(app)
+      .put(`/${packageName}`)
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .send(JSON.stringify(generatePackageMetadata(packageName)))
+      .expect(HTTP_STATUS.CREATED);
+  }
+}
 
 describe('web endpoint: search', () => {
   vi.setConfig({ testTimeout: 10000 });
@@ -20,6 +33,10 @@ describe('web endpoint: search', () => {
 
   afterAll(() => {
     mockRegistry[0].stop();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   test('should search pk1-test', () => {
@@ -53,5 +70,60 @@ describe('web endpoint: search', () => {
           done(true);
         });
     });
+  });
+
+  test('should limit the number of search results', async () => {
+    await publishSearchPackages(app, 'search-limit-package', 25);
+
+    const res = await request(app)
+      .get('/-/verdaccio/data/search/search-limit-package')
+      .expect(HTTP_STATUS.OK);
+
+    expect(res.body).toHaveLength(20);
+  });
+
+  test('should return all search results when there are fewer than the limit', async () => {
+    await publishSearchPackages(app, 'quokkaomega', 5);
+
+    const res = await request(app)
+      .get('/-/verdaccio/data/search/quokkaomega')
+      .expect(HTTP_STATUS.OK);
+
+    expect(res.body).toHaveLength(5);
+  });
+
+  test('should wait for asynchronous access checks', async () => {
+    await publishSearchPackages(app, 'nebulaquartz', 3);
+    vi.spyOn(Auth.prototype, 'allow_access').mockImplementation((_pkg, _user, callback) => {
+      setTimeout(() => callback(null, true), 10);
+    });
+
+    const res = await request(app)
+      .get('/-/verdaccio/data/search/nebulaquartz')
+      .expect(HTTP_STATUS.OK);
+
+    expect(res.body).toHaveLength(3);
+  });
+
+  test('should skip an access error and continue searching', async () => {
+    await publishSearchPackages(app, 'vortexmango', 3);
+    vi.spyOn(Auth.prototype, 'allow_access').mockImplementation(
+      ({ packageName }, _user, callback) => {
+        setTimeout(() => {
+          if (packageName.endsWith('-1')) {
+            callback(errorUtils.getInternalError('access failed'), false);
+          } else {
+            callback(null, true);
+          }
+        }, 10);
+      }
+    );
+
+    const res = await request(app)
+      .get('/-/verdaccio/data/search/vortexmango')
+      .expect(HTTP_STATUS.OK);
+
+    expect(res.body).toHaveLength(2);
+    expect(res.body.map((pkg) => pkg.name)).not.toContain('vortexmango-1');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1938,12 +1938,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@verdaccio/e2e-ui@npm:2.4.2":
-  version: 2.4.2
-  resolution: "@verdaccio/e2e-ui@npm:2.4.2"
+"@verdaccio/e2e-ui@npm:2.4.3":
+  version: 2.4.3
+  resolution: "@verdaccio/e2e-ui@npm:2.4.3"
   peerDependencies:
     cypress: ">=12.0.0"
-  checksum: 10c0/de607d84e045c028396c8a42ae54698fd7e652ddf12e67987c97e691565186eebed8792bbd6f8a197e15b1df3cfb9e864f8378b9d4996e1dd3f984df582ee792
+  checksum: 10c0/3266835642479a5c09e0896469fd3aa4d47a9969c554688e0f435e8a4b1d0ff150c68e18556a04204c3a69f27976b86f35e658afcb16188c1bea025a2bedb6e7
   languageName: node
   linkType: hard
 
@@ -8240,7 +8240,7 @@ __metadata:
     "@verdaccio/config": "npm:8.2.2"
     "@verdaccio/core": "npm:8.2.2"
     "@verdaccio/e2e-cli": "npm:2.10.4"
-    "@verdaccio/e2e-ui": "npm:2.4.2"
+    "@verdaccio/e2e-ui": "npm:2.4.3"
     "@verdaccio/hooks": "npm:8.1.3"
     "@verdaccio/loaders": "npm:8.1.2"
     "@verdaccio/local-storage-legacy": "npm:11.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1924,17 +1924,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@verdaccio/e2e-cli@npm:2.10.2":
-  version: 2.10.2
-  resolution: "@verdaccio/e2e-cli@npm:2.10.2"
+"@verdaccio/e2e-cli@npm:2.10.4":
+  version: 2.10.4
+  resolution: "@verdaccio/e2e-cli@npm:2.10.4"
   dependencies:
     "@verdaccio/registry-cli": "npm:^1.1.0"
-    debug: "npm:4.4.0"
-    get-port: "npm:5.1.1"
-    js-yaml: "npm:4.1.1"
+    debug: "npm:4.4.3"
+    get-port: "npm:7.2.0"
+    js-yaml: "npm:5.2.3"
   bin:
     verdaccio-e2e: ./bin/e2e-cli.js
-  checksum: 10c0/eb1d014fc5dc62eaa6944a387c7dd7f23250d58e94a1be8344e6012ac0a119f47bacf8b50c5a16095cd0987fe11c14baf8a6c6c3dc76ca7c3c3eb6d091497a30
+  checksum: 10c0/fcbeda5464fec6379b6b9f07f8258730b676a91213cc1241d1ea9a03d5cdeab237743adbd593ea26b27a130255030cf56c961c765193754792762313509dc6c5
   languageName: node
   linkType: hard
 
@@ -3467,18 +3467,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4.4.0":
-  version: 4.4.0
-  resolution: "debug@npm:4.4.0"
-  dependencies:
-    ms: "npm:^2.1.3"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/db94f1a182bf886f57b4755f85b3a74c39b5114b9377b7ab375dc2cfa3454f09490cc6c30f829df3fc8042bc8b8995f6567ce5cd96f3bc3688bd24027197d9de
-  languageName: node
-  linkType: hard
-
 "debug@npm:4.4.3, debug@npm:^4.3.4":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
@@ -4416,13 +4404,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-port@npm:5.1.1":
-  version: 5.1.1
-  resolution: "get-port@npm:5.1.1"
-  checksum: 10c0/2873877a469b24e6d5e0be490724a17edb39fafc795d1d662e7bea951ca649713b4a50117a473f9d162312cb0e946597bd0e049ed2f866e79e576e8e213d3d1c
-  languageName: node
-  linkType: hard
-
 "get-port@npm:7.2.0":
   version: 7.2.0
   resolution: "get-port@npm:7.2.0"
@@ -5072,17 +5053,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1, js-yaml@npm:^4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
-  languageName: node
-  linkType: hard
-
 "js-yaml@npm:5.2.2":
   version: 5.2.2
   resolution: "js-yaml@npm:5.2.2"
@@ -5091,6 +5061,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.mjs
   checksum: 10c0/e8ded203b235b3d562818c67bf362122abbcee89e507b62bddcdd3085b2f2dd866071e5e78f8e617d41d1a0c0baa1cec12a8fdec5859c571bf862adf585e2684
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:5.2.3":
+  version: 5.2.3
+  resolution: "js-yaml@npm:5.2.3"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.mjs
+  checksum: 10c0/55cd6310c8eee88d432ae038d451ac9d6aa0eb9e5d38a94df3d6c4a4015d08c9dad7c18669e0e8854e4173a615d6b6b7448bd0aac408773f8a46122ffd863c69
   languageName: node
   linkType: hard
 
@@ -5103,6 +5084,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "js-yaml@npm:4.1.1"
+  dependencies:
+    argparse: "npm:^2.0.1"
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
   languageName: node
   linkType: hard
 
@@ -8247,7 +8239,7 @@ __metadata:
     "@verdaccio/auth": "npm:8.1.2"
     "@verdaccio/config": "npm:8.2.2"
     "@verdaccio/core": "npm:8.2.2"
-    "@verdaccio/e2e-cli": "npm:2.10.2"
+    "@verdaccio/e2e-cli": "npm:2.10.4"
     "@verdaccio/e2e-ui": "npm:2.4.2"
     "@verdaccio/hooks": "npm:8.1.3"
     "@verdaccio/loaders": "npm:8.1.2"


### PR DESCRIPTION
## Context

The Verdaccio 6.x web UI search endpoint returned every matching package without a result-size limit. Large registries could therefore trigger oversized responses and unnecessary storage and authorization work.

Fixes #6087.

## Changes

- cap web UI search responses at 20 authorized packages, matching the bounded behavior used by newer Verdaccio search paths
- stop walking index hits once the response page is full
- wait for each asynchronous access check before deciding whether to continue or respond
- skip missing packages and access-check errors while continuing to inspect later results
- add a patch Changeset for verdaccio
- ignore the local AGENTS.md contributor-instruction file

## Why the access-check flow changed

The previous callback flow continued to the next index hit immediately after starting allow_access. That worked with synchronous authorization plugins, but a plugin backed by a database, LDAP server, or remote API could answer later. In that case the endpoint could respond before authorization callbacks had populated the result list.

The new flow advances only after the current storage lookup and access callback have completed. This preserves access filtering, produces deterministic results for asynchronous plugins, and allows the 20-result early exit to work reliably.
