### PR TITLE
fix: validate the scope segment on the web package endpoints

### DIFF
--- a/.changeset/web-package-scope-validation.md
+++ b/.changeset/web-package-scope-validation.md
@@ -1,0 +1,8 @@
+---
+'verdaccio': patch
+---
+
+fix: validate the scope segment on the web package endpoints
+
+The readme and sidebar web endpoints now validate the `:scope` route segment
+and return 404 for malformed requests.

--- a/src/api/web/api/package.ts
+++ b/src/api/web/api/package.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 
 import type { Auth } from '@verdaccio/auth';
 import { createAnonymousRemoteUser } from '@verdaccio/config';
-import { WebUrls, allow } from '@verdaccio/middleware';
+import { WebUrls } from '@verdaccio/middleware';
 import {
   convertDistRemoteToLocalTarballUrls,
   getLocalRegistryTarballUri,
@@ -36,6 +36,18 @@ const getOrder = (order = 'asc') => {
   return order === 'asc';
 };
 
+// Builds the package name from the route params; returns null for a malformed
+// `:scope` segment.
+const resolveScopedName = (rawScope: string | undefined, pkg: string): string | null => {
+  if (!rawScope) {
+    return pkg;
+  }
+  if (rawScope[0] !== '@') {
+    return null;
+  }
+  return addScope(rawScope.slice(1), pkg);
+};
+
 export type PackcageExt = Manifest & {
   author: any;
   dist?: { tarball: string };
@@ -43,12 +55,6 @@ export type PackcageExt = Manifest & {
 
 function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router {
   const pkgRouter = Router();
-  const can = allow(auth, {
-    beforeAll: (params, message) => {
-      logger.debug(params, message);
-    },
-    afterAll: (params, message) => logger.debug(params, message),
-  });
 
   const checkAllow = (name, remoteUser): Promise<boolean> =>
     new Promise((resolve, reject): void => {
@@ -66,6 +72,28 @@ function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router 
         reject(err);
       }
     });
+
+  // Validates the route params and checks access before the handlers run.
+  const canAccessScopedPackage = (
+    req: $RequestExtend,
+    _res: $ResponseExtend,
+    next: $NextFunctionVer
+  ): void => {
+    const packageName = resolveScopedName(req.params.scope, req.params.package);
+    if (packageName === null) {
+      return next(ErrorCode.getNotFound());
+    }
+    req.scopedPackageName = packageName;
+    auth.allow_access({ packageName }, req.remote_user, (err, allowed): void => {
+      if (err) {
+        return next(err);
+      }
+      if (allowed) {
+        return next();
+      }
+      return next(ErrorCode.getForbidden());
+    });
+  };
 
   // Get list of all visible package
   pkgRouter.get(
@@ -131,11 +159,9 @@ function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router 
   // Get package readme
   pkgRouter.get(
     [wrapPath(WebUrls.readme_package_scoped_version), wrapPath(WebUrls.readme_package_version)],
-    can('access'),
+    canAccessScopedPackage,
     function (req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer): void {
-      const rawScope = req.params.scope; // May include '@'
-      const scope = rawScope ? rawScope.slice(1) : null; // Remove '@' if present
-      const packageName = scope ? addScope(scope, req.params.package) : req.params.package;
+      const packageName = req.scopedPackageName as string;
 
       storage.getPackage({
         name: packageName,
@@ -155,11 +181,9 @@ function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router 
 
   pkgRouter.get(
     [wrapPath(WebUrls.sidebar_scopped_package), wrapPath(WebUrls.sidebar_package)],
-    can('access'),
+    canAccessScopedPackage,
     function (req: $RequestExtend, res: $ResponseExtend, next: $NextFunctionVer): void {
-      const rawScope = req.params.scope; // May include '@'
-      const scope = rawScope ? rawScope.slice(1) : null; // Remove '@' if present
-      const packageName: string = scope ? addScope(scope, req.params.package) : req.params.package;
+      const packageName = req.scopedPackageName as string;
 
       storage.getPackage({
         name: packageName,

--- a/src/api/web/api/package.ts
+++ b/src/api/web/api/package.ts
@@ -16,6 +16,7 @@ const { addGravatarSupport, formatAuthor, generateGravatarUrl } = authorUtils;
 import { DIST_TAGS, HEADERS, HEADER_TYPE, HTTP_STATUS } from '../../../lib/constants';
 import { logger } from '../../../lib/logger';
 import type Storage from '../../../lib/storage';
+import { isPackageValid } from '../../../lib/validation';
 import {
   ErrorCode,
   addScope,
@@ -45,7 +46,8 @@ const resolveScopedName = (rawScope: string | undefined, pkg: string): string | 
   if (rawScope[0] !== '@') {
     return null;
   }
-  return addScope(rawScope.slice(1), pkg);
+  const name = addScope(rawScope.slice(1), pkg);
+  return isPackageValid(name) ? name : null;
 };
 
 export type PackcageExt = Manifest & {
@@ -84,7 +86,9 @@ function addPackageWebApi(storage: Storage, auth: Auth, config: Config): Router 
       return next(ErrorCode.getNotFound());
     }
     req.scopedPackageName = packageName;
-    auth.allow_access({ packageName }, req.remote_user, (err, allowed): void => {
+    const isLoginEnabled = _.isNil(config?.web?.login) || config?.web?.login === true;
+    const remoteUser: RemoteUser = isLoginEnabled ? req.remote_user : createAnonymousRemoteUser();
+    auth.allow_access({ packageName }, remoteUser, (err, allowed): void => {
       if (err) {
         return next(err);
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,7 +60,11 @@ export interface Profile {
   fullname: string;
 }
 
-export type $RequestExtend = Request & { remote_user?: any; log: Logger };
+export type $RequestExtend = Request & {
+  remote_user?: any;
+  log: Logger;
+  scopedPackageName?: string;
+};
 export type $ResponseExtend = Response & { cookies?: any };
 export type $NextFunctionVer = NextFunction & any;
 export type $SidebarPackage = Manifest & { latest: any };

--- a/test/unit/modules/api/config/package-scope-access.yaml
+++ b/test/unit/modules/api/config/package-scope-access.yaml
@@ -1,0 +1,28 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd-package-scope-access
+
+web:
+  enable: true
+  title: verdaccio
+
+publish:
+  allow_offline: false
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@restricted/*':
+    access: maintainer
+    publish: $anonymous
+  '@*/*':
+    access: $anonymous
+    publish: $anonymous
+  '**':
+    access: $anonymous
+    publish: $anonymous
+_debug: true

--- a/test/unit/modules/api/package-scope-access.spec.ts
+++ b/test/unit/modules/api/package-scope-access.spec.ts
@@ -1,0 +1,65 @@
+import supertest from 'supertest';
+import { beforeAll, describe, expect, test } from 'vitest';
+
+import { HEADERS, HTTP_STATUS, TOKEN_BEARER, authUtils } from '@verdaccio/core';
+
+import { getNewToken, initializeServer, publishVersion } from './_helper';
+
+const { buildToken } = authUtils;
+
+describe('package access on scoped names', () => {
+  let app;
+
+  beforeAll(async () => {
+    app = await initializeServer('package-scope-access.yaml');
+    await publishVersion(app, '@restricted/webapp', '1.0.0').expect(HTTP_STATUS.CREATED);
+    await publishVersion(app, '@team/webapp', '1.0.0').expect(HTTP_STATUS.CREATED);
+  });
+
+  test('an anonymous request can read an open scoped package', async () => {
+    const response = await supertest(app)
+      .get('/@team/webapp')
+      .set(HEADERS.ACCEPT, HEADERS.JSON)
+      .expect(HTTP_STATUS.OK);
+    expect(response.body.name).toBe('@team/webapp');
+  });
+
+  test('an anonymous request cannot read a restricted scoped package', async () => {
+    const response = await supertest(app)
+      .get('/@restricted/webapp')
+      .set(HEADERS.ACCEPT, HEADERS.JSON);
+    expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(response.status);
+    expect(response.body?.name).toBeUndefined();
+  });
+
+  test('an anonymous request cannot read a restricted scoped package (encoded name)', async () => {
+    const response = await supertest(app)
+      .get('/@restricted%2fwebapp')
+      .set(HEADERS.ACCEPT, HEADERS.JSON);
+    expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(response.status);
+    expect(response.body?.name).toBeUndefined();
+  });
+
+  test('an anonymous request cannot fetch a restricted tarball', async () => {
+    const response = await supertest(app)
+      .get('/@restricted/webapp/-/webapp-1.0.0.tgz')
+      .set(HEADERS.ACCEPT, HEADERS.JSON);
+    expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(response.status);
+  });
+
+  test('the package name without its scope does not resolve to the scoped package', async () => {
+    const response = await supertest(app).get('/webapp').set(HEADERS.ACCEPT, HEADERS.JSON);
+    expect(response.status).toBe(HTTP_STATUS.NOT_FOUND);
+    expect(response.body?.name).toBeUndefined();
+  });
+
+  test('an authorized user can read a restricted scoped package', async () => {
+    const token = await getNewToken(app, { name: 'maintainer', password: 'strongPass123' });
+    const response = await supertest(app)
+      .get('/@restricted/webapp')
+      .set(HEADERS.ACCEPT, HEADERS.JSON)
+      .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+      .expect(HTTP_STATUS.OK);
+    expect(response.body.name).toBe('@restricted/webapp');
+  });
+});

--- a/test/unit/modules/web/web-package-scope-validation.spec.ts
+++ b/test/unit/modules/web/web-package-scope-validation.spec.ts
@@ -59,6 +59,22 @@ describe('web endpoints: scope segment validation', () => {
     }
   );
 
+  test.each([['@'], ['@.scope'], ['@sc%20ope'], ['@sc*ope']])(
+    'a scope segment that is not a valid npm scope is rejected (sidebar, %s)',
+    async (scope) => {
+      const res = await request(app).get(`/-/verdaccio/data/sidebar/${scope}/pk1-test`);
+      expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
+    }
+  );
+
+  test.each([['@'], ['@.scope'], ['@sc%20ope'], ['@sc*ope']])(
+    'a scope segment that is not a valid npm scope is rejected (readme, %s)',
+    async (scope) => {
+      const res = await request(app).get(`/-/verdaccio/data/package/readme/${scope}/pk1-test`);
+      expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
+    }
+  );
+
   describe('access control on scoped packages', () => {
     test('an anonymous request cannot read a protected package (sidebar)', async () => {
       const res = await request(app).get('/-/verdaccio/data/sidebar/@protected/pk1');
@@ -100,6 +116,40 @@ describe('web endpoints: scope segment validation', () => {
         .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, loginRes.body.token));
       expect(res.status).toBe(HTTP_STATUS.OK);
       expect(res.body.latest.name).toBe('@protected/dashboard');
+    });
+  });
+
+  describe('web login disabled', () => {
+    let appNoLogin;
+    let mockRegistryNoLogin;
+
+    beforeAll(async () => {
+      ({ app: appNoLogin, mockRegistry: mockRegistryNoLogin } = await createWebApp(
+        { web: { login: false } },
+        'htpasswd-web-scope-nologin'
+      ));
+      await seedPackages(appNoLogin);
+    });
+
+    afterAll(() => {
+      mockRegistryNoLogin[0].stop();
+    });
+
+    test('an open scoped package is served (sidebar)', async () => {
+      const res = await request(appNoLogin).get('/-/verdaccio/data/sidebar/@scope/pk1-test');
+      expect(res.status).toBe(HTTP_STATUS.OK);
+    });
+
+    test('an open scoped package is served (readme)', async () => {
+      const res = await request(appNoLogin).get(
+        '/-/verdaccio/data/package/readme/@scope/pk1-test'
+      );
+      expect(res.status).toBe(HTTP_STATUS.OK);
+    });
+
+    test('a protected package stays hidden (sidebar)', async () => {
+      const res = await request(appNoLogin).get('/-/verdaccio/data/sidebar/@protected/pk1');
+      expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(res.status);
     });
   });
 });

--- a/test/unit/modules/web/web-package-scope-validation.spec.ts
+++ b/test/unit/modules/web/web-package-scope-validation.spec.ts
@@ -141,9 +141,7 @@ describe('web endpoints: scope segment validation', () => {
     });
 
     test('an open scoped package is served (readme)', async () => {
-      const res = await request(appNoLogin).get(
-        '/-/verdaccio/data/package/readme/@scope/pk1-test'
-      );
+      const res = await request(appNoLogin).get('/-/verdaccio/data/package/readme/@scope/pk1-test');
       expect(res.status).toBe(HTTP_STATUS.OK);
     });
 

--- a/test/unit/modules/web/web-package-scope-validation.spec.ts
+++ b/test/unit/modules/web/web-package-scope-validation.spec.ts
@@ -1,0 +1,105 @@
+import request from 'supertest';
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER, authUtils } from '@verdaccio/core';
+
+import { generatePackageMetadata } from '@verdaccio/test-helper';
+
+import { setup } from '../../../../src/lib/logger';
+import { addUser } from '../../__helper/api';
+import { createWebApp, seedPackages } from './__helper';
+
+const { buildToken } = authUtils;
+
+setup({});
+
+describe('web endpoints: scope segment validation', () => {
+  vi.setConfig({ testTimeout: 10000 });
+  let app;
+  let mockRegistry;
+
+  beforeAll(async () => {
+    // default config: `@protected/*` is only accessible to the `jota_token` user
+    ({ app, mockRegistry } = await createWebApp({}, 'htpasswd-web-scope'));
+    await seedPackages(app); // seeds @scope/pk1-test, forbidden-place and @protected/pk1
+    await request(app)
+      .put('/@protected%2fdashboard')
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .send(JSON.stringify(generatePackageMetadata('@protected/dashboard')))
+      .expect(HTTP_STATUS.CREATED);
+  });
+
+  afterAll(() => {
+    mockRegistry[0].stop();
+  });
+
+  test('a valid "@scope" segment is served (sidebar)', async () => {
+    const res = await request(app).get('/-/verdaccio/data/sidebar/@scope/pk1-test');
+    expect(res.status).toBe(HTTP_STATUS.OK);
+  });
+
+  test('a valid "@scope" segment is served (readme)', async () => {
+    const res = await request(app).get('/-/verdaccio/data/package/readme/@scope/pk1-test');
+    expect(res.status).toBe(HTTP_STATUS.OK);
+  });
+
+  test.each([['scope'], ['qscope'], ['0scope'], ['%20scope']])(
+    'a scope segment without "@" is rejected (sidebar, %s)',
+    async (scope) => {
+      const res = await request(app).get(`/-/verdaccio/data/sidebar/${scope}/pk1-test`);
+      expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
+    }
+  );
+
+  test.each([['scope'], ['qscope'], ['0scope'], ['%20scope']])(
+    'a scope segment without "@" is rejected (readme, %s)',
+    async (scope) => {
+      const res = await request(app).get(`/-/verdaccio/data/package/readme/${scope}/pk1-test`);
+      expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
+    }
+  );
+
+  describe('access control on scoped packages', () => {
+    test('an anonymous request cannot read a protected package (sidebar)', async () => {
+      const res = await request(app).get('/-/verdaccio/data/sidebar/@protected/pk1');
+      expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(res.status);
+      expect(res.body?.name).toBeUndefined();
+    });
+
+    test('an anonymous request cannot read a protected package (readme)', async () => {
+      const res = await request(app).get('/-/verdaccio/data/package/readme/@protected/pk1');
+      expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(res.status);
+    });
+
+    test.each([['protected'], ['qprotected'], ['0protected']])(
+      'a malformed scope segment never resolves to a protected package (sidebar, %s)',
+      async (scope) => {
+        const res = await request(app).get(`/-/verdaccio/data/sidebar/${scope}/pk1`);
+        expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(res.body?.name).toBeUndefined();
+      }
+    );
+
+    test.each([['protected'], ['qprotected'], ['0protected']])(
+      'a malformed scope segment never resolves to a protected package (readme, %s)',
+      async (scope) => {
+        const res = await request(app).get(`/-/verdaccio/data/package/readme/${scope}/pk1`);
+        expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
+      }
+    );
+
+    test('an authorized user can read a protected package (sidebar)', async () => {
+      const credentials = { name: 'jota_token', password: 'secretPass' };
+      await addUser(request(app), credentials.name, credentials);
+      const loginRes = await request(app)
+        .post('/-/verdaccio/sec/login')
+        .send({ username: credentials.name, password: credentials.password })
+        .expect(HTTP_STATUS.OK);
+      const res = await request(app)
+        .get('/-/verdaccio/data/sidebar/@protected/dashboard')
+        .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, loginRes.body.token));
+      expect(res.status).toBe(HTTP_STATUS.OK);
+      expect(res.body.latest.name).toBe('@protected/dashboard');
+    });
+  });
+});


### PR DESCRIPTION
The readme and sidebar web endpoints now resolve the requested package name in a single place: the `:scope` route segment must be a valid npm scope, and malformed requests return 404. The access check and the package lookup use the same resolved name.

Includes unit tests at both levels: the web endpoints (valid, malformed and access-controlled scoped requests) and the registry API (access enforcement on scoped names), plus a changeset.
