### PR TITLE
fix(core): reject package names with extra path separators in validatePackage

### DIFF
--- a/.changeset/fix-useloginform-declaration-emit.md
+++ b/.changeset/fix-useloginform-declaration-emit.md
@@ -1,0 +1,9 @@
+---
+'@verdaccio/ui-components': patch
+---
+
+Annotate the `useLoginForm` return type so declaration emit no longer fails
+
+The inferred return type referenced `react-hook-form`'s internal `FormState`,
+which `tsc --emitDeclarationOnly` could not name portably (TS2883). Declaring the
+return as `UseFormReturn<LoginFormValues> & { onSubmit }` fixes the build.

--- a/.changeset/validate-package-name-canonical.md
+++ b/.changeset/validate-package-name-canonical.md
@@ -1,0 +1,10 @@
+---
+'@verdaccio/core': patch
+---
+
+Reject package names with extra path separators in `validatePackage`
+
+`validatePackage` split the name with a limit, which ignored any separators past
+the second segment and accepted non-canonical names such as `@scope/pkg/`. The
+name is now split on every separator and only one- or two-segment names are
+considered valid, so a package name has a single canonical form.

--- a/packages/core/core/src/validation-utils.ts
+++ b/packages/core/core/src/validation-utils.ts
@@ -53,13 +53,20 @@ export function validateName(name: string): boolean {
  * @return {Boolean} whether the package is valid or not
  */
 export function validatePackage(name: string): boolean {
-  const nameList = name.split('/', 2);
+  // Split on every separator (no limit) so trailing or interior slashes are not
+  // silently dropped, keeping a single canonical form per package name.
+  const nameList = name.split('/');
   if (nameList.length === 1) {
     // normal package
     return validateName(nameList[0]);
+  } else if (nameList.length === 2) {
+    // scoped package
+    return (
+      nameList[0][0] === '@' && validateName(nameList[0].slice(1)) && validateName(nameList[1])
+    );
   }
-  // scoped package
-  return nameList[0][0] === '@' && validateName(nameList[0].slice(1)) && validateName(nameList[1]);
+  // anything with 3+ segments is never a valid package name
+  return false;
 }
 
 /**

--- a/packages/core/core/test/validation-utilts.spec.ts
+++ b/packages/core/core/test/validation-utilts.spec.ts
@@ -29,6 +29,17 @@ describe('validatePackage', () => {
     expect(validatePackage('favicon.ico')).toBeFalsy();
     expect(validatePackage('%')).toBeFalsy();
   });
+
+  // a package name must have a single canonical form: extra path separators
+  // (trailing, interior or nested) are not valid and must be rejected.
+  test('should reject non-canonical names with extra path separators', () => {
+    expect(validatePackage('@scope/pkg/')).toBeFalsy();
+    expect(validatePackage('@scope/pkg//')).toBeFalsy();
+    expect(validatePackage('@scope/pkg/extra')).toBeFalsy();
+    expect(validatePackage('@scope/')).toBeFalsy();
+    expect(validatePackage('pkg/')).toBeFalsy();
+    expect(validatePackage('@scope//pkg')).toBeFalsy();
+  });
 });
 
 describe('isObject', () => {

--- a/packages/ui-components/src/components/LoginForm/useLoginForm.ts
+++ b/packages/ui-components/src/components/LoginForm/useLoginForm.ts
@@ -1,6 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useCallback } from 'react';
-import { useForm } from 'react-hook-form';
+import { type UseFormReturn, useForm } from 'react-hook-form';
 
 import { useAuth } from '../../providers/AuthProvider';
 import type { LoginFormValues } from '../../utils/schemas';
@@ -10,7 +10,9 @@ type Options = {
   onSuccess?: () => void;
 };
 
-export function useLoginForm({ onSuccess }: Options = {}) {
+export function useLoginForm({ onSuccess }: Options = {}): UseFormReturn<LoginFormValues> & {
+  onSubmit: (data: LoginFormValues) => Promise<void>;
+} {
   const { handleLogin } = useAuth();
 
   const form = useForm<LoginFormValues>({


### PR DESCRIPTION
## What

`validatePackage` in `@verdaccio/core` now rejects package names that carry extra
path separators. It previously split the name with a limit, which ignored any
separators past the second segment (so a name like `@scope/pkg/` was accepted). It
now splits on every separator and only one- or two-segment names are considered
valid, giving each package name a single canonical form.

## Notes

- `@verdaccio/core` gets a `patch`; changeset included.
- No behavior change for well-formed names — scoped (`@scope/name`) and unscoped
  (`name`) packages validate exactly as before.

## Testing

- `@verdaccio/core` validation test suite green, with new cases covering
  trailing, interior and nested separators.
