### PR TITLE
fix(search): include license in local results

### DIFF
--- a/.changeset/search-local-license.md
+++ b/.changeset/search-local-license.md
@@ -1,0 +1,7 @@
+---
+'@verdaccio/core': patch
+'@verdaccio/store': patch
+'@verdaccio/types': patch
+---
+
+Include the latest package version license in local npm Search v1 results.

--- a/packages/api/test/integration/search.spec.ts
+++ b/packages/api/test/integration/search.spec.ts
@@ -42,6 +42,7 @@ describe('search', () => {
               date: mockDate,
               description: 'package generated',
               keywords: [],
+              license: 'ISC',
               links: {
                 npm: '',
               },
@@ -106,6 +107,7 @@ describe('search', () => {
               date: mockDate,
               description: 'package generated',
               keywords: [],
+              license: 'ISC',
               links: {
                 npm: '',
               },

--- a/packages/api/test/integration/search.spec.ts
+++ b/packages/api/test/integration/search.spec.ts
@@ -221,6 +221,44 @@ describe('search', () => {
       expect(forwardedQuery.get('size')).toBe('250');
       expect(forwardedQuery.get('from')).toBe('10000');
     });
+
+    test('should preserve the license returned by an uplink', async () => {
+      nock('https://registry.npmjs.org')
+        .get(/\/-\/v1\/search/)
+        .reply(200, {
+          objects: [
+            {
+              package: {
+                name: 'remote-license-package',
+                version: '1.0.0',
+                description: 'remote package',
+                license: 'BSD-3-Clause',
+                keywords: [],
+                date: '2018-01-14T11:17:40.712Z',
+                publisher: { username: 'remote-user', email: '' },
+                maintainers: [{ username: 'remote-user', email: '' }],
+                links: { npm: 'https://www.npmjs.com/package/remote-license-package' },
+              },
+              score: {
+                final: 1,
+                detail: { maintenance: 1, popularity: 1, quality: 1 },
+              },
+              searchScore: 1,
+            },
+          ],
+          total: 1,
+          time: '2018-01-14T11:17:40.712Z',
+        });
+
+      const app = await initializeServer('search-abort.yaml');
+      const response = await supertest(app)
+        .get('/-/v1/search?text=remote-license-package&size=20&from=0')
+        .set(HEADERS.ACCEPT, HEADERS.JSON)
+        .expect(HTTP_STATUS.OK);
+
+      expect(response.body.objects).toHaveLength(1);
+      expect(response.body.objects[0].package.license).toBe('BSD-3-Clause');
+    });
   });
 
   describe('error handling', () => {

--- a/packages/core/core/src/search-utils.ts
+++ b/packages/core/core/src/search-utils.ts
@@ -54,6 +54,7 @@ export type SearchPackageBody = {
   description: string;
   author: string | PublisherMaintainer;
   version: string;
+  license?: string;
   keywords: string | string[] | undefined;
   date: string;
   links?: {

--- a/packages/core/types/src/search.ts
+++ b/packages/core/types/src/search.ts
@@ -9,6 +9,7 @@ export type SearchPackageBody = {
   description: string;
   author: string | PublisherMaintainer;
   version: string;
+  license?: string;
   keywords: string | string[] | undefined;
   date: string;
   links?: {

--- a/packages/store/src/lib/storage-utils.ts
+++ b/packages/store/src/lib/storage-utils.ts
@@ -407,6 +407,7 @@ export function mapManifestToSearchPackageBody(
     scope: '',
     description: version.description,
     version: latest,
+    license: version.license,
     keywords: version.keywords,
     date: pkg.time[latest],
     // FIXME: type

--- a/packages/store/test/storage-utils.spec.ts
+++ b/packages/store/test/storage-utils.spec.ts
@@ -412,6 +412,15 @@ describe('Storage Utils', () => {
       expect(body.publisher).toEqual({ username: 'foo', email: '' });
     });
 
+    test('should map the latest version license to the npm search package', () => {
+      const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
+      manifest.time = { '1.0.0': '2018-01-14T11:17:40.712Z' };
+      manifest.versions['1.0.0'].license = 'Apache-2.0';
+
+      const body = mapManifestToSearchPackageBody(manifest, searchItem);
+      expect(body.license).toBe('Apache-2.0');
+    });
+
     test('should fall back to the first maintainer as publisher without _npmUser', () => {
       const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
       manifest.time = { '1.0.0': '2018-01-14T11:17:40.712Z' };

--- a/packages/store/test/storage-utils.spec.ts
+++ b/packages/store/test/storage-utils.spec.ts
@@ -421,6 +421,44 @@ describe('Storage Utils', () => {
       expect(body.license).toBe('Apache-2.0');
     });
 
+    test('should leave license undefined when the latest version has no license', () => {
+      const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
+      manifest.time = { '1.0.0': '2018-01-14T11:17:40.712Z' };
+      delete manifest.versions['1.0.0'].license;
+
+      const body = mapManifestToSearchPackageBody(manifest, searchItem);
+      expect(body.license).toBeUndefined();
+    });
+
+    test('should preserve compound SPDX license expressions', () => {
+      const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
+      manifest.time = { '1.0.0': '2018-01-14T11:17:40.712Z' };
+      manifest.versions['1.0.0'].license = 'MIT OR Apache-2.0';
+
+      const body = mapManifestToSearchPackageBody(manifest, searchItem);
+      expect(body.license).toBe('MIT OR Apache-2.0');
+    });
+
+    test('should use the license selected by the latest dist-tag instead of highest semver', () => {
+      const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
+      manifest.versions['1.0.0'].license = 'MIT';
+      manifest.versions['2.0.0'] = {
+        ...manifest.versions['1.0.0'],
+        _id: 'npm_test@2.0.0',
+        version: '2.0.0',
+        license: 'Apache-2.0',
+      };
+      manifest['dist-tags'].latest = '1.0.0';
+      manifest.time = {
+        '1.0.0': '2018-01-14T11:17:40.712Z',
+        '2.0.0': '2019-01-14T11:17:40.712Z',
+      };
+
+      const body = mapManifestToSearchPackageBody(manifest, searchItem);
+      expect(body.version).toBe('1.0.0');
+      expect(body.license).toBe('MIT');
+    });
+
     test('should fall back to the first maintainer as publisher without _npmUser', () => {
       const manifest = generatePackageMetadata('npm_test', '1.0.0') as Manifest;
       manifest.time = { '1.0.0': '2018-01-14T11:17:40.712Z' };


### PR DESCRIPTION
## Summary

- include the latest package version license in local npm Search v1 results
- expose license as an optional SearchPackageBody field in canonical and deprecated public types
- cover local unscoped/scoped packages, missing and compound SPDX licenses, `dist-tags.latest` selection, and remote uplink results
- add patch changesets for @verdaccio/core, @verdaccio/store, and @verdaccio/types

## Context

The documented npm Search v1 response supports package.license, but Verdaccio omitted it when mapping locally stored manifests. Remote results could contain the field, so local and remote search results had inconsistent shapes.

The mapper now copies the license from the version selected by the latest dist-tag. The property remains optional for packages without license metadata, and SPDX expressions are preserved without transformation.

Related to #5357, point 7.

## Test coverage

- local unscoped package returns its published `ISC` license over HTTP
- local scoped package returns its published `ISC` license over HTTP
- absent license remains `undefined` and is omitted from JSON serialization
- compound SPDX expression (`MIT OR Apache-2.0`) is preserved exactly
- license comes from the version selected by `dist-tags.latest`, not the highest semver
- remote uplink license (`BSD-3-Clause`) survives proxying, authorization, and final Search v1 serialization

## Validation

- `pnpm --filter @verdaccio/store exec vitest run test/storage-utils.spec.ts` (35 passed)
- `pnpm --filter @verdaccio/api exec vitest run test/integration/search.spec.ts` (8 passed)
- `pnpm build`
- `pnpm type-check`
- oxfmt check on changed files
- `git diff --check`
