### PR TITLE
fix(web): web ui review follow-ups

### DIFF
--- a/.changeset/fifty-lamps-shine.md
+++ b/.changeset/fifty-lamps-shine.md
@@ -1,0 +1,14 @@
+---
+'@verdaccio/ui-components': patch
+'@verdaccio/ui-theme': patch
+---
+
+fix(ui): follow-ups to the web UI bug batch
+
+- login and signup now update the auth context, so the header reflects the session immediately instead of showing the login button until a manual refresh
+- a 2xx login/signup response without a token shows an error instead of a false success page
+- a readme-only failure no longer blanks the whole package detail page, and a failed revalidation no longer hides the cached package list on the home page
+- the versions filter resets when navigating to another package instead of silently applying the previous package's filter
+- the search dropdown shows the loading state during the debounce window instead of flashing "No results found" on every keystroke
+- the session now logs out exactly when the token expires (single timer) instead of polling every minute and hard-reloading mid-interaction
+- a malformed leading `funding` entry no longer hides a later valid funding url

--- a/.changeset/great-mirrors-follow.md
+++ b/.changeset/great-mirrors-follow.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/web': patch
+---
+
+fix(web): sign up now issues the web session JWT (the npm API token stored before could not be parsed by the UI, so the new user was never logged in), and the sidebar/readme endpoints resolve dist-tags in the `v` query param again — deep links like `/detail/pkg/v/beta` were returning 404 after the own-property hardening. Unknown versions and tags still 404, and `__proto__`-style values still never resolve.

--- a/.changeset/tidy-donkeys-drum.md
+++ b/.changeset/tidy-donkeys-drum.md
@@ -1,0 +1,6 @@
+---
+'@verdaccio/ui-components': patch
+'@verdaccio/ui-theme': patch
+---
+
+fix(ui): drop `credentials: 'include'` from the tarball download fetch. Web-UI auth travels in the `Authorization: Bearer` header, not cookies, so `include` gained nothing but made the browser reject the registry's wildcard `Access-Control-Allow-Origin: *` on cross-origin downloads (e.g. `pnpm start`, where the UI dev server on :4873 fetches tarballs from the registry on :8000), breaking the download-tarball button with a CORS error.

--- a/README.md
+++ b/README.md
@@ -95,13 +95,13 @@ We test compatibility across different versions of npm, pnpm, and Yarn to ensure
 
 E2E CLI tests run in CI via the [`verdaccio-e2e`](https://github.com/verdaccio/e2e-tests) tool on Node.js 24 and 26 against the following matrix:
 
-| Package Manager | Versions        |
-| --------------- | --------------- |
-| npm             | 10, 11, 12      |
-| yarn modern     | 3, 4            |
-| pnpm            | 10, 11          |
-| bun             | latest          |
-| deno            | latest          |
+| Package Manager | Versions   |
+| --------------- | ---------- |
+| npm             | 10, 11, 12 |
+| yarn modern     | 3, 4       |
+| pnpm            | 10, 11     |
+| bun             | latest     |
+| deno            | latest     |
 
 ## Donations
 
@@ -278,13 +278,13 @@ Thanks to the following companies to help us to achieve our goals providing free
 
 ## Maintainers
 
-| [Juan Picado](https://github.com/juanpicado)                                   | [Ayush Sharma](https://github.com/ayusharma)                             | [Sergio Hg](https://github.com/sergiohgz)                                 |
-| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
-| ![jotadeveloper](https://avatars3.githubusercontent.com/u/558752?s=120&v=4)    | ![ayusharma](https://avatars2.githubusercontent.com/u/6918450?s=120&v=4) | ![sergiohgz](https://avatars2.githubusercontent.com/u/14012309?s=120&v=4) |
-|                                                                                | [@ayusharma\_](https://twitter.com/ayusharma_)                           | [@sergiohgz](https://twitter.com/sergiohgz)                               |
-| [Priscila Oliveria](https://github.com/priscilawebdev)                         | [Daniel Ruf](https://github.com/DanielRuf)                               | [Marc Bernard](https://github.com/mbtools)
-| ![priscilawebdev](https://avatars2.githubusercontent.com/u/29228205?s=120&v=4) | ![DanielRuf](https://avatars3.githubusercontent.com/u/827205?s=120&v=4)  | <img src="https://cdn.bsky.app/img/avatar/plain/did:plc:yqleoidz7bqq5iybtbo6llib/bafkreie5gsltwp4hqfjzs6nnlsa5djbz6rk2gsdqpidpkvfpnj3uf4tcfa" width="120px" height="120px">
-| [@priscilawebdev](https://twitter.com/priscilawebdev)                          | [@DanielRufde](https://twitter.com/DanielRufde)                          | [@marcfbe](https://bsky.app/profile/marcf.be)   
+| [Juan Picado](https://github.com/juanpicado)                                   | [Ayush Sharma](https://github.com/ayusharma)                             | [Sergio Hg](https://github.com/sergiohgz)                                                                                                                                   |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ![jotadeveloper](https://avatars3.githubusercontent.com/u/558752?s=120&v=4)    | ![ayusharma](https://avatars2.githubusercontent.com/u/6918450?s=120&v=4) | ![sergiohgz](https://avatars2.githubusercontent.com/u/14012309?s=120&v=4)                                                                                                   |
+|                                                                                | [@ayusharma\_](https://twitter.com/ayusharma_)                           | [@sergiohgz](https://twitter.com/sergiohgz)                                                                                                                                 |
+| [Priscila Oliveria](https://github.com/priscilawebdev)                         | [Daniel Ruf](https://github.com/DanielRuf)                               | [Marc Bernard](https://github.com/mbtools)                                                                                                                                  |
+| ![priscilawebdev](https://avatars2.githubusercontent.com/u/29228205?s=120&v=4) | ![DanielRuf](https://avatars3.githubusercontent.com/u/827205?s=120&v=4)  | <img src="https://cdn.bsky.app/img/avatar/plain/did:plc:yqleoidz7bqq5iybtbo6llib/bafkreie5gsltwp4hqfjzs6nnlsa5djbz6rk2gsdqpidpkvfpnj3uf4tcfa" width="120px" height="120px"> |
+| [@priscilawebdev](https://twitter.com/priscilawebdev)                          | [@DanielRufde](https://twitter.com/DanielRufde)                          | [@marcfbe](https://bsky.app/profile/marcf.be)                                                                                                                               |
 
 You can find and chat with them over Discord, click [here](http://chat.verdaccio.org).
 

--- a/cypress/e2e/07-detail.cy.ts
+++ b/cypress/e2e/07-detail.cy.ts
@@ -1,0 +1,19 @@
+import { createRegistryConfig, detailTests } from '@verdaccio/e2e-ui';
+
+const registryUrl = Cypress.env('VERDACCIO_URL') || 'http://localhost:4873';
+
+const config = createRegistryConfig({
+  registryUrl,
+  title: 'Verdaccio e2e',
+  credentials: { user: 'test', password: 'test' },
+  features: {
+    detail: {
+      // master 404s an unknown version and no longer leaks the previous
+      // package's version filter across SPA navigation (verdaccio#6210 + follow-ups)
+      versionNotFound: true,
+      staleVersionsNavigation: true,
+    },
+  },
+});
+
+detailTests(config);

--- a/cypress/e2e/08-failure-modes.cy.ts
+++ b/cypress/e2e/08-failure-modes.cy.ts
@@ -1,0 +1,21 @@
+import { createRegistryConfig, failureModeTests } from '@verdaccio/e2e-ui';
+
+const registryUrl = Cypress.env('VERDACCIO_URL') || 'http://localhost:4873';
+
+const config = createRegistryConfig({
+  registryUrl,
+  title: 'Verdaccio e2e',
+  credentials: { user: 'test', password: 'test' },
+  features: {
+    failureModes: {
+      // master surfaces error states instead of blank pages / empty-registry
+      // onboarding / "no results found" on network and 5xx failures (verdaccio#6210)
+      homeNetworkError: true,
+      detailErrorState: true,
+      searchError: true,
+      downloadError: true,
+    },
+  },
+});
+
+failureModeTests(config);

--- a/cypress/e2e/09-manifest-rendering.cy.ts
+++ b/cypress/e2e/09-manifest-rendering.cy.ts
@@ -1,0 +1,20 @@
+import { createRegistryConfig, manifestRenderingTests } from '@verdaccio/e2e-ui';
+
+const registryUrl = Cypress.env('VERDACCIO_URL') || 'http://localhost:4873';
+
+const config = createRegistryConfig({
+  registryUrl,
+  title: 'Verdaccio e2e',
+  credentials: { user: 'test', password: 'test' },
+  features: {
+    manifestRendering: {
+      // master renders string/array repository, funding and bugs, gravatar
+      // avatars and email-less contributors (verdaccio#6210)
+      stringForms: true,
+      gravatarAvatars: true,
+      developersWithoutEmail: true,
+    },
+  },
+});
+
+manifestRenderingTests(config);

--- a/cypress/e2e/10-session.cy.ts
+++ b/cypress/e2e/10-session.cy.ts
@@ -1,0 +1,17 @@
+import { createRegistryConfig, sessionTests } from '@verdaccio/e2e-ui';
+
+const registryUrl = Cypress.env('VERDACCIO_URL') || 'http://localhost:4873';
+
+const config = createRegistryConfig({
+  registryUrl,
+  title: 'Verdaccio e2e',
+  credentials: { user: 'test', password: 'test' },
+  features: {
+    session: {
+      // master purges an expired token from localStorage on boot (verdaccio#6210)
+      expiredTokenPurged: true,
+    },
+  },
+});
+
+sessionTests(config);

--- a/cypress/e2e/11-i18n-keys.cy.ts
+++ b/cypress/e2e/11-i18n-keys.cy.ts
@@ -1,0 +1,17 @@
+import { createRegistryConfig, i18nKeyTests } from '@verdaccio/e2e-ui';
+
+const registryUrl = Cypress.env('VERDACCIO_URL') || 'http://localhost:4873';
+
+const config = createRegistryConfig({
+  registryUrl,
+  title: 'Verdaccio e2e',
+  credentials: { user: 'test', password: 'test' },
+  features: {
+    i18n: {
+      // the security.* namespace now ships in the bundle (verdaccio#6210)
+      noRawKeysSecurityPages: true,
+    },
+  },
+});
+
+i18nKeyTests(config);

--- a/cypress/e2e/12-signup.cy.ts
+++ b/cypress/e2e/12-signup.cy.ts
@@ -1,0 +1,19 @@
+import { createRegistryConfig, signupTests } from '@verdaccio/e2e-ui';
+
+const registryUrl = Cypress.env('VERDACCIO_URL') || 'http://localhost:4873';
+
+const config = createRegistryConfig({
+  registryUrl,
+  title: 'Verdaccio e2e',
+  credentials: { user: 'test', password: 'test' },
+  features: {
+    signup: {
+      // master posts to the real signup endpoint and logs the new user in
+      // (verdaccio#6210 + follow-ups); requires flags.createUser: true
+      happyPath: true,
+      validation: true,
+    },
+  },
+});
+
+signupTests(config);

--- a/cypress/e2e/13-change-password.cy.ts
+++ b/cypress/e2e/13-change-password.cy.ts
@@ -1,0 +1,24 @@
+import { changePasswordTests, createRegistryConfig } from '@verdaccio/e2e-ui';
+
+const registryUrl = Cypress.env('VERDACCIO_URL') || 'http://localhost:4873';
+
+// requires flags.changePassword: true on the registry
+const config = createRegistryConfig({
+  registryUrl,
+  title: 'Verdaccio e2e',
+  credentials: { user: 'test', password: 'test' },
+  features: {
+    changePassword: {
+      // The happy-path BODY works on master (a valid change lands on the
+      // success page), but the suite's after() cleanup calls cy.login to
+      // restore the original password assuming a logged-out header — and
+      // changing the password does not invalidate the JWT still in
+      // localStorage, so the user stays logged in and cy.login can't find
+      // the login button. Re-enable once the e2e-ui change-password after()
+      // hook clears the session before its restore login.
+      happyPath: false,
+    },
+  },
+});
+
+changePasswordTests(config);

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/supertest": "7.2.0",
     "@types/validator": "13.15.10",
     "@verdaccio/e2e-cli": "3.1.0",
-    "@verdaccio/e2e-ui": "2.5.0",
+    "@verdaccio/e2e-ui": "2.7.0",
     "@verdaccio/package-filter": "workspace:*",
     "@verdaccio/types": "workspace:*",
     "@verdaccio/ui-theme": "workspace:*",

--- a/packages/ui-components/src/api/use-data-mutation.test.tsx
+++ b/packages/ui-components/src/api/use-data-mutation.test.tsx
@@ -1,0 +1,39 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTarballDownload } from './use-data-mutation';
+
+const requestMock = vi.fn();
+vi.mock('../store/api', () => ({
+  default: {
+    request: (...args: unknown[]) => requestMock(...args),
+  },
+}));
+
+describe('useTarballDownload', () => {
+  beforeEach(() => {
+    requestMock.mockReset();
+    requestMock.mockResolvedValue(new Blob(['tgz']));
+  });
+
+  it('fetches the tarball link with a GET', async () => {
+    const { result } = renderHook(() => useTarballDownload());
+    await act(async () => {
+      await result.current.download({ link: 'http://localhost:8000/pkg/-/pkg-1.0.0.tgz' });
+    });
+
+    const [url, method] = requestMock.mock.calls[0];
+    expect(url).toBe('http://localhost:8000/pkg/-/pkg-1.0.0.tgz');
+    expect(method).toBe('GET');
+  });
+
+  it("must not send credentials: 'include' (registry serves ACAO '*', which the browser rejects for credentialed cross-origin requests)", async () => {
+    const { result } = renderHook(() => useTarballDownload());
+    await act(async () => {
+      await result.current.download({ link: 'http://localhost:8000/pkg/-/pkg-1.0.0.tgz' });
+    });
+
+    const options = requestMock.mock.calls[0][2] ?? {};
+    expect(options.credentials).not.toBe('include');
+  });
+});

--- a/packages/ui-components/src/api/use-data-mutation.ts
+++ b/packages/ui-components/src/api/use-data-mutation.ts
@@ -43,12 +43,15 @@ export function useDataMutation<T>(
 }
 
 async function tarballFetcher(url: string, { arg }: { arg: { link: string } }): Promise<Blob> {
+  // no `credentials: 'include'`: auth is the Bearer header (added in API.request),
+  // and `include` makes the browser reject the registry's wildcard
+  // `Access-Control-Allow-Origin: *` when the UI dev server is a different origin
+  // than the registry (pnpm start: :4873 vs :8000)
   return API.request<Blob>(arg.link, 'GET', {
     headers: {
       accept:
         'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3',
     },
-    credentials: 'include',
   });
 }
 

--- a/packages/ui-components/src/components/FundButton/FundButton.test.tsx
+++ b/packages/ui-components/src/components/FundButton/FundButton.test.tsx
@@ -104,4 +104,27 @@ describe('test FundButton', () => {
 
     expect(wrapper.getByText('button.fund-this-package')).toBeTruthy();
   });
+
+  test('a malformed leading entry must not hide a later valid url', () => {
+    const value = {
+      latest: {
+        ...pkgMeta.latest,
+        funding: [{ type: 'individual', url: 'not-a-url' }, 'https://opencollective.com/verdaccio'],
+      },
+    };
+
+    const wrapper = render(<FundButton packageMeta={value} />);
+
+    expect(wrapper.getByText('button.fund-this-package')).toBeTruthy();
+  });
+
+  test('should not display the button when no funding entry is a valid url', () => {
+    const value = {
+      latest: { ...pkgMeta.latest, funding: [{ type: 'individual', url: 'not-a-url' }] },
+    };
+
+    const wrapper = render(<FundButton packageMeta={value} />);
+
+    expect(wrapper.queryByText('button.fund-this-package')).toBeNull();
+  });
 });

--- a/packages/ui-components/src/components/Search/Search.tsx
+++ b/packages/ui-components/src/components/Search/Search.tsx
@@ -1,6 +1,6 @@
 import SearchMui from '@mui/icons-material/Search';
 import { debounce } from 'lodash-es';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 
@@ -55,12 +55,17 @@ const Search: React.FC = () => {
   const doSearchRef = useRef(doSearch);
   doSearchRef.current = doSearch;
 
+  // shows the dropdown as loading during the debounce window; without it the
+  // immediate reset below reads as "no results found" on every keystroke
+  const [isDebouncing, setIsDebouncing] = useState(false);
+
   /**
    * Stable fetch function that reads the latest doSearch from a ref,
    * avoiding dependency changes that would break the debounce.
    */
   const handleFetchPackages = useCallback(
     async ({ value }: { value: string }) => {
+      setIsDebouncing(false);
       if (value?.trim() !== '') {
         // Abort any previous pending request before starting a new one
         cancelAllSearchRequests();
@@ -93,17 +98,17 @@ const Search: React.FC = () => {
     [handleFetchPackages]
   );
 
-  const resetSearchRef = useRef(resetSearch);
-  resetSearchRef.current = resetSearch;
-
   // clear the previous query's results right away so the dropdown never lists
   // stale suggestions under the new input while the debounce timer runs
   const handleSuggestionsFetch = useCallback(
     ({ value }: { value: string }) => {
-      resetSearchRef.current?.();
+      resetSearch?.();
+      if (value?.trim() !== '') {
+        setIsDebouncing(true);
+      }
       debouncedFetch({ value });
     },
-    [debouncedFetch]
+    [resetSearch, debouncedFetch]
   );
 
   useEffect(() => {
@@ -165,7 +170,7 @@ const Search: React.FC = () => {
       renderInput={renderInput}
       renderOption={renderOption}
       suggestions={searchResults}
-      suggestionsLoading={isLoading}
+      suggestionsLoading={isLoading || isDebouncing}
     />
   );
 };

--- a/packages/ui-components/src/components/Versions/Versions.test.tsx
+++ b/packages/ui-components/src/components/Versions/Versions.test.tsx
@@ -105,6 +105,31 @@ describe('<Version /> component', () => {
     expect(versions).toEqual(['1.0.1', '1.0.0', '0.1.1', '0.1.0']);
   });
 
+  test('the filter must reset when navigating to another package', () => {
+    window.__VERDACCIO_BASENAME_UI_OPTIONS.hideDeprecatedVersions = false;
+    const SwappablePackage: React.FC = () => {
+      const [pkg, setPkg] = React.useState<any>({ meta: data, name: 'jquery' });
+      return (
+        <>
+          <button
+            data-testid="swap"
+            onClick={() => setPkg({ meta: dataUnsorted, name: 'other' })}
+            type="button"
+          />
+          <VersionsComponent packageMeta={pkg.meta} packageName={pkg.name} />
+        </>
+      );
+    };
+    renderWithRouteDetail(<SwappablePackage />);
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '2.3.0' } });
+    expect(screen.queryAllByTestId('version-list-text')).toHaveLength(1);
+
+    fireEvent.click(screen.getByTestId('swap'));
+    // the previous package's filter no longer applies and the box is cleared
+    expect(screen.queryAllByTestId('version-list-text')).toHaveLength(4);
+    expect((screen.getByRole('textbox') as HTMLInputElement).value).toBe('');
+  });
+
   test('garbage in the version filter must not crash the page', () => {
     // the filter text goes straight into semver.satisfies as a range
     window.__VERDACCIO_BASENAME_UI_OPTIONS.hideDeprecatedVersions = false;

--- a/packages/ui-components/src/components/Versions/Versions.tsx
+++ b/packages/ui-components/src/components/Versions/Versions.tsx
@@ -6,7 +6,7 @@ import CardContent from '@mui/material/CardContent';
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
 import { debounce } from 'lodash-es';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import semver from 'semver';
 
@@ -28,19 +28,20 @@ const Versions: React.FC<Props> = ({ packageMeta, packageName }) => {
   const { versions = {}, time = {}, ['dist-tags']: distTags = {} } = packageMeta ?? {};
 
   const [textSearch, setTextSearch] = useState('');
-  // derive the filtered list instead of caching it in state: the detail routes
-  // reuse this mounted component across packages, so cached versions from the
-  // previously visited package would leak into the next one
+  // the detail routes reuse this mounted component across packages: reset the
+  // filter so the previous package's text does not apply to the next one
+  useEffect(() => {
+    setTextSearch('');
+  }, [packageName]);
   const packageVersions = useMemo(() => {
+    if (textSearch === '') {
+      return versions;
+    }
     return Object.keys(versions).reduce((acc, version) => {
-      if (textSearch !== '') {
-        if (typeof versions[version] !== 'undefined') {
-          if (semver.satisfies(version, textSearch, { includePrerelease: true, loose: true })) {
-            acc[version] = versions[version];
-          }
+      if (typeof versions[version] !== 'undefined') {
+        if (semver.satisfies(version, textSearch, { includePrerelease: true, loose: true })) {
+          acc[version] = versions[version];
         }
-      } else {
-        acc[version] = versions[version];
       }
       return acc;
     }, {});
@@ -73,6 +74,8 @@ const Versions: React.FC<Props> = ({ packageMeta, packageName }) => {
               <span>{` (${Object.keys(packageVersions).length})`}</span>
             </StyledText>
             <TextField
+              // uncontrolled input: remount on navigation to clear its text
+              key={packageName}
               helperText={t('versions.search.placeholder')}
               onChange={debounce((e) => {
                 setTextSearch(e.target.value);

--- a/packages/ui-components/src/providers/ManifestsProvider/ManifestsProvider.test.tsx
+++ b/packages/ui-components/src/providers/ManifestsProvider/ManifestsProvider.test.tsx
@@ -1,22 +1,33 @@
+import { HttpResponse, http } from 'msw';
 import React from 'react';
+import { useSWRConfig } from 'swr';
 
+import { server } from '../../../vitest/server';
 import {
   RouterPath,
   act,
   cleanup,
+  fireEvent,
   renderWithRouter,
   screen,
   waitFor,
 } from '../../test/test-react-testing-library';
 import ManifestsProvider, { useManifests } from './ManifestsProvider';
 
+const PACKAGES_URL = 'http://localhost:9000/-/verdaccio/data/packages';
+
 function CustomComponent() {
-  const { isLoading, manifests } = useManifests();
+  const { isError, isLoading, manifests } = useManifests();
+  const { mutate } = useSWRConfig();
 
   return isLoading ? (
     <div>{'loading ...'}</div>
   ) : (
     <div>
+      <button onClick={() => mutate(() => true)} type="button">
+        {'revalidate'}
+      </button>
+      <div>{isError ? 'has-error' : 'no-error'}</div>
       {'packages:'}
       {manifests?.length}
     </div>
@@ -40,5 +51,42 @@ describe('<ManifestsProvider />', () => {
     );
 
     await waitFor(() => screen.getByText(400, { exact: false }));
+  });
+
+  test('should flag an error when the backend fails with nothing cached', async () => {
+    server.use(http.get(PACKAGES_URL, () => HttpResponse.error()));
+
+    await act(async () =>
+      renderWithRouter(
+        <ManifestsProvider>
+          <CustomComponent />
+        </ManifestsProvider>,
+        RouterPath.ROOT,
+        [RouterPath.ROOT]
+      )
+    );
+
+    await waitFor(() => screen.getByText('has-error'));
+  });
+
+  test('should keep the cached list when a revalidation fails', async () => {
+    await act(async () =>
+      renderWithRouter(
+        <ManifestsProvider>
+          <CustomComponent />
+        </ManifestsProvider>,
+        RouterPath.ROOT,
+        [RouterPath.ROOT]
+      )
+    );
+    await waitFor(() => screen.getByText(400, { exact: false }));
+
+    server.use(http.get(PACKAGES_URL, () => HttpResponse.error()));
+    fireEvent.click(screen.getByText('revalidate'));
+    // let the failed refetch settle
+    await act(async () => new Promise((resolve) => setTimeout(resolve, 300)));
+
+    expect(screen.getByText('no-error')).toBeInTheDocument();
+    expect(screen.getByText(400, { exact: false })).toBeInTheDocument();
   });
 });

--- a/packages/ui-components/src/providers/ManifestsProvider/ManifestsProvider.tsx
+++ b/packages/ui-components/src/providers/ManifestsProvider/ManifestsProvider.tsx
@@ -42,9 +42,9 @@ const ManifestsProvider: React.FC<{ children: ReactElement }> = ({ children }) =
       value={{
         manifests: (data.data as ManifestWeb[]) ?? [],
         isLoading: data.isLoading,
-        // network failures and malformed responses reject without a `.code`;
-        // treating them as "no error" made a dead backend look like an empty registry
-        isError: typeof data.error !== 'undefined',
+        // any error counts (network failures have no `.code`), but a failed
+        // revalidation must not hide an already-cached, renderable list
+        isError: typeof data.error !== 'undefined' && typeof data.data === 'undefined',
       }}
     >
       {children}

--- a/packages/ui-components/src/providers/VersionProvider/VersionProvider.test.tsx
+++ b/packages/ui-components/src/providers/VersionProvider/VersionProvider.test.tsx
@@ -1,5 +1,7 @@
+import { HttpResponse, http } from 'msw';
 import React from 'react';
 
+import { server } from '../../../vitest/server';
 import {
   RouterPath,
   act,
@@ -9,6 +11,16 @@ import {
   waitFor,
 } from '../../test/test-react-testing-library';
 import VersionProvider, { useVersion } from './VersionProvider';
+
+function ErrorProbe() {
+  const { isError, isLoading, packageMeta } = useVersion();
+
+  return isLoading ? (
+    <div>{'loading ...'}</div>
+  ) : (
+    <div>{`${isError ? 'has-error' : 'no-error'}:${packageMeta ? 'meta' : 'no-meta'}`}</div>
+  );
+}
 
 function CustomComponent() {
   const { isLoading, packageMeta, packageName, packageVersion } = useVersion();
@@ -53,5 +65,39 @@ describe('<VersionProvider />', () => {
       screen.queryAllByText('jquery', { exact: false });
       screen.queryAllByText('1.5.1', { exact: false });
     });
+  });
+
+  test('a readme-only failure must not flag the whole page as error', async () => {
+    server.use(
+      http.get('http://localhost:9000/-/verdaccio/data/package/readme/*', () =>
+        HttpResponse.error()
+      )
+    );
+    await act(async () =>
+      renderWithRouter(
+        <VersionProvider>
+          <ErrorProbe />
+        </VersionProvider>,
+        RouterPath.PACKAGE,
+        ['/-/web/detail/jquery']
+      )
+    );
+    await waitFor(() => screen.getByText('no-error:meta'));
+  });
+
+  test('a sidebar failure flags the page as error', async () => {
+    server.use(
+      http.get('http://localhost:9000/-/verdaccio/data/sidebar/*', () => HttpResponse.error())
+    );
+    await act(async () =>
+      renderWithRouter(
+        <VersionProvider>
+          <ErrorProbe />
+        </VersionProvider>,
+        RouterPath.PACKAGE,
+        ['/-/web/detail/jquery']
+      )
+    );
+    await waitFor(() => screen.getByText('has-error:no-meta'));
   });
 });

--- a/packages/ui-components/src/providers/VersionProvider/VersionProvider.tsx
+++ b/packages/ui-components/src/providers/VersionProvider/VersionProvider.tsx
@@ -50,8 +50,10 @@ const VersionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) 
     packageVersion
   );
   const isLoading = readmeData.isLoading || sidebarData.isLoading;
-  const error: ApiError | undefined = readmeData.error || sidebarData.error;
-  const errorCode = (readmeData.error as ApiError)?.code ?? (sidebarData.error as ApiError)?.code;
+  // only the sidebar data drives the whole page; a readme-only failure must
+  // not blank a page that can render from sidebar data
+  const error: ApiError | undefined = sidebarData.error;
+  const errorCode = (sidebarData.error as ApiError)?.code;
 
   const value = useMemo<DetailContextProps>(
     () => ({

--- a/packages/ui-components/src/sections/Header/Header.test.tsx
+++ b/packages/ui-components/src/sections/Header/Header.test.tsx
@@ -95,7 +95,7 @@ describe('<Header /> component with logged in state', () => {
   });
 
   test('should load the component in logged in state', async () => {
-    vi.spyOn(tokenUtils, 'isTokenExpire').mockReturnValue(false);
+    vi.spyOn(tokenUtils, 'tokenExpireInMs').mockReturnValue(60_000);
 
     renderHeader();
     await login('user', 'token');
@@ -118,7 +118,7 @@ describe('<Header /> component with logged in state', () => {
   });
 
   test('should login and logout the user', async () => {
-    vi.spyOn(tokenUtils, 'isTokenExpire').mockReturnValue(false); // avoid immediate logout due to invalid token
+    vi.spyOn(tokenUtils, 'tokenExpireInMs').mockReturnValue(60_000); // avoid immediate logout due to invalid token
     renderHeader();
     await login('user', 'token');
     expect(screen.getByTestId('logInDialogIcon')).toBeTruthy();
@@ -130,7 +130,7 @@ describe('<Header /> component with logged in state', () => {
       base: 'foo',
       flags: { stage: true },
     };
-    vi.spyOn(tokenUtils, 'isTokenExpire').mockReturnValue(false);
+    vi.spyOn(tokenUtils, 'tokenExpireInMs').mockReturnValue(60_000);
 
     renderHeader();
     await login('user', 'token');
@@ -239,5 +239,13 @@ describe('<Header /> component with logged in state', () => {
 
   test.todo('autocompletion should display suggestions according to the type value');
 
-  test.todo('token expiration and auto logout');
+  test('should log out automatically when the token expires', async () => {
+    // first call arms the timer close to expiry; once it fires, the token reports expired
+    vi.spyOn(tokenUtils, 'tokenExpireInMs').mockReturnValueOnce(50).mockReturnValue(-1);
+    renderHeader();
+    await login('user', 'token');
+    await waitFor(() => {
+      expect(window.location.reload).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/ui-components/src/sections/Header/Header.tsx
+++ b/packages/ui-components/src/sections/Header/Header.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { LoginDialog, Search, useAuth, useConfig } from '../../';
-import { isTokenExpire } from '../../utils/token';
+import { tokenExpireInMs } from '../../utils/token';
 import HeaderLeft from './HeaderLeft';
 import HeaderRight from './HeaderRight';
 import HeaderSettingsDialog from './HeaderSettingsDialog';
@@ -12,17 +12,9 @@ import { InnerMobileNavBar, InnerNavBar, MobileNavBar, NavBar } from './styles';
 type Props = {
   HeaderInfoDialog?: React.FC<any>;
   isPlainHeader?: boolean;
-  tokenCheckIntervalMs?: number;
 };
 
-// checking the token is a local decode, so a short interval is cheap; the old
-// hourly default kept showing the user as logged in for up to an hour after
-// the session expired
-const Header: React.FC<Props> = ({
-  HeaderInfoDialog,
-  isPlainHeader,
-  tokenCheckIntervalMs = 60 * 1000,
-}) => {
+const Header: React.FC<Props> = ({ HeaderInfoDialog, isPlainHeader }) => {
   const { t } = useTranslation();
   const [isInfoDialogOpen, setOpenInfoDialog] = useState<boolean>(false);
   const [isSettingsDialogOpen, setSettingsDialogOpen] = useState<boolean>(false);
@@ -31,27 +23,32 @@ const Header: React.FC<Props> = ({
   const { configOptions } = useConfig();
   const { userState, logOutUser } = useAuth();
 
-  // Use refs to always have the latest token/logout in the interval callback
-  const tokenRef = useRef(userState?.token);
+  // Use a ref to always have the latest logout in the timer callback
   const logOutUserRef = useRef(logOutUser);
-  useEffect(() => {
-    tokenRef.current = userState?.token;
-  }, [userState?.token]);
   useEffect(() => {
     logOutUserRef.current = logOutUser;
   }, [logOutUser]);
 
+  // log out exactly when the token expires; polling reloaded the page at an
+  // arbitrary moment up to a minute later, mid-interaction
   useEffect(() => {
-    function checkToken() {
-      const token = tokenRef.current;
-      if (token && isTokenExpire(token)) {
-        logOutUserRef.current?.();
-      }
+    const token = userState?.token;
+    if (!token) {
+      return;
     }
-    checkToken();
-    const interval = setInterval(checkToken, tokenCheckIntervalMs);
-    return () => clearInterval(interval);
-  }, [tokenCheckIntervalMs]);
+    let timer: ReturnType<typeof setTimeout>;
+    const arm = () => {
+      const remaining = tokenExpireInMs(token);
+      if (remaining === null || remaining <= 0) {
+        logOutUserRef.current?.();
+        return;
+      }
+      // setTimeout overflows above 2^31-1 ms; re-arm for far-away expiries
+      timer = setTimeout(arm, Math.min(remaining, 2 ** 31 - 1));
+    };
+    arm();
+    return () => clearTimeout(timer);
+  }, [userState?.token]);
 
   const handleLogout = () => {
     logOutUser?.();

--- a/packages/ui-components/src/sections/Header/Header.tsx
+++ b/packages/ui-components/src/sections/Header/Header.tsx
@@ -36,7 +36,7 @@ const Header: React.FC<Props> = ({ HeaderInfoDialog, isPlainHeader }) => {
     if (!token) {
       return;
     }
-    let timer: ReturnType<typeof setTimeout>;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const arm = () => {
       const remaining = tokenExpireInMs(token);
       if (remaining === null || remaining <= 0) {

--- a/packages/ui-components/src/sections/Security/AddUser.test.tsx
+++ b/packages/ui-components/src/sections/Security/AddUser.test.tsx
@@ -317,7 +317,7 @@ describe('<AddUser /> component', () => {
       expect(requests).toBe(1);
     });
 
-    test('a 2xx response without a token still lands on success without crashing or saving auth', async () => {
+    test('a 2xx response without a token shows an error instead of a false success', async () => {
       window.localStorage.removeItem('token');
       window.localStorage.removeItem('username');
       server.use(
@@ -342,8 +342,9 @@ describe('<AddUser /> component', () => {
       });
 
       await waitFor(() => {
-        expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining(Route.SUCCESS));
+        expect(screen.getByText('security.error.unable-to-add-user')).toBeInTheDocument();
       });
+      expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining(Route.SUCCESS));
       expect(window.localStorage.getItem('token')).toBeNull();
     });
   });

--- a/packages/ui-components/src/sections/Security/AddUser.tsx
+++ b/packages/ui-components/src/sections/Security/AddUser.tsx
@@ -11,6 +11,7 @@ import PasswordField from '../../components/LoginForm/PasswordField';
 import UsernameField from '../../components/LoginForm/UsernameField';
 import { getConfiguration } from '../../configuration';
 import SecurityLayout from '../../layouts/Security/Dialog';
+import { useAuth } from '../../providers/AuthProvider/AuthProvider';
 import { authErrorMessage } from '../../providers/AuthProvider/utils';
 import { saveAuth } from '../../store/storage';
 import { stripTrailingSlash } from '../../store/utils';
@@ -35,6 +36,7 @@ const AddUser: React.FC = () => {
   const { t } = useTranslation();
   const location = useLocation();
   const navigate = useNavigate();
+  const { setUserState } = useAuth();
   const configuration = getConfiguration();
   const basePath = stripTrailingSlash(configuration.base);
   const { next, user } = getSecurityUrlParams(location);
@@ -87,9 +89,13 @@ const AddUser: React.FC = () => {
           email: data.email,
           sessionId: generateSessionId(),
         });
-        if (result && result.username && result.token) {
-          saveAuth(result.username, result.token);
+        if (!result || !result.username || !result.token) {
+          // a 2xx with an unexpected body must not pass as a successful signup
+          throw new Error('signup response is missing the token');
         }
+        saveAuth(result.username, result.token);
+        // AuthProvider reads storage only once, so the header needs the state update
+        setUserState?.({ username: result.username, token: result.token });
         navigate(`${Route.SUCCESS}?messageType=${MessageType.AddUser}`);
       } catch (err) {
         setError('root', {
@@ -100,7 +106,7 @@ const AddUser: React.FC = () => {
         inFlight.current = false;
       }
     },
-    [handleAddUser, setError, navigate, t]
+    [handleAddUser, setError, setUserState, navigate, t]
   );
 
   useEffect(() => {

--- a/packages/ui-components/src/sections/Security/Login.test.tsx
+++ b/packages/ui-components/src/sections/Security/Login.test.tsx
@@ -166,6 +166,43 @@ describe('<Login /> component', () => {
     });
   });
 
+  test('a 2xx response without a token shows an error instead of a false success', async () => {
+    server.use(http.post(/\/-\/v1\/login_cli\/.*/, () => HttpResponse.json({}, { status: 200 })));
+
+    await act(async () => {
+      renderWithRouter(
+        <Routes>
+          <RouterRoute element={<Login />} path={Route.LOGIN} />
+          <RouterRoute element={<div data-testid="success-page" />} path={Route.SUCCESS} />
+        </Routes>,
+        '*',
+        [LOGIN_URL_WITH_NEXT]
+      );
+    });
+
+    await act(async () => {
+      fireEvent.change(screen.getByPlaceholderText('form-placeholder.username'), {
+        target: { value: 'testuser' },
+      });
+      fireEvent.change(screen.getByPlaceholderText('form-placeholder.password'), {
+        target: { value: 'testpass' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('login-dialog-form-login-button')).not.toBeDisabled();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('login-dialog-form-login-button'));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('security.error.unable-to-login')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('success-page')).not.toBeInTheDocument();
+    expect(storage.getItem('token')).toBeNull();
+  });
+
   test('a dead server shows the generic failure, never "invalid credentials"', async () => {
     server.use(http.post(/\/-\/v1\/login_cli\/.*/, () => HttpResponse.error()));
 

--- a/packages/ui-components/src/sections/Security/Login.tsx
+++ b/packages/ui-components/src/sections/Security/Login.tsx
@@ -12,6 +12,7 @@ import LoginFormHeader from '../../components/LoginForm/styles';
 import NotFound from '../../components/NotFound';
 import { getConfiguration } from '../../configuration';
 import SecurityLayout from '../../layouts/Security/Dialog';
+import { useAuth } from '../../providers/AuthProvider/AuthProvider';
 import type { LoginBody } from '../../providers/AuthProvider/types';
 import { authErrorMessage } from '../../providers/AuthProvider/utils';
 import { saveAuth } from '../../store/storage';
@@ -29,6 +30,7 @@ const Login: React.FC = () => {
   const { t } = useTranslation();
   const location = useLocation();
   const navigate = useNavigate();
+  const { setUserState } = useAuth();
   const { next } = getSecurityUrlParams(location);
   const createUserEnabled = configuration?.flags?.createUser;
   const addUserLink = Route.ADD_USER + (next ? '?next=' + next : '');
@@ -70,9 +72,13 @@ const Login: React.FC = () => {
       inFlight.current = true;
       try {
         const result = await handleLogin?.(data);
-        if (result && result.username && result.token) {
-          saveAuth(result.username, result.token);
+        if (!result || !result.username || !result.token) {
+          // a 2xx with an unexpected body must not pass as a successful login
+          throw new Error('login response is missing the token');
         }
+        saveAuth(result.username, result.token);
+        // AuthProvider reads storage only once, so the header needs the state update
+        setUserState?.({ username: result.username, token: result.token });
         onSuccess();
       } catch (err: any) {
         // only a 401 means wrong credentials; a dead server, 500 or 429 must
@@ -86,7 +92,7 @@ const Login: React.FC = () => {
         inFlight.current = false;
       }
     },
-    [handleLogin, setError, onSuccess, t]
+    [handleLogin, setError, setUserState, onSuccess, t]
   );
 
   return !next ? (

--- a/packages/ui-components/src/utils/token.test.ts
+++ b/packages/ui-components/src/utils/token.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-import { isTokenExpire } from './token';
+import { isTokenExpire, tokenExpireInMs } from './token';
 import {
   generateInvalidToken,
   generateTokenWithExpirationAsString,
@@ -50,5 +50,22 @@ describe('isTokenExpire', (): void => {
   test('isTokenExpire - token expiration is not a number', (): void => {
     const token = generateTokenWithExpirationAsString();
     expect(isTokenExpire(token)).toBeTruthy();
+  });
+});
+
+describe('tokenExpireInMs', (): void => {
+  test('returns null for undecodable tokens', (): void => {
+    expect(tokenExpireInMs(null)).toBeNull();
+    expect(tokenExpireInMs('not_a_valid_token')).toBeNull();
+    expect(tokenExpireInMs(generateTokenWithOutExpiration())).toBeNull();
+    expect(tokenExpireInMs(generateTokenWithExpirationAsString())).toBeNull();
+  });
+
+  test('returns a positive delay for a token expiring in the future', (): void => {
+    expect(tokenExpireInMs(generateTokenWithTimeRange(24))).toBeGreaterThan(0);
+  });
+
+  test('returns a non-positive delay for an expired token', (): void => {
+    expect(tokenExpireInMs(generateTokenWithTimeRange())).toBeLessThanOrEqual(0);
   });
 });

--- a/packages/ui-components/src/utils/token.ts
+++ b/packages/ui-components/src/utils/token.ts
@@ -25,7 +25,7 @@ export function tokenExpireInMs(token: string | null): number | null {
   if (!exp || !isNumber(exp)) {
     return null;
   }
-  // Report as expire before (real expire time - 30s)
+  // Report as expired before (real expire time - 30s)
   return exp * 1000 - 30000 - Date.now();
 }
 

--- a/packages/ui-components/src/utils/token.ts
+++ b/packages/ui-components/src/utils/token.ts
@@ -1,15 +1,16 @@
 import { Base64 } from 'js-base64';
 import { isNumber } from 'lodash-es';
 
-export function isTokenExpire(token: string | null): boolean {
+// ms until the token reports as expired (30s guard included); null when undecodable
+export function tokenExpireInMs(token: string | null): number | null {
   if (typeof token !== 'string') {
-    return true;
+    return null;
   }
 
   const [, payload] = token.split('.');
 
   if (!payload) {
-    return true;
+    return null;
   }
 
   let exp: number;
@@ -18,15 +19,17 @@ export function isTokenExpire(token: string | null): boolean {
   } catch (error: unknown) {
     // never log the token itself: even a malformed one is credential material
     console.error('Invalid token:', error);
-    return true;
+    return null;
   }
 
   if (!exp || !isNumber(exp)) {
-    return true;
+    return null;
   }
   // Report as expire before (real expire time - 30s)
-  const jsTimestamp = exp * 1000 - 30000;
-  const expired = Date.now() >= jsTimestamp;
+  return exp * 1000 - 30000 - Date.now();
+}
 
-  return expired;
+export function isTokenExpire(token: string | null): boolean {
+  const remaining = tokenExpireInMs(token);
+  return remaining === null || remaining <= 0;
 }

--- a/packages/ui-components/src/utils/utils.ts
+++ b/packages/ui-components/src/utils/utils.ts
@@ -6,6 +6,7 @@ import i18next from 'i18next';
 import type { UpLinks } from '@verdaccio/types';
 
 import type { Time } from '../types/packageMeta';
+import { isURL } from './url';
 
 export const TIMEFORMAT = 'L LTS';
 
@@ -81,11 +82,18 @@ export function getBugsUrl(bugs: unknown): string | null {
  */
 export function getFundingUrl(funding: unknown): string | null {
   const entries = Array.isArray(funding) ? funding : [funding];
+  // first *valid* url wins: a malformed entry must not hide a later valid one
   for (const entry of entries) {
-    if (typeof entry === 'string') {
+    if (typeof entry === 'string' && isURL(entry)) {
       return entry;
     }
-    if (entry && typeof entry === 'object' && 'url' in entry && typeof entry.url === 'string') {
+    if (
+      entry &&
+      typeof entry === 'object' &&
+      'url' in entry &&
+      typeof entry.url === 'string' &&
+      isURL(entry.url)
+    ) {
       return entry.url;
     }
   }

--- a/packages/web/src/api/readme.ts
+++ b/packages/web/src/api/readme.ts
@@ -13,7 +13,7 @@ import {
 import type { Storage } from '@verdaccio/store';
 import type { Config, Manifest } from '@verdaccio/types';
 
-import { isVersionValid } from '../web-utils';
+import { isVersionValid, resolveVersion } from '../web-utils';
 import { scopedPackageAccess } from './scoped-access';
 
 export { $RequestExtend, $ResponseExtend, $NextFunctionVer }; // Was required by other packages
@@ -78,15 +78,19 @@ function addReadmeWebApi(storage: Storage, auth: Auth, config: Config): Router {
         debug('readme pkg %o', manifest?.name);
         // TODO: sanitize query
         const { v } = req.query;
-        // a version that does not exist must be a 404, not the readme of latest
-        if (typeof v === 'string' && !isVersionValid(manifest, v)) {
-          debug('version %o not found for %o', v, name);
-          res.status(HTTP_STATUS.NOT_FOUND);
-          res.end();
-          return;
+        // `v` may be a version or a dist-tag; anything else is a 404
+        let requestedVersion: string | undefined;
+        if (typeof v === 'string') {
+          requestedVersion = resolveVersion(manifest, v);
+          if (!requestedVersion) {
+            debug('version %o not found for %o', v, name);
+            res.status(HTTP_STATUS.NOT_FOUND);
+            res.end();
+            return;
+          }
         }
         res.set(HEADER_TYPE.CONTENT_TYPE, HEADERS.TEXT_PLAIN_UTF8);
-        const readme = getReadmeFromManifest(manifest, v);
+        const readme = getReadmeFromManifest(manifest, requestedVersion);
         next(getReadme(readme));
       } catch (err) {
         next(err);

--- a/packages/web/src/api/sidebar.ts
+++ b/packages/web/src/api/sidebar.ts
@@ -15,7 +15,7 @@ import { convertDistRemoteToLocalTarballUrls } from '@verdaccio/tarball';
 import type { Config, Manifest, WebManifest } from '@verdaccio/types';
 
 import { addGravatarSupport, formatAuthor } from '../author-utils';
-import { deleteProperties } from '../web-utils';
+import { deleteProperties, resolveVersion } from '../web-utils';
 import { scopedPackageAccess } from './scoped-access';
 
 export { $RequestExtend, $ResponseExtend, $NextFunctionVer }; // Was required by other packages
@@ -44,25 +44,25 @@ function addSidebarWebApi(config: Config, storage: Storage, auth: Auth): Router 
           requestOptions,
         })) as Manifest;
         const { v } = req.query;
+        // `v` may be a version or a dist-tag; anything else is a 404
+        let requestedVersion: string | undefined;
+        if (typeof v === 'string') {
+          requestedVersion = resolveVersion(info, v);
+          if (!requestedVersion) {
+            debug('version %o not found for %o', v, name);
+            res.status(HTTP_STATUS.NOT_FOUND);
+            res.end();
+            return;
+          }
+        }
         let sideBarInfo = { ...info } as WebManifest;
         sideBarInfo.versions = convertDistRemoteToLocalTarballUrls(
           info,
           requestOptions,
           config.url_prefix
         ).versions;
-        if (typeof v === 'string') {
-          // own-property check right at the lookup: `v` is user input, and a
-          // crafted value like `__proto__` would otherwise resolve to
-          // Object.prototype and be polluted by the author assignment below.
-          // It also makes a version that does not exist a 404 instead of a
-          // silent fallback to latest rendered under the requested title.
-          if (!Object.hasOwn(sideBarInfo.versions, v)) {
-            debug('version %o not found for %o', v, name);
-            res.status(HTTP_STATUS.NOT_FOUND);
-            res.end();
-            return;
-          }
-          sideBarInfo.latest = sideBarInfo.versions[v];
+        if (requestedVersion) {
+          sideBarInfo.latest = sideBarInfo.versions[requestedVersion];
         } else {
           // a manifest without a resolvable dist-tags.latest (corrupt or partial
           // uplink data) used to crash here and surface as a 404 for a package

--- a/packages/web/src/api/user.ts
+++ b/packages/web/src/api/user.ts
@@ -3,7 +3,7 @@ import type { Request, Response } from 'express';
 import { Router } from 'express';
 import { isNil } from 'lodash-es';
 
-import { type Auth, getApiToken } from '@verdaccio/auth';
+import type { Auth } from '@verdaccio/auth';
 import type { VerdaccioError } from '@verdaccio/core';
 import {
   API_ERROR,
@@ -124,11 +124,11 @@ function addUserAuthApi(auth: Auth, config: Config, storage: Storage): Router {
             return;
           }
 
-          const token =
-            name && password
-              ? await getApiToken(auth, config, user as RemoteUser, password)
-              : undefined;
-          if (token) {
+          // the UI stores this token as its web session: it must be the web
+          // JWT the login endpoint issues, not the opaque npm API token
+          if (name && password) {
+            const jWTSignOptions: JWTSignOptions = config.security.web.sign;
+            const token = await auth.jwtEncrypt(user as RemoteUser, jWTSignOptions);
             debug('adduser: new token %o', cryptoUtils.mask(token as string, 4));
             return next({ token, username: name });
           }

--- a/packages/web/src/web-utils.ts
+++ b/packages/web/src/web-utils.ts
@@ -1,5 +1,6 @@
 import { forEach, isNil } from 'lodash-es';
 
+import { DIST_TAGS } from '@verdaccio/core';
 import type { ConfigYaml, Manifest } from '@verdaccio/types';
 
 export function hasLogin(config: ConfigYaml) {
@@ -41,4 +42,25 @@ export function isVersionValid(packageMeta: Manifest, packageVersion: string): b
   // own-property check: the version may come from user input, and values like
   // `__proto__` must never validate against inherited properties
   return Object.hasOwn(packageMeta.versions, packageVersion);
+}
+
+/**
+ * Resolve a user-supplied version or dist-tag to a concrete version of the
+ * manifest, or undefined. Own-property checks only: `__proto__` must never
+ * resolve against inherited properties.
+ */
+export function resolveVersion(packageMeta: Manifest, version: string): string | undefined {
+  if (isVersionValid(packageMeta, version)) {
+    return version;
+  }
+
+  const distTags = packageMeta[DIST_TAGS];
+  if (distTags && Object.hasOwn(distTags, version)) {
+    const resolved = distTags[version];
+    if (typeof resolved === 'string' && isVersionValid(packageMeta, resolved)) {
+      return resolved;
+    }
+  }
+
+  return undefined;
 }

--- a/packages/web/test/api.readme.test.ts
+++ b/packages/web/test/api.readme.test.ts
@@ -105,6 +105,18 @@ describe('readme api', () => {
     expect(response2.text).toMatch('my readme');
   });
 
+  test('should resolve a dist-tag used as version', async () => {
+    const app = await initializeServer('keep-all-readmes.yaml');
+    await publishVersion(app, 'pk2-test', '1.0.0', { readme: 'my readme' });
+    await publishVersion(app, 'pk2-test', '1.2.0', { readme: 'my new readme' });
+    const response = await supertest(app)
+      .get('/-/verdaccio/data/package/readme/pk2-test?v=latest')
+      .set('Accept', HEADERS.TEXT_PLAIN)
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.TEXT_PLAIN_UTF8)
+      .expect(HTTP_STATUS.OK);
+    expect(response.text).toMatch('my new readme');
+  });
+
   test('should return 404 for a version that does not exist instead of falling back to latest', async () => {
     const app = await initializeServer('default-test.yaml');
     await publishVersion(app, 'pk1-test', '1.0.0', { readme: 'my readme' });

--- a/packages/web/test/api.sidebar.test.ts
+++ b/packages/web/test/api.sidebar.test.ts
@@ -69,11 +69,21 @@ describe('sidebar api', () => {
       .expect(HTTP_STATUS.NOT_FOUND);
   });
 
-  test('should return 404 for a dist-tag used as version', async () => {
+  test('should resolve a dist-tag used as version', async () => {
     const app = await initializeServer('default-test.yaml');
     await publishVersion(app, 'pk5-test', '1.0.0', { readme: 'my readme' });
-    await supertest(app)
+    const response = await supertest(app)
       .get('/-/verdaccio/data/sidebar/pk5-test?v=latest')
+      .expect(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON_CHARSET)
+      .expect(HTTP_STATUS.OK);
+    expect(JSON.parse(response.text).latest.version).toBe('1.0.0');
+  });
+
+  test('should return 404 for an unknown dist-tag', async () => {
+    const app = await initializeServer('default-test.yaml');
+    await publishVersion(app, 'pk5b-test', '1.0.0', { readme: 'my readme' });
+    await supertest(app)
+      .get('/-/verdaccio/data/sidebar/pk5b-test?v=next')
       .expect(HTTP_STATUS.NOT_FOUND);
   });
 

--- a/packages/web/test/api.user.test.ts
+++ b/packages/web/test/api.user.test.ts
@@ -286,7 +286,7 @@ describe('test web server', () => {
           // not the opaque npm API token
           const [, payload] = response.body.token.split('.');
           expect(payload).toBeDefined();
-          const decoded = JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
+          const decoded = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
           expect(decoded.name).toEqual('newuser');
           expect(decoded.exp).toBeGreaterThan(Date.now() / 1000);
         });

--- a/packages/web/test/api.user.test.ts
+++ b/packages/web/test/api.user.test.ts
@@ -282,6 +282,13 @@ describe('test web server', () => {
         .then((response) => {
           expect(response.body.token).toBeDefined();
           expect(response.body.username).toEqual('newuser');
+          // the UI stores this as its web session: it must be the web JWT,
+          // not the opaque npm API token
+          const [, payload] = response.body.token.split('.');
+          expect(payload).toBeDefined();
+          const decoded = JSON.parse(Buffer.from(payload, 'base64').toString('utf8'));
+          expect(decoded.name).toEqual('newuser');
+          expect(decoded.exp).toBeGreaterThan(Date.now() / 1000);
         });
     });
 

--- a/packages/web/test/web-utils.spec.ts
+++ b/packages/web/test/web-utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { isVersionValid, sortByName } from '../src/web-utils';
+import { isVersionValid, resolveVersion, sortByName } from '../src/web-utils';
 
 describe('Utilities', () => {
   describe('Sort packages', () => {
@@ -65,6 +65,43 @@ describe('Utilities', () => {
     test('should return false if version is undefined', () => {
       // @ts-ignore: partial manifest for test
       expect(isVersionValid(manifest, undefined)).toBe(false);
+    });
+  });
+
+  describe('resolveVersion', () => {
+    const manifest = {
+      versions: {
+        '1.0.0': {},
+        '2.0.0': {},
+      },
+      'dist-tags': {
+        latest: '2.0.0',
+        beta: '1.0.0',
+        broken: '9.9.9',
+      },
+    } as any;
+
+    test('should return a concrete version as is', () => {
+      expect(resolveVersion(manifest, '1.0.0')).toBe('1.0.0');
+    });
+
+    test('should resolve a dist-tag to its version', () => {
+      expect(resolveVersion(manifest, 'beta')).toBe('1.0.0');
+      expect(resolveVersion(manifest, 'latest')).toBe('2.0.0');
+    });
+
+    test('should return undefined for an unknown version or tag', () => {
+      expect(resolveVersion(manifest, '3.0.0')).toBeUndefined();
+      expect(resolveVersion(manifest, 'next')).toBeUndefined();
+    });
+
+    test('should return undefined for a dist-tag pointing to a missing version', () => {
+      expect(resolveVersion(manifest, 'broken')).toBeUndefined();
+    });
+
+    test('should never resolve inherited properties', () => {
+      expect(resolveVersion(manifest, '__proto__')).toBeUndefined();
+      expect(resolveVersion(manifest, 'constructor')).toBeUndefined();
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,8 +119,8 @@ importers:
         specifier: 3.1.0
         version: 3.1.0
       '@verdaccio/e2e-ui':
-        specifier: 2.5.0
-        version: 2.5.0(cypress@15.10.0)
+        specifier: 2.7.0
+        version: 2.7.0(cypress@15.10.0)
       '@verdaccio/package-filter':
         specifier: workspace:*
         version: link:packages/plugins/package-filter
@@ -3295,8 +3295,8 @@ packages:
     resolution: {integrity: sha512-uGhrQPmGQvG8VBo8Dv4syhgSrmd8WmiJ8op50OcN5JspHFq9y9hjOSzw+bWt5wBwnJ733WAWLvq7zmssMYpfbw==}
     hasBin: true
 
-  '@verdaccio/e2e-ui@2.5.0':
-    resolution: {integrity: sha512-FYM1SBOFuBOqBPt5AHt1qHT93tzZCzhdz1fdlpr15krFvjd+c7G7+rt9L5q5QeevAhEzEN525Pz0Mion5mb11Q==}
+  '@verdaccio/e2e-ui@2.7.0':
+    resolution: {integrity: sha512-mM1/oYqC3zu4cnkB9BajNQMcIkNyGFI4RCCakpaQ6X4+bW7f+DCUVcxcxXO02M7rD0TNm18fmAYbIcaAOXtLSw==}
     peerDependencies:
       cypress: '>=12.0.0'
 
@@ -8124,7 +8124,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@verdaccio/e2e-ui@2.5.0(cypress@15.10.0)':
+  '@verdaccio/e2e-ui@2.7.0(cypress@15.10.0)':
     dependencies:
       cypress: 15.10.0
 

--- a/scripts/e2e-ui-config.yaml
+++ b/scripts/e2e-ui-config.yaml
@@ -46,4 +46,9 @@ userRateLimit:
   windowMs: 1000
   max: 10000
 
+# needed by the signup and change-password e2e-ui suites
+flags:
+  createUser: true
+  changePassword: true
+
 log: { type: stdout, format: json, level: warn }

--- a/scripts/e2e-ui-local.sh
+++ b/scripts/e2e-ui-local.sh
@@ -86,6 +86,11 @@ userRateLimit:
   windowMs: 1000
   max: 10000
 
+# needed by the signup and change-password e2e-ui suites
+flags:
+  createUser: true
+  changePassword: true
+
 listen: 0.0.0.0:${PORT}
 
 log: { type: stdout, format: json, level: warn }


### PR DESCRIPTION
Follow-ups from the code review of the web UI bug batch (#6210):

- signup issues the web session JWT (was the opaque npm API token, so the new user was never logged in), and login/signup hydrate the auth context so the header reflects the session
- sidebar/readme resolve dist-tags in the `?v=` deep link again (unknown versions/tags still 404)
- readme-only failures and failed revalidations no longer blank a renderable detail/home page
- versions filter resets across package navigation; search dropdown stops flashing "no results"; token logout uses a single timer instead of a 60s poll
- tarball download drops `credentials: 'include'` (fixes the cross-origin CORS error in `pnpm start`)

Bumps `@verdaccio/e2e-ui` to 2.7.0 and adds the wave-2 specs that cover the above. Changesets included.