### PR TITLE
fix(proxy): forward uplink headers in search requests

### DIFF
--- a/.changeset/forward-search-uplink-headers.md
+++ b/.changeset/forward-search-uplink-headers.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/proxy': patch
+---
+
+Forward authentication and configured uplink headers in search requests.

--- a/packages/api/test/integration/config/search-uplink-headers.yaml
+++ b/packages/api/test/integration/config/search-uplink-headers.yaml
@@ -1,0 +1,28 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd-search-uplink-headers
+
+web:
+  enable: true
+  title: verdaccio
+
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+    auth:
+      type: Bearer
+      token: uplink-token
+    headers:
+      x-uplink-header: configured-value
+
+log: { type: stdout, format: pretty, level: trace }
+
+packages:
+  '**':
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
+
+_debug: true

--- a/packages/api/test/integration/search.spec.ts
+++ b/packages/api/test/integration/search.spec.ts
@@ -217,6 +217,52 @@ describe('search', () => {
       expect(forwardedQuery.get('from')).toBe('10000');
     });
 
+    test('should isolate client headers from configured uplink headers', async () => {
+      const app = await initializeServer('search-uplink-headers.yaml');
+      const user = await createUser(app, 'search-client', 'password');
+      const clientToken = user.body.token;
+      const request = nock('https://registry.npmjs.org')
+        .get(/\/-\/v1\/search/)
+        .reply(200, function () {
+          expect(this.req.headers.authorization).toBe('Bearer uplink-token');
+          expect(this.req.headers['x-uplink-header']).toBe('configured-value');
+          expect(this.req.headers.cookie).toBeUndefined();
+          expect(this.req.headers['npm-otp']).toBeUndefined();
+          expect(this.req.headers['npm-session']).toBeUndefined();
+          expect(this.req.headers['npm-command']).toBeUndefined();
+          expect(this.req.headers['npm-scope']).toBeUndefined();
+          expect(this.req.headers['npm-auth-type']).toBeUndefined();
+          expect(this.req.headers['proxy-authorization']).toBeUndefined();
+          expect(this.req.headers['x-forwarded-for']).toBeUndefined();
+          expect(this.req.headers['x-real-ip']).toBeUndefined();
+          expect(this.req.headers.forwarded).toBeUndefined();
+          expect(this.req.headers.referer).toBeUndefined();
+          expect(this.req.headers['x-client-secret']).toBeUndefined();
+          expect(Object.values(this.req.headers).join(' ')).not.toContain(clientToken);
+          return { objects: [], total: 0, time: '' };
+        });
+
+      await supertest(app)
+        .get('/-/v1/search?text=header-security&size=20&from=0')
+        .set(HEADERS.AUTHORIZATION, `Bearer ${clientToken}`)
+        .set('Cookie', 'session=client-secret')
+        .set('npm-otp', '123456')
+        .set('npm-session', 'client-session')
+        .set('npm-command', 'search')
+        .set('npm-scope', '@private')
+        .set('npm-auth-type', 'legacy')
+        .set('proxy-authorization', 'Basic proxy-secret')
+        .set('x-forwarded-for', '192.0.2.1')
+        .set('x-real-ip', '192.0.2.2')
+        .set('forwarded', 'for=192.0.2.3')
+        .set('referer', 'https://client.example/private')
+        .set('x-client-secret', 'secret')
+        .set('x-uplink-header', 'client-value')
+        .expect(HTTP_STATUS.OK);
+
+      expect(request.isDone()).toBe(true);
+    });
+
     test('should preserve optional package fields returned by an uplink', async () => {
       nock('https://registry.npmjs.org')
         .get(/\/-\/v1\/search/)

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -503,12 +503,14 @@ class ProxyStorage implements IProxy {
   public async search({ url, abort, retry }: ProxySearchParams): Promise<Stream.Readable> {
     try {
       const uri = this.buildUri(url);
+      const headers = this.applyUplinkHeaders(this.getHeaders());
       this.logger.http(
         { uri, uplink: this.uplinkName },
         'search request to uplink @{uplink} - @{uri}'
       );
       debug('searching on %o', uri);
       const response = got(uri, {
+        headers,
         signal: abort ? abort.signal : undefined,
         agent: this.agent,
         timeout: this.timeout,

--- a/packages/proxy/test/proxy.search.spec.ts
+++ b/packages/proxy/test/proxy.search.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
 
 import { Config, parseConfigFile } from '@verdaccio/config';
-import { streamUtils } from '@verdaccio/core';
+import { HEADERS, TOKEN_BASIC, TOKEN_BEARER, streamUtils } from '@verdaccio/core';
 import { logger, setup } from '@verdaccio/logger';
 
 import { ProxyStorage } from '../src';
@@ -64,6 +64,97 @@ describe('proxy', () => {
       const stream = await prox1.search({
         abort,
         url: searchUrl,
+      });
+
+      const searchResponse = await getStream(stream.pipe(streamUtils.transformObjectToString()));
+      expect(searchResponse).not.toBe('');
+      expect(request.isDone()).toBe(true);
+    });
+
+    test('forwards the default search headers to the uplink', async () => {
+      const response = require('./partials/search-v1.json');
+      const request = nock(domain, {
+        reqheaders: {
+          [HEADERS.ACCEPT_ENCODING]: 'gzip',
+          [HEADERS.USER_AGENT]: /npm/,
+        },
+      })
+        .get(queryUrl)
+        .reply(200, response);
+      const prox1 = new ProxyStorage('uplink', defaultRequestOptions, conf, logger);
+
+      const stream = await prox1.search({
+        abort: new AbortController(),
+        url: queryUrl,
+      });
+
+      const searchResponse = await getStream(stream.pipe(streamUtils.transformObjectToString()));
+      expect(searchResponse).not.toBe('');
+      expect(request.isDone()).toBe(true);
+    });
+
+    test.each([
+      ['Bearer', TOKEN_BEARER, 'bearer-token', `${TOKEN_BEARER} bearer-token`],
+      ['Basic', TOKEN_BASIC, 'basic-token', `${TOKEN_BASIC} basic-token`],
+    ])('forwards %s authentication to the uplink', async (_name, type, token, authorization) => {
+      const response = require('./partials/search-v1.json');
+      const request = nock(domain, {
+        reqheaders: {
+          [HEADERS.AUTHORIZATION]: authorization,
+        },
+      })
+        .get(queryUrl)
+        .reply(200, response);
+      const prox1 = new ProxyStorage(
+        'uplink',
+        {
+          url: domain,
+          auth: { type, token },
+        },
+        conf,
+        logger
+      );
+
+      const stream = await prox1.search({
+        abort: new AbortController(),
+        url: queryUrl,
+      });
+
+      const searchResponse = await getStream(stream.pipe(streamUtils.transformObjectToString()));
+      expect(searchResponse).not.toBe('');
+      expect(request.isDone()).toBe(true);
+    });
+
+    test('allows configured uplink headers to override generated headers', async () => {
+      const response = require('./partials/search-v1.json');
+      const request = nock(domain, {
+        reqheaders: {
+          [HEADERS.AUTHORIZATION]: `${TOKEN_BASIC} configured-token`,
+          'x-uplink-header': 'search-value',
+        },
+      })
+        .get(queryUrl)
+        .reply(200, response);
+      const prox1 = new ProxyStorage(
+        'uplink',
+        {
+          url: domain,
+          auth: {
+            type: TOKEN_BEARER,
+            token: 'generated-token',
+          },
+          headers: {
+            [HEADERS.AUTHORIZATION]: `${TOKEN_BASIC} configured-token`,
+            'x-uplink-header': 'search-value',
+          },
+        },
+        conf,
+        logger
+      );
+
+      const stream = await prox1.search({
+        abort: new AbortController(),
+        url: queryUrl,
       });
 
       const searchResponse = await getStream(stream.pipe(streamUtils.transformObjectToString()));

--- a/packages/proxy/test/proxy.search.spec.ts
+++ b/packages/proxy/test/proxy.search.spec.ts
@@ -75,6 +75,7 @@ describe('proxy', () => {
       const response = require('./partials/search-v1.json');
       const request = nock(domain, {
         reqheaders: {
+          [HEADERS.ACCEPT]: `${HEADERS.JSON};`,
           [HEADERS.ACCEPT_ENCODING]: 'gzip',
           [HEADERS.USER_AGENT]: /npm/,
         },
@@ -86,6 +87,53 @@ describe('proxy', () => {
       const stream = await prox1.search({
         abort: new AbortController(),
         url: queryUrl,
+      });
+
+      const searchResponse = await getStream(stream.pipe(streamUtils.transformObjectToString()));
+      expect(searchResponse).not.toBe('');
+      expect(request.isDone()).toBe(true);
+    });
+
+    test('does not forward caller-provided headers to the uplink', async () => {
+      const response = require('./partials/search-v1.json');
+      const request = nock(domain)
+        .get(queryUrl)
+        .reply(200, function () {
+          expect(this.req.headers.authorization).toBeUndefined();
+          expect(this.req.headers.cookie).toBeUndefined();
+          expect(this.req.headers['npm-otp']).toBeUndefined();
+          expect(this.req.headers['npm-session']).toBeUndefined();
+          expect(this.req.headers['npm-command']).toBeUndefined();
+          expect(this.req.headers['npm-scope']).toBeUndefined();
+          expect(this.req.headers['npm-auth-type']).toBeUndefined();
+          expect(this.req.headers['proxy-authorization']).toBeUndefined();
+          expect(this.req.headers['x-forwarded-for']).toBeUndefined();
+          expect(this.req.headers['x-real-ip']).toBeUndefined();
+          expect(this.req.headers.forwarded).toBeUndefined();
+          expect(this.req.headers.referer).toBeUndefined();
+          expect(this.req.headers['x-client-secret']).toBeUndefined();
+          return response;
+        });
+      const prox1 = new ProxyStorage('uplink', defaultRequestOptions, conf, logger);
+
+      const stream = await prox1.search({
+        abort: new AbortController(),
+        url: queryUrl,
+        headers: new Headers({
+          authorization: 'Bearer client-token',
+          cookie: 'session=secret',
+          'npm-otp': '123456',
+          'npm-session': 'client-session',
+          'npm-command': 'search',
+          'npm-scope': '@private',
+          'npm-auth-type': 'legacy',
+          'proxy-authorization': 'Basic proxy-secret',
+          'x-forwarded-for': '192.0.2.1',
+          'x-real-ip': '192.0.2.2',
+          forwarded: 'for=192.0.2.3',
+          referer: 'https://client.example/private',
+          'x-client-secret': 'secret',
+        }),
       });
 
       const searchResponse = await getStream(stream.pipe(streamUtils.transformObjectToString()));
@@ -118,6 +166,10 @@ describe('proxy', () => {
       const stream = await prox1.search({
         abort: new AbortController(),
         url: queryUrl,
+        headers: new Headers({
+          authorization: `${TOKEN_BEARER} client-token`,
+          'x-uplink-header': 'client-value',
+        }),
       });
 
       const searchResponse = await getStream(stream.pipe(streamUtils.transformObjectToString()));


### PR DESCRIPTION
## Summary

- forward the standard proxy headers in Search v1 uplink requests
- include configured Basic or Bearer authentication
- apply custom uplink headers with the existing override precedence
- add a patch changeset for `@verdaccio/proxy`

## Problem

`ProxyStorage.search()` sends requests without calling `getHeaders()` or `applyUplinkHeaders()`. As a result, authenticated uplinks can reject search requests even though metadata and tarball requests work, and registries do not receive the configured uplink headers or npm-compatible user agent.

## Solution

Build the search request headers with the same existing helpers used by other proxy operations, then pass them to `got`. Configured uplink headers are applied last, preserving their existing override behavior.

## Tests

Coverage includes:

- default search headers and npm-compatible user agent
- Bearer authentication
- Basic authentication
- custom uplink headers
- configured-header precedence over generated authorization

Validation completed:

- `@verdaccio/proxy` test suite: 9 files, 100 tests passed
- `@verdaccio/proxy` build
- focused TypeScript check
- Oxfmt check
- `git diff --check`

## Dependency

This PR is stacked on #6209 so its diff contains only the header-forwarding fix. After #6209 merges, the base can be changed to `master`.