### PR TITLE
fix(cli): move tsx to devDependencies

### DIFF
--- a/.changeset/tsx-dev-dependency.md
+++ b/.changeset/tsx-dev-dependency.md
@@ -1,0 +1,7 @@
+---
+'@verdaccio/cli': patch
+---
+
+Move `tsx` to `devDependencies`
+
+`tsx` is only used by the package's `start` script, but it was listed as a runtime dependency, so every install of `verdaccio` also pulled in `esbuild` (~10MB) and its `postinstall` script. Nothing in the published build references `tsx`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,12 +51,12 @@
     "@verdaccio/server": "workspace:9.0.0-next-9.29",
     "clipanion": "4.0.0-rc.4",
     "envinfo": "7.19.0",
-    "semver": "7.8.5",
-    "tsx": "4.22.4"
+    "semver": "7.8.5"
   },
   "devDependencies": {
     "@verdaccio/types": "workspace:14.0.0-next-9.13",
     "rimraf": "6.1.3",
+    "tsx": "4.22.4",
     "vite": "8.2.1",
     "vitest": "4.1.10"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,9 +368,6 @@ importers:
       semver:
         specifier: 7.8.5
         version: 7.8.5
-      tsx:
-        specifier: 4.22.4
-        version: 4.22.4
     devDependencies:
       '@verdaccio/types':
         specifier: workspace:14.0.0-next-9.13
@@ -378,6 +375,9 @@ importers:
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
       vite:
         specifier: 8.2.1
         version: 8.2.1(@types/node@24.13.2)(esbuild@0.28.1)(tsx@4.22.4)(yaml@2.8.1)


### PR DESCRIPTION
`tsx` is declared as a runtime dependency of `@verdaccio/cli`, but it is only used by the package's `start` script. As a result every install of `verdaccio` also pulls in `esbuild` (~10MB) and triggers its `postinstall` script — which npm now surfaces as an `allow-scripts` warning on a plain `npm i -g verdaccio`.

```
verdaccio
└─ @verdaccio/cli
   └─ tsx
      └─ esbuild  (postinstall: node install.js)
```

Nothing in the published build references `tsx` (`grep -rn tsx build/` is empty), so moving it to `devDependencies` drops `esbuild` from the install tree with no runtime impact.

Introduced in #5915, which swapped `ts-node` (a devDependency) for `tsx` and landed it under `dependencies`. `@verdaccio/cli` is the only package in the monorepo affected.