### PR TITLE
fix(package-filter): flaky test

### DIFF
--- a/.changeset/wacky-tigers-attend.md
+++ b/.changeset/wacky-tigers-attend.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/package-filter': patch
+---
+
+fix(package-filter): flaky test

--- a/packages/plugins/package-filter/test/parser.test.ts
+++ b/packages/plugins/package-filter/test/parser.test.ts
@@ -45,7 +45,7 @@ describe('parseConfig', () => {
   test('parses dateThreshold', () => {
     const result = parseConfig({ dateThreshold: '2024-01-01' });
     expect(result.dateThreshold).toBeInstanceOf(Date);
-    expect(result.dateThreshold!.getFullYear()).toBe(2024);
+    expect(result.dateThreshold!.toISOString()).toBe('2024-01-01T00:00:00.000Z');
   });
 
   test('parses minAgeDays', () => {


### PR DESCRIPTION
`new Date('2024-01-01')` is UTC midnight, so `getFullYear()` can be 2023 in western time zones. 