### PR TITLE
chore: migrate pnpm to v12

### DIFF
--- a/.changeset/migrate-pnpm-12.md
+++ b/.changeset/migrate-pnpm-12.md
@@ -1,0 +1,7 @@
+---
+---
+
+Migrate the repo tooling to pnpm 12 (`pnpm@12.3.4`). No package code changes:
+`ci:version:install` drops the `--frozen-lockfile=false` form that pnpm 12
+rejects, and `minimumReleaseAgeStrict: true` keeps the release-age cooldown
+blocking immature versions instead of auto-excluding them.

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "changeset": "changeset",
     "changeset:check": "changeset status --since=master",
     "ci:version": "run-s ci:version:changeset ci:version:install",
-    "ci:version:install": "pnpm install --frozen-lockfile=false --config.prefer-online=true",
+    "ci:version:install": "pnpm install --no-frozen-lockfile --config.prefer-online=true",
     "ci:version:changeset": "changeset version",
     "ci:publish": "changeset publish",
     "ts:ref": "update-ts-references --discardComments --rootConfigName tsconfig.base.json",
@@ -133,5 +133,5 @@
     "node": ">=24"
   },
   "license": "MIT",
-  "packageManager": "pnpm@11.1.2+sha512.415a1cc25974731e75455c1468371be74c5aa5fb7621b50d4056d222451609f11412f23fd602e6169f1e060466641f798597e1be961a10688836a67b16569499"
+  "packageManager": "pnpm@12.3.4+sha512.961aa41fb077da3a04a441d9f8e15ebc0c96da8ef710b2eb67bf9ee7cb0610eabd48f1fd85f51cffe73846785fa0f87c56a3a872a1d893f8446741b5cce45457"
 }

--- a/packages/api/.npmignore
+++ b/packages/api/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/auth/.npmignore
+++ b/packages/auth/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/config/.npmignore
+++ b/packages/config/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/core/core/.npmignore
+++ b/packages/core/core/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/core/file-locking/.npmignore
+++ b/packages/core/file-locking/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/core/i18n/.npmignore
+++ b/packages/core/i18n/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/core/tarball/.npmignore
+++ b/packages/core/tarball/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/core/types/.npmignore
+++ b/packages/core/types/.npmignore
@@ -1,5 +1,5 @@
 /*
-!/src/**/*
+!/src/
 !index.js
 !LICENSE
 !README.md

--- a/packages/core/url/.npmignore
+++ b/packages/core/url/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/hooks/.npmignore
+++ b/packages/hooks/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/loaders/.npmignore
+++ b/packages/loaders/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/middleware/.npmignore
+++ b/packages/middleware/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/node-api/.npmignore
+++ b/packages/node-api/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/plugins/audit/.npmignore
+++ b/packages/plugins/audit/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/plugins/auth-memory/.npmignore
+++ b/packages/plugins/auth-memory/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/plugins/htpasswd/.npmignore
+++ b/packages/plugins/htpasswd/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/plugins/local-storage/.npmignore
+++ b/packages/plugins/local-storage/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/plugins/memory/.npmignore
+++ b/packages/plugins/memory/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/plugins/package-filter/.npmignore
+++ b/packages/plugins/package-filter/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/plugins/ui-theme/.npmignore
+++ b/packages/plugins/ui-theme/.npmignore
@@ -1,4 +1,4 @@
 /*
-!/static/**/*
+!/static/
 !index.js
 !README.md

--- a/packages/proxy/.npmignore
+++ b/packages/proxy/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/search-indexer/.npmignore
+++ b/packages/search-indexer/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/search/.npmignore
+++ b/packages/search/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/server/express/.npmignore
+++ b/packages/server/express/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/signature/.npmignore
+++ b/packages/signature/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/store/.npmignore
+++ b/packages/store/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/ui-components/.npmignore
+++ b/packages/ui-components/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/packages/verdaccio/.npmignore
+++ b/packages/verdaccio/.npmignore
@@ -1,7 +1,7 @@
 /*
-!/bin/**/*
-!/build/**/*
-!/debug/**/*
+!/bin/
+!/build/
+!/debug/
 !index.js
 !LICENSE
 !README.md

--- a/packages/web/.npmignore
+++ b/packages/web/.npmignore
@@ -1,6 +1,6 @@
 /*
-!/bin/**/*
-!/build/**/*
+!/bin/
+!/build/
 !index.js
 !LICENSE
 !README.md

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.3.4
+        version: 12.3.4
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.3.4':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.3.4':
+    optional: true
+
+  pnpm@12.3.4:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,9 @@ allowBuilds:
   msw: true
   unrs-resolver: true
 minimumReleaseAge: 10080
+# pnpm 12 auto-adds new direct dependencies to minimumReleaseAgeExclude instead
+# of blocking them; strict keeps the pnpm 11 behavior (fail on immature versions)
+minimumReleaseAgeStrict: true
 minimumReleaseAgeExclude:
   - '@verdaccio/*'
   - '@verdaccio-scope/*'


### PR DESCRIPTION
- bump packageManager to pnpm@12.3.4
- ci:version:install: pnpm 12 rejects --frozen-lockfile=false, use --no-frozen-lockfile
- set minimumReleaseAgeStrict so pnpm 12 keeps blocking immature versions instead of auto-adding them to minimumReleaseAgeExclude