### PR TITLE
fix: validate the scope segment on the web package endpoints

### DIFF
--- a/.changeset/web-package-scope-validation.md
+++ b/.changeset/web-package-scope-validation.md
@@ -1,0 +1,8 @@
+---
+'@verdaccio/web': patch
+---
+
+fix: validate the scope segment on the web package endpoints
+
+The readme and sidebar web endpoints now validate the `:scope` route segment
+and return 404 for malformed requests.

--- a/packages/api/test/integration/config/package-scope-access.yaml
+++ b/packages/api/test/integration/config/package-scope-access.yaml
@@ -1,0 +1,28 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd-package-scope-access
+
+web:
+  enable: true
+  title: verdaccio
+
+publish:
+  allow_offline: false
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@restricted/*':
+    access: maintainer
+    publish: $anonymous
+  '@*/*':
+    access: $anonymous
+    publish: $anonymous
+  '**':
+    access: $anonymous
+    publish: $anonymous
+_debug: true

--- a/packages/api/test/integration/package-scope-access.spec.ts
+++ b/packages/api/test/integration/package-scope-access.spec.ts
@@ -1,0 +1,63 @@
+import supertest from 'supertest';
+import { beforeAll, describe, expect, test } from 'vitest';
+
+import { HEADERS, HTTP_STATUS, TOKEN_BEARER } from '@verdaccio/core';
+
+import { buildToken, getNewToken, initializeServer, publishVersion } from './_helper';
+
+describe('package access on scoped names', () => {
+  let app;
+
+  beforeAll(async () => {
+    app = await initializeServer('package-scope-access.yaml');
+    await publishVersion(app, '@restricted/webapp', '1.0.0').expect(HTTP_STATUS.CREATED);
+    await publishVersion(app, '@team/webapp', '1.0.0').expect(HTTP_STATUS.CREATED);
+  });
+
+  test('an anonymous request can read an open scoped package', async () => {
+    const response = await supertest(app)
+      .get('/@team/webapp')
+      .set(HEADERS.ACCEPT, HEADERS.JSON)
+      .expect(HTTP_STATUS.OK);
+    expect(response.body.name).toBe('@team/webapp');
+  });
+
+  test('an anonymous request cannot read a restricted scoped package', async () => {
+    const response = await supertest(app)
+      .get('/@restricted/webapp')
+      .set(HEADERS.ACCEPT, HEADERS.JSON);
+    expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(response.status);
+    expect(response.body?.name).toBeUndefined();
+  });
+
+  test('an anonymous request cannot read a restricted scoped package (encoded name)', async () => {
+    const response = await supertest(app)
+      .get('/@restricted%2fwebapp')
+      .set(HEADERS.ACCEPT, HEADERS.JSON);
+    expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(response.status);
+    expect(response.body?.name).toBeUndefined();
+  });
+
+  test('an anonymous request cannot fetch a restricted tarball', async () => {
+    const response = await supertest(app)
+      .get('/@restricted/webapp/-/webapp-1.0.0.tgz')
+      .set(HEADERS.ACCEPT, HEADERS.JSON);
+    expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(response.status);
+  });
+
+  test('the package name without its scope does not resolve to the scoped package', async () => {
+    const response = await supertest(app).get('/webapp').set(HEADERS.ACCEPT, HEADERS.JSON);
+    expect(response.status).toBe(HTTP_STATUS.NOT_FOUND);
+    expect(response.body?.name).toBeUndefined();
+  });
+
+  test('an authorized user can read a restricted scoped package', async () => {
+    const token = await getNewToken(app, { name: 'maintainer', password: 'strongPass123' });
+    const response = await supertest(app)
+      .get('/@restricted/webapp')
+      .set(HEADERS.ACCEPT, HEADERS.JSON)
+      .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, token))
+      .expect(HTTP_STATUS.OK);
+    expect(response.body.name).toBe('@restricted/webapp');
+  });
+});

--- a/packages/web/src/api/index.ts
+++ b/packages/web/src/api/index.ts
@@ -22,7 +22,7 @@ export default (auth, storage, config) => {
   route.use(WebUrlsNamespace.data, packageApi(storage, auth, config));
   route.use(WebUrlsNamespace.data, search(storage, auth));
   route.use(WebUrlsNamespace.data, sidebar(config, storage, auth));
-  route.use(WebUrlsNamespace.data, readme(storage, auth));
+  route.use(WebUrlsNamespace.data, readme(storage, auth, config));
   if (hasLogin(config)) {
     route.use(WebUrlsNamespace.sec, user(auth, config, storage));
   }

--- a/packages/web/src/api/readme.ts
+++ b/packages/web/src/api/readme.ts
@@ -2,20 +2,19 @@ import buildDebug from 'debug';
 import { Router } from 'express';
 
 import type { Auth } from '@verdaccio/auth';
-import { DIST_TAGS, HEADERS, HEADER_TYPE, reqUtils } from '@verdaccio/core';
-import { logger } from '@verdaccio/logger';
+import { DIST_TAGS, HEADERS, HEADER_TYPE } from '@verdaccio/core';
 import {
   $NextFunctionVer,
   $RequestExtend,
   $ResponseExtend,
   WebUrls,
-  allow,
   getRequestOptions,
 } from '@verdaccio/middleware';
 import type { Storage } from '@verdaccio/store';
-import type { Manifest } from '@verdaccio/types';
+import type { Config, Manifest } from '@verdaccio/types';
 
-import { addScope, isVersionValid } from '../web-utils';
+import { isVersionValid } from '../web-utils';
+import { scopedPackageAccess } from './scoped-access';
 
 export { $RequestExtend, $ResponseExtend, $NextFunctionVer }; // Was required by other packages
 
@@ -53,26 +52,20 @@ const getReadmeFromManifest = (manifest: Manifest, v?: any): string | undefined 
   return readme;
 };
 
-function addReadmeWebApi(storage: Storage, auth: Auth): Router {
+function addReadmeWebApi(storage: Storage, auth: Auth, config: Config): Router {
   debug('initialized readme web api');
-  const can = allow(auth, {
-    beforeAll: (a, b) => logger.trace(a, b),
-    afterAll: (a, b) => logger.trace(a, b),
-  });
   const pkgRouter = Router(); /* eslint new-cap: 0 */
 
   pkgRouter.get(
     [WebUrls.readme_package_scoped_version, WebUrls.readme_package_version],
-    can('access'),
+    scopedPackageAccess(auth, config),
     async function (
       req: $RequestExtend,
       res: $ResponseExtend,
       next: $NextFunctionVer
     ): Promise<void> {
       debug('readme hit');
-      const scope = reqUtils.paramToString(req.params.scope).replace(/^@/, '');
-      const packageName = reqUtils.paramToString(req.params.package);
-      const name = scope ? addScope(scope, packageName) : packageName;
+      const name = (req as $RequestExtend & { scopedPackageName: string }).scopedPackageName;
       debug('readme name %o', name);
       const requestOptions = getRequestOptions(req);
       try {

--- a/packages/web/src/api/scoped-access.ts
+++ b/packages/web/src/api/scoped-access.ts
@@ -1,0 +1,49 @@
+import type { Auth } from '@verdaccio/auth';
+import { createAnonymousRemoteUser } from '@verdaccio/config';
+import { errorUtils, reqUtils, validationUtils } from '@verdaccio/core';
+import type { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '@verdaccio/middleware';
+import type { Config, RemoteUser } from '@verdaccio/types';
+
+import { addScope, hasLogin } from '../web-utils';
+
+/**
+ * Builds the package name from the route params; returns null for a malformed
+ * `:scope` segment.
+ */
+type Param = string | string[] | undefined;
+
+export function resolveScopedName(rawScope: Param, rawPackage: Param): string | null {
+  const packageName = reqUtils.paramToString(rawPackage);
+  const scope = reqUtils.paramToString(rawScope);
+  if (!scope) {
+    return packageName;
+  }
+  if (scope[0] !== '@') {
+    return null;
+  }
+  const name = addScope(scope.slice(1), packageName);
+  return validationUtils.validatePackage(name) && !name.includes('*') ? name : null;
+}
+
+/**
+ * Validates the route params and checks access before the handlers run.
+ */
+export function scopedPackageAccess(auth: Auth, config: Config) {
+  return function (req: $RequestExtend, _res: $ResponseExtend, next: $NextFunctionVer): void {
+    const packageName = resolveScopedName(req.params.scope, req.params.package);
+    if (packageName === null) {
+      return next(errorUtils.getNotFound());
+    }
+    (req as $RequestExtend & { scopedPackageName?: string }).scopedPackageName = packageName;
+    const remoteUser: RemoteUser = hasLogin(config) ? req.remote_user : createAnonymousRemoteUser();
+    auth.allow_access({ packageName }, remoteUser, (err, allowed): void => {
+      if (err) {
+        return next(err);
+      }
+      if (allowed) {
+        return next();
+      }
+      return next(errorUtils.getForbidden());
+    });
+  };
+}

--- a/packages/web/src/api/sidebar.ts
+++ b/packages/web/src/api/sidebar.ts
@@ -2,14 +2,12 @@ import buildDebug from 'debug';
 import { Router } from 'express';
 
 import type { Auth } from '@verdaccio/auth';
-import { DIST_TAGS, HTTP_STATUS, reqUtils } from '@verdaccio/core';
-import { logger } from '@verdaccio/logger';
+import { DIST_TAGS, HTTP_STATUS } from '@verdaccio/core';
 import {
   $NextFunctionVer,
   $RequestExtend,
   $ResponseExtend,
   WebUrls,
-  allow,
   getRequestOptions,
 } from '@verdaccio/middleware';
 import type { Storage } from '@verdaccio/store';
@@ -17,7 +15,8 @@ import { convertDistRemoteToLocalTarballUrls } from '@verdaccio/tarball';
 import type { Config, Manifest, WebManifest } from '@verdaccio/types';
 
 import { addGravatarSupport, formatAuthor } from '../author-utils';
-import { addScope, deleteProperties, isVersionValid } from '../web-utils';
+import { deleteProperties, isVersionValid } from '../web-utils';
+import { scopedPackageAccess } from './scoped-access';
 
 export { $RequestExtend, $ResponseExtend, $NextFunctionVer }; // Was required by other packages
 
@@ -26,22 +25,16 @@ const debug = buildDebug('verdaccio:web:api:sidebar');
 function addSidebarWebApi(config: Config, storage: Storage, auth: Auth): Router {
   debug('initialized sidebar web api');
   const router = Router(); /* eslint new-cap: 0 */
-  const can = allow(auth, {
-    beforeAll: (a, b) => logger.trace(a, b),
-    afterAll: (a, b) => logger.trace(a, b),
-  });
   // Get package sidebar
   router.get(
     [WebUrls.sidebar_scopped_package, WebUrls.sidebar_package],
-    can('access'),
+    scopedPackageAccess(auth, config),
     async function (
       req: $RequestExtend,
       res: $ResponseExtend,
       next: $NextFunctionVer
     ): Promise<void> {
-      const scope = reqUtils.paramToString(req.params.scope).replace(/^@/, '');
-      const packageName = reqUtils.paramToString(req.params.package);
-      const name = scope ? addScope(scope, packageName) : packageName;
+      const name = (req as $RequestExtend & { scopedPackageName: string }).scopedPackageName;
       const requestOptions = getRequestOptions(req);
       try {
         const info = (await storage.getPackageByOptions({

--- a/packages/web/test/api.scope-validation.test.ts
+++ b/packages/web/test/api.scope-validation.test.ts
@@ -1,0 +1,166 @@
+import path from 'node:path';
+import supertest from 'supertest';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+
+import { HEADERS, HEADER_TYPE, HTTP_STATUS, TOKEN_BEARER, authUtils } from '@verdaccio/core';
+import { setup } from '@verdaccio/logger';
+import { publishVersion } from '@verdaccio/test-helper';
+
+import { initializeServer } from './helper';
+
+const { buildToken } = authUtils;
+
+beforeAll(async () => {
+  await setup({});
+});
+
+const mockManifest = vi.hoisted(() => vi.fn());
+vi.mock('@verdaccio/ui-theme', () => ({ default: (...args: any[]) => mockManifest()(...args) }));
+
+describe('web endpoints: scope segment validation', () => {
+  beforeAll(() => {
+    mockManifest.mockReturnValue(() => ({
+      staticPath: path.join(import.meta.dirname, 'static'),
+      manifestFiles: {
+        js: ['runtime.js', 'vendors.js', 'main.js'],
+      },
+      manifest: require('./partials/manifest/manifest.json'),
+    }));
+  });
+
+  test('a valid "@scope" segment is served (sidebar)', async () => {
+    const app = await initializeServer('default-test.yaml');
+    await publishVersion(app, '@scope/pk1-test', '1.0.0', { readme: 'a readme' });
+    await supertest(app).get('/-/verdaccio/data/sidebar/@scope/pk1-test').expect(HTTP_STATUS.OK);
+  });
+
+  test('a valid "@scope" segment is served (readme)', async () => {
+    const app = await initializeServer('default-test.yaml');
+    await publishVersion(app, '@scope/pk1-test', '1.0.0', { readme: 'a readme' });
+    await supertest(app)
+      .get('/-/verdaccio/data/package/readme/@scope/pk1-test')
+      .expect(HTTP_STATUS.OK);
+  });
+
+  test.each([['scope'], ['qscope'], ['0scope'], ['%20scope']])(
+    'a scope segment without "@" is rejected (sidebar, %s)',
+    async (scope) => {
+      const app = await initializeServer('default-test.yaml');
+      await publishVersion(app, '@scope/pk1-test', '1.0.0', { readme: 'a readme' });
+      await supertest(app)
+        .get(`/-/verdaccio/data/sidebar/${scope}/pk1-test`)
+        .expect(HTTP_STATUS.NOT_FOUND);
+    }
+  );
+
+  test.each([['scope'], ['qscope'], ['0scope'], ['%20scope']])(
+    'a scope segment without "@" is rejected (readme, %s)',
+    async (scope) => {
+      const app = await initializeServer('default-test.yaml');
+      await publishVersion(app, '@scope/pk1-test', '1.0.0', { readme: 'a readme' });
+      await supertest(app)
+        .get(`/-/verdaccio/data/package/readme/${scope}/pk1-test`)
+        .expect(HTTP_STATUS.NOT_FOUND);
+    }
+  );
+
+  test.each([['@'], ['@.scope'], ['@sc%20ope'], ['@sc*ope']])(
+    'a scope segment that is not a valid npm scope is rejected (sidebar, %s)',
+    async (scope) => {
+      const app = await initializeServer('default-test.yaml');
+      await publishVersion(app, '@scope/pk1-test', '1.0.0', { readme: 'a readme' });
+      await supertest(app)
+        .get(`/-/verdaccio/data/sidebar/${scope}/pk1-test`)
+        .expect(HTTP_STATUS.NOT_FOUND);
+    }
+  );
+
+  test.each([['@'], ['@.scope'], ['@sc%20ope'], ['@sc*ope']])(
+    'a scope segment that is not a valid npm scope is rejected (readme, %s)',
+    async (scope) => {
+      const app = await initializeServer('default-test.yaml');
+      await publishVersion(app, '@scope/pk1-test', '1.0.0', { readme: 'a readme' });
+      await supertest(app)
+        .get(`/-/verdaccio/data/package/readme/${scope}/pk1-test`)
+        .expect(HTTP_STATUS.NOT_FOUND);
+    }
+  );
+
+  describe('web login disabled', () => {
+    test('an open scoped package is served (sidebar)', async () => {
+      const app = await initializeServer('scope-access-nologin.yaml');
+      await publishVersion(app, '@scope/pk1-test', '1.0.0', { readme: 'a readme' });
+      await supertest(app).get('/-/verdaccio/data/sidebar/@scope/pk1-test').expect(HTTP_STATUS.OK);
+    });
+
+    test('an open scoped package is served (readme)', async () => {
+      const app = await initializeServer('scope-access-nologin.yaml');
+      await publishVersion(app, '@scope/pk1-test', '1.0.0', { readme: 'a readme' });
+      await supertest(app)
+        .get('/-/verdaccio/data/package/readme/@scope/pk1-test')
+        .expect(HTTP_STATUS.OK);
+    });
+
+    test('a restricted package stays hidden (sidebar)', async () => {
+      const app = await initializeServer('scope-access-nologin.yaml');
+      await publishVersion(app, '@restricted/dashboard', '1.0.0', { readme: 'a readme' });
+      const res = await supertest(app).get('/-/verdaccio/data/sidebar/@restricted/dashboard');
+      expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(res.status);
+    });
+  });
+
+  describe('access control on scoped packages', () => {
+    test('an anonymous request cannot read a restricted package (sidebar)', async () => {
+      const app = await initializeServer('scope-access.yaml');
+      await publishVersion(app, '@restricted/dashboard', '1.0.0', { readme: 'a readme' });
+      const res = await supertest(app).get('/-/verdaccio/data/sidebar/@restricted/dashboard');
+      expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(res.status);
+    });
+
+    test('an anonymous request cannot read a restricted package (readme)', async () => {
+      const app = await initializeServer('scope-access.yaml');
+      await publishVersion(app, '@restricted/dashboard', '1.0.0', { readme: 'a readme' });
+      const res = await supertest(app).get(
+        '/-/verdaccio/data/package/readme/@restricted/dashboard'
+      );
+      expect([HTTP_STATUS.UNAUTHORIZED, HTTP_STATUS.FORBIDDEN]).toContain(res.status);
+    });
+
+    test.each([['restricted'], ['qrestricted'], ['0restricted']])(
+      'a malformed scope segment never resolves to a restricted package (sidebar, %s)',
+      async (scope) => {
+        const app = await initializeServer('scope-access.yaml');
+        await publishVersion(app, '@restricted/dashboard', '1.0.0', { readme: 'a readme' });
+        const res = await supertest(app).get(`/-/verdaccio/data/sidebar/${scope}/dashboard`);
+        expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(res.body?.latest).toBeUndefined();
+      }
+    );
+
+    test.each([['restricted'], ['qrestricted'], ['0restricted']])(
+      'a malformed scope segment never resolves to a restricted package (readme, %s)',
+      async (scope) => {
+        const app = await initializeServer('scope-access.yaml');
+        await publishVersion(app, '@restricted/dashboard', '1.0.0', { readme: 'a readme' });
+        const res = await supertest(app).get(`/-/verdaccio/data/package/readme/${scope}/dashboard`);
+        expect(res.status).toBe(HTTP_STATUS.NOT_FOUND);
+        expect(res.text).not.toMatch('a readme');
+      }
+    );
+
+    test('an authorized user can read a restricted package (sidebar)', async () => {
+      const app = await initializeServer('scope-access.yaml');
+      await publishVersion(app, '@restricted/dashboard', '1.0.0', { readme: 'a readme' });
+      const loginRes = await supertest(app)
+        .post('/-/verdaccio/sec/login')
+        .send(JSON.stringify({ username: 'test', password: 'test' }))
+        .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+        .expect(HTTP_STATUS.OK);
+      const res = await supertest(app)
+        .get('/-/verdaccio/data/sidebar/@restricted/dashboard')
+        .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, loginRes.body.token));
+      expect(res.status).toBe(HTTP_STATUS.OK);
+      expect(res.body.latest.name).toBe('@restricted/dashboard');
+    });
+  });
+});

--- a/packages/web/test/config/scope-access-nologin.yaml
+++ b/packages/web/test/config/scope-access-nologin.yaml
@@ -1,0 +1,30 @@
+auth:
+  auth-memory:
+    users:
+      test:
+        name: test
+        password: test
+
+web:
+  title: verdaccio
+  login: false
+
+publish:
+  allow_offline: false
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@restricted/*':
+    access: $authenticated
+    # to facilitate the test we allow anonymous publish
+    publish: $anonymous
+  '@*/*':
+    access: $anonymous
+    publish: $anonymous
+  '**':
+    access: $anonymous
+    publish: $anonymous
+_debug: true

--- a/packages/web/test/config/scope-access.yaml
+++ b/packages/web/test/config/scope-access.yaml
@@ -1,0 +1,29 @@
+auth:
+  auth-memory:
+    users:
+      test:
+        name: test
+        password: test
+
+web:
+  title: verdaccio
+
+publish:
+  allow_offline: false
+
+uplinks:
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '@restricted/*':
+    access: $authenticated
+    # to facilitate the test we allow anonymous publish
+    publish: $anonymous
+  '@*/*':
+    access: $anonymous
+    publish: $anonymous
+  '**':
+    access: $anonymous
+    publish: $anonymous
+_debug: true


### PR DESCRIPTION
The readme and sidebar web endpoints now resolve the requested package name in a single place: the `:scope` route segment must be a valid npm scope, malformed requests return 404, and the access check and the package lookup use the same resolved name. The access guard also honors `web.login: false` by evaluating access as the anonymous user, consistent with the packages listing.

Includes unit tests at both levels — the web endpoints (valid, malformed and access-controlled scoped requests, plus a `web.login: false` suite) and the registry API (access enforcement on scoped names) — and a changeset.

Same change as #6201 for the `next` line.
