### PR TITLE
fix(config): TypeError if process.env.HOME is undefined

### DIFF
--- a/.changeset/wacky-places-grab.md
+++ b/.changeset/wacky-places-grab.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/config': patch
+---
+
+fix(config): typeerror if process.env.HOME is undefined

--- a/.changeset/wacky-places-grab.md
+++ b/.changeset/wacky-places-grab.md
@@ -2,4 +2,4 @@
 '@verdaccio/config': patch
 ---
 
-fix(config): typeerror if process.env.HOME is undefined
+fix(config): TypeError if process.env.HOME is undefined

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -103,7 +103,12 @@ function updateStorageLinks(configLocation: SetupDirectory, defaultConfig: strin
   // files should be stored, If $XDG_DATA_HOME is either not set or empty, a default
   // equal to $HOME/.local/share should be used.
   let dataDir =
-    process.env.XDG_DATA_HOME || path.join(process.env.HOME as string, '.local', 'share');
+    process.env.XDG_DATA_HOME ||
+    (process.env.HOME && path.join(process.env.HOME, '.local', 'share'));
+  if (!dataDir) {
+    debug(`could not determine data directory, skip override`);
+    return defaultConfig;
+  }
   if (folderExists(dataDir)) {
     debug(`previous storage located`);
     debug(`update storage links to %s`, dataDir);

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -103,12 +103,7 @@ function updateStorageLinks(configLocation: SetupDirectory, defaultConfig: strin
   // files should be stored, If $XDG_DATA_HOME is either not set or empty, a default
   // equal to $HOME/.local/share should be used.
   let dataDir =
-    process.env.XDG_DATA_HOME ||
-    (process.env.HOME && path.join(process.env.HOME, '.local', 'share'));
-  if (!dataDir) {
-    debug(`could not determine data directory, skip override`);
-    return defaultConfig;
-  }
+    process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');  
   if (folderExists(dataDir)) {
     debug(`previous storage located`);
     debug(`update storage links to %s`, dataDir);

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -153,8 +153,7 @@ function getConfigPaths(): SetupDirectory[] {
  * @returns
  */
 const getXDGDirectory = (): SetupDirectory | void => {
-  const xDGConfigPath =
-    process.env.XDG_CONFIG_HOME || (process.env.HOME && path.join(process.env.HOME, '.config'));
+  const xDGConfigPath = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
   debug('XDGConfig folder path %s', xDGConfigPath);
   if (xDGConfigPath && folderExists(xDGConfigPath)) {
     debug('XDGConfig folder path %s', xDGConfigPath);

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -102,8 +102,7 @@ function updateStorageLinks(configLocation: SetupDirectory, defaultConfig: strin
   // $XDG_DATA_HOME defines the base directory relative to which user specific data
   // files should be stored, If $XDG_DATA_HOME is either not set or empty, a default
   // equal to $HOME/.local/share should be used.
-  let dataDir =
-    process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');  
+  let dataDir = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
   if (folderExists(dataDir)) {
     debug(`previous storage located`);
     debug(`update storage links to %s`, dataDir);


### PR DESCRIPTION
Fix in case `HOME` is not defined (windows)

<img width="736" height="146" alt="image" src="https://github.com/user-attachments/assets/b61670f6-b741-4e96-afbd-15155a8d332f" />
