### PR TITLE
fix(search): paginate uplink results before applying client offset

### DIFF
--- a/.changeset/witty-things-poke.md
+++ b/.changeset/witty-things-poke.md
@@ -5,4 +5,4 @@
 '@verdaccio/store': patch
 ---
 
-Fix Search v1 pagination by collecting bounded uplink pages from offset zero and applying the client offset once, after deduplication and access checks. Keep result ordering stable across uplink rounds, fetch additional candidates when needed, and cancel work on disconnect or after 30 seconds. Return 503 when an uplink fails, stops advancing, or the shared budget of 100 requests / 25,000 candidates is exhausted instead of returning an incomplete successful page.
+Fix Search v1 pagination by collecting bounded uplink pages from offset zero and applying the client offset once, after deduplication and access checks. Keep result ordering stable across uplink rounds, fetch additional candidates when needed, and cancel work on disconnect or after 30 seconds. Skip uplinks that fail before contributing any results so local and healthy-uplink searches remain available. Return 503 when an uplink fails after contributing a page, stops advancing, or the shared budget of 100 requests / 25,000 candidates is exhausted instead of returning an incomplete successful page.

--- a/.changeset/witty-things-poke.md
+++ b/.changeset/witty-things-poke.md
@@ -1,0 +1,8 @@
+---
+'@verdaccio/api': patch
+'@verdaccio/proxy': patch
+'@verdaccio/search': patch
+'@verdaccio/store': patch
+---
+
+Fix Search v1 pagination by collecting bounded uplink pages from offset zero and applying the client offset once, after deduplication and access checks. Keep result ordering stable across uplink rounds, fetch additional candidates when needed, and cancel work on disconnect or after 30 seconds. Return 503 when an uplink fails, stops advancing, or the shared budget of 100 requests / 25,000 candidates is exhausted instead of returning an incomplete successful page.

--- a/packages/api/src/v1/search.ts
+++ b/packages/api/src/v1/search.ts
@@ -1,13 +1,9 @@
-import buildDebug from 'debug';
-
 import type { Auth } from '@verdaccio/auth';
 import type { searchUtils } from '@verdaccio/core';
-import { HTTP_STATUS } from '@verdaccio/core';
+import { HTTP_STATUS, errorUtils } from '@verdaccio/core';
 import { SEARCH_API_ENDPOINTS, rateLimit } from '@verdaccio/middleware';
 import type { Storage } from '@verdaccio/store';
 import type { Config, Logger } from '@verdaccio/types';
-
-const debug = buildDebug('verdaccio:api:search');
 
 const DEFAULT_SIZE = 20;
 // the public npm registry caps page size at 250 as well
@@ -18,6 +14,7 @@ const MAX_FROM = 10_000;
 // access checks run in batches so the scan can stop early once the
 // requested page is filled
 const CHECK_ACCESS_BATCH_SIZE = 50;
+const SEARCH_TIMEOUT_MS = 30_000;
 
 function parseQueryInt(value: unknown, defaultValue: number, max: number): number {
   const parsed = Number.parseInt(String(value), 10);
@@ -40,7 +37,11 @@ export default function (
   config: Config,
   logger: Logger
 ): void {
-  function checkAccess(pkg: any, auth: any, remoteUser): Promise<searchUtils.SearchItemPkg | null> {
+  function checkAccess(
+    pkg: any,
+    auth: any,
+    remoteUser
+  ): Promise<searchUtils.SearchPackageItem | null> {
     return new Promise((resolve, reject) => {
       auth.allow_access({ packageName: pkg?.package?.name }, remoteUser, function (err, allowed) {
         if (err) {
@@ -67,55 +68,64 @@ export default function (
       // request cannot demand unbounded work
       const size = parseQueryInt(query.size, DEFAULT_SIZE, MAX_SIZE);
       const from = parseQueryInt(query.from, 0, MAX_FROM);
-      // rebuild the query and relative url from the clamped values so the
-      // bounds hold end-to-end: storage plugins read `query.size`/`query.from`
-      // and the uplink proxy forwards `url` verbatim to the remote registry
       const safeQuery = { ...query, size, from };
-      const searchParams = new URLSearchParams(query);
-      searchParams.set('size', String(size));
-      searchParams.set('from', String(from));
-      const safeUrl = `${url.split('?')[0]}?${searchParams.toString()}`;
       const abort = new AbortController();
       const onClientClose = (): void => {
-        debug('search web aborted');
-        abort.abort();
+        if (!res.writableEnded) abort.abort(new Error('search client disconnected'));
       };
-      req.socket.on('close', onClientClose);
+      res.on('close', onClientClose);
+      const timeout = setTimeout(() => {
+        abort.abort(errorUtils.getServiceUnavailable('search pagination timed out'));
+      }, SEARCH_TIMEOUT_MS);
+      timeout.unref();
+      let onAbort: () => void;
+      const cancelled = new Promise<never>((_resolve, reject) => {
+        onAbort = () => reject(abort.signal.reason);
+        abort.signal.addEventListener('abort', onAbort, { once: true });
+      });
 
       try {
-        debug('storage search initiated');
-        const data = await storage.search({
-          query: safeQuery,
-          url: safeUrl,
-          abort,
-        });
-        debug('storage items total: %o', data.length);
-
-        // evaluate access in batches and stop as soon as the requested page
-        // is filled, instead of running an auth check on every result
         const requested = from + size;
-        const allowed: searchUtils.SearchItemPkg[] = [];
-        for (
-          let i = 0;
-          i < data.length && allowed.length < requested && !abort.signal.aborted;
-          i += CHECK_ACCESS_BATCH_SIZE
-        ) {
-          const batch = await Promise.all(
-            data
-              .slice(i, i + CHECK_ACCESS_BATCH_SIZE)
-              .map((pkgItem) => checkAccess(pkgItem, auth, req.remote_user))
-          );
-          for (const item of batch) {
-            if (item !== null) {
-              allowed.push(item);
+        const access = new Map<string, Promise<boolean>>();
+        const collect = async (): Promise<searchUtils.SearchPackageItem[]> => {
+          if (size === 0) return [];
+          let allowed: searchUtils.SearchPackageItem[] = [];
+          for await (const data of storage.searchPages({ query: safeQuery, url, abort })) {
+            abort.signal.throwIfAborted();
+            allowed = [];
+            for (
+              let i = 0;
+              i < data.length && allowed.length < requested;
+              i += CHECK_ACCESS_BATCH_SIZE
+            ) {
+              abort.signal.throwIfAborted();
+              const batch = await Promise.race([
+                Promise.all(
+                  data.slice(i, i + CHECK_ACCESS_BATCH_SIZE).map(async (item) => {
+                    const name = item.package.name;
+                    let permission = access.get(name);
+                    if (!permission) {
+                      permission = checkAccess(item, auth, req.remote_user).then(
+                        (result) => result !== null
+                      );
+                      access.set(name, permission);
+                    }
+                    return (await permission) ? item : null;
+                  })
+                ),
+                cancelled,
+              ]);
+              for (const item of batch) if (item !== null) allowed.push(item);
             }
+            if (allowed.length >= requested) break;
           }
-        }
-
-        const final: searchUtils.SearchItemPkg[] = allowed.slice(from, requested);
+          abort.signal.throwIfAborted();
+          return allowed.slice(from, requested);
+        };
+        const final = await Promise.race([collect(), cancelled]);
         logger.debug(`search results ${final?.length}`);
 
-        const response: searchUtils.SearchResults = {
+        const response = {
           objects: final,
           total: final.length,
           time: new Date().toUTCString(),
@@ -123,11 +133,15 @@ export default function (
 
         res.status(HTTP_STATUS.OK).json(response);
       } catch (error) {
+        if (res.destroyed) return;
         logger.error({ error }, 'search endpoint has failed @{error.message}');
         next(error);
         return;
       } finally {
-        req.socket.off('close', onClientClose);
+        clearTimeout(timeout);
+        abort.signal.removeEventListener('abort', onAbort!);
+        res.off('close', onClientClose);
+        abort.abort();
       }
     }
   );

--- a/packages/api/test/integration/config/search-pagination.yaml
+++ b/packages/api/test/integration/config/search-pagination.yaml
@@ -1,0 +1,18 @@
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd-search-pagination
+
+uplinks:
+  first:
+    url: https://first.registry.test/
+  second:
+    url: https://second.registry.test/
+
+log: { type: stdout, format: pretty, level: fatal }
+
+packages:
+  '**':
+    access: $all
+    publish: $authenticated

--- a/packages/api/test/integration/search-pagination.spec.ts
+++ b/packages/api/test/integration/search-pagination.spec.ts
@@ -1,0 +1,240 @@
+import nock from 'nock';
+import supertest from 'supertest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import {
+  createUser,
+  initializeServer,
+  initializeServerWithContext,
+  publishVersionWithToken,
+} from './_helper';
+
+const domain = 'https://registry.npmjs.org';
+const item = (name: string, version = '1.0.0') => ({ package: { name, version } });
+const catalog = (count: number) => Array.from({ length: count }, (_, i) => item(`remote-${i}`));
+
+function paginatedUplink(objects: ReturnType<typeof item>[], cap = 250, reportTotal = true) {
+  const requests: URLSearchParams[] = [];
+  nock(domain)
+    .persist()
+    .get('/-/v1/search')
+    .query(true)
+    .reply(200, (uri) => {
+      const query = new URL(uri, domain).searchParams;
+      requests.push(query);
+      const from = Number(query.get('from'));
+      const size = Math.min(Number(query.get('size')), cap);
+      return {
+        objects: objects.slice(from, from + size),
+        ...(reportTotal ? { total: objects.length } : {}),
+      };
+    });
+  return requests;
+}
+
+const names = (response) => response.body.objects.map((entry) => entry.package.name);
+
+afterEach(() => {
+  nock.cleanAll();
+  nock.abortPendingRequests();
+  vi.restoreAllMocks();
+});
+
+describe('Search v1 progressive pagination', () => {
+  test.each([
+    ['first', 15, 0],
+    ['second', 0, 15],
+  ])(
+    'keeps round and duplicate ordering when %s is slower',
+    async (_name, firstDelay, secondDelay) => {
+      const mock = (host: string, delay: number, entries: ReturnType<typeof item>[]) => {
+        const offsets: number[] = [];
+        nock(host)
+          .persist()
+          .get('/-/v1/search')
+          .query(true)
+          .delay(delay)
+          .reply(200, (uri) => {
+            const offset = Number(new URL(uri, host).searchParams.get('from'));
+            offsets.push(offset);
+            return { objects: entries.slice(offset, offset + 2), total: entries.length };
+          });
+        return offsets;
+      };
+      const first = mock('https://first.registry.test', firstDelay, [
+        item('a'),
+        item('b'),
+        item('d'),
+        item('e'),
+      ]);
+      const second = mock('https://second.registry.test', secondDelay, [
+        item('a', '2.0.0'),
+        item('c'),
+        item('f'),
+        item('g'),
+      ]);
+      const app = await initializeServer('search-pagination.yaml');
+      const response = await supertest(app).get('/-/v1/search?text=any&from=1&size=5').expect(200);
+      expect(names(response)).toEqual(['b', 'c', 'd', 'e', 'f']);
+      const pageOne = await supertest(app).get('/-/v1/search?text=any&from=0&size=1').expect(200);
+      expect(pageOne.body.objects[0].package).toEqual({ name: 'a', version: '2.0.0' });
+      expect(first).toEqual([0, 2, 0]);
+      expect(second).toEqual([0, 2, 0]);
+    }
+  );
+
+  test('fills a deep page using bounded requests and preserves search parameters', async () => {
+    const requests = paginatedUplink(catalog(600));
+    const app = await initializeServer('search-abort.yaml');
+    const response = await supertest(app)
+      .get(
+        '/-/v1/search?text=remote%20test&from=300&size=20&quality=0.1&popularity=0.2&maintenance=0.3'
+      )
+      .expect(200);
+    expect(names(response)).toEqual(
+      catalog(600)
+        .slice(300, 320)
+        .map((entry) => entry.package.name)
+    );
+    expect(requests.map((query) => query.get('from'))).toEqual(['0', '250']);
+    for (const query of requests) {
+      expect(Object.fromEntries(query)).toMatchObject({
+        size: '250',
+        text: 'remote test',
+        quality: '0.1',
+        popularity: '0.2',
+        maintenance: '0.3',
+      });
+    }
+  });
+
+  test('continues after short pages when an uplink has a smaller cap and no total', async () => {
+    const requests = paginatedUplink(catalog(8), 2, false);
+    const app = await initializeServer('search-abort.yaml');
+    const response = await supertest(app).get('/-/v1/search?text=remote&from=5&size=2').expect(200);
+    expect(names(response)).toEqual(['remote-5', 'remote-6']);
+    expect(requests.map((query) => query.get('from'))).toEqual(['0', '2', '4', '6']);
+  });
+
+  test.each([0, 6, 8, 100])('handles empty and exhausted pages at offset %i', async (from) => {
+    const requests = paginatedUplink(catalog(7), 2, false);
+    const app = await initializeServer('search-abort.yaml');
+    const response = await supertest(app)
+      .get(`/-/v1/search?text=remote&from=${from}&size=2`)
+      .expect(200);
+    expect(names(response)).toEqual(
+      catalog(7)
+        .slice(from, from + 2)
+        .map((entry) => entry.package.name)
+    );
+    expect(requests.length).toBeLessThanOrEqual(5);
+  });
+
+  test('combines local and remote packages and retains the newer duplicate in its original position', async () => {
+    const app = await initializeServer('search-abort.yaml');
+    const user = await createUser(app, 'test', 'test');
+    await publishVersionWithToken(app, 'foo-a', '1.0.0', user.body.token);
+    await publishVersionWithToken(app, 'foo-b', '1.0.0', user.body.token);
+    const requests = paginatedUplink(
+      [item('foo-a', '2.0.0'), item('foo-c'), item('foo-d'), item('foo-e')],
+      2
+    );
+    const first = await supertest(app).get('/-/v1/search?text=foo&from=0&size=2').expect(200);
+    const second = await supertest(app).get('/-/v1/search?text=foo&from=2&size=2').expect(200);
+    expect(names(first)).toEqual(['foo-a', 'foo-b']);
+    expect(first.body.objects[0].package.version).toBe('2.0.0');
+    expect(names(second)).toEqual(['foo-c', 'foo-d']);
+    expect(requests.map((query) => query.get('from'))).toEqual(['0', '0', '2']);
+  });
+
+  test('fetches more candidates after denied permissions and checks each name once', async () => {
+    const requests = paginatedUplink(catalog(10), 2);
+    const { app, auth } = await initializeServerWithContext('search-abort.yaml');
+    const access = vi.spyOn(auth, 'allow_access').mockImplementation((pkg, _user, callback) => {
+      callback(null, Number(pkg.packageName.split('-')[1]) % 2 === 0);
+    });
+    const response = await supertest(app).get('/-/v1/search?text=remote&from=2&size=2').expect(200);
+    expect(names(response)).toEqual(['remote-4', 'remote-6']);
+    expect(requests).toHaveLength(4);
+    expect(access).toHaveBeenCalledTimes(8);
+  });
+
+  test('does no upstream work for size zero', async () => {
+    const requests = paginatedUplink(catalog(10));
+    const app = await initializeServer('search-abort.yaml');
+    const response = await supertest(app).get('/-/v1/search?text=remote&from=5&size=0').expect(200);
+    expect(names(response)).toEqual([]);
+    expect(requests).toHaveLength(0);
+  });
+
+  test('aborts an in-flight second HTTP page when the client disconnects', async () => {
+    nock(domain)
+      .get('/-/v1/search')
+      .query(true)
+      .reply(200, { objects: catalog(2), total: 10 });
+    let started: () => void;
+    const secondStarted = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    nock(domain)
+      .get('/-/v1/search')
+      .query(true)
+      .delay(5_000)
+      .reply(200, { objects: [item('remote-2'), item('remote-3')], total: 10 })
+      .on('request', () => started!());
+    const third = nock(domain)
+      .get('/-/v1/search')
+      .query({ text: 'remote', from: '4', size: '250' })
+      .reply(200, { objects: [], total: 10 });
+    const { app, storage } = await initializeServerWithContext('search-abort.yaml');
+    const search = vi.spyOn(storage, 'searchPages');
+    const request = supertest(app).get('/-/v1/search?text=remote&from=4&size=2');
+    request.end(() => {});
+    await secondStarted;
+    const signal = search.mock.calls[0][0].abort.signal;
+    const cancelled = new Promise<void>((resolve) =>
+      signal.addEventListener('abort', () => resolve(), { once: true })
+    );
+    request.abort();
+    await cancelled;
+    expect(signal.aborted).toBe(true);
+    expect(third.isDone()).toBe(false);
+  });
+
+  test('rejects an uplink that repeats pages instead of silently truncating results', async () => {
+    let requests = 0;
+    nock(domain)
+      .persist()
+      .get('/-/v1/search')
+      .query(true)
+      .reply(200, () => {
+        requests++;
+        return { objects: catalog(2), total: 100 };
+      });
+    const app = await initializeServer('search-abort.yaml');
+    const response = await supertest(app).get('/-/v1/search?text=remote&from=2&size=2').expect(503);
+    expect(response.body.error).toContain('did not advance');
+    expect(requests).toBe(2);
+  });
+
+  test('rejects requests that exhaust the shared uplink request budget', async () => {
+    const requests = paginatedUplink(catalog(200), 1);
+    const app = await initializeServer('search-abort.yaml');
+    const response = await supertest(app)
+      .get('/-/v1/search?text=remote&from=100&size=2')
+      .expect(503);
+    expect(response.body.error).toContain('budget exhausted');
+    expect(requests).toHaveLength(100);
+  });
+
+  test('reports an upstream failure after a successful page without returning partial success', async () => {
+    nock(domain)
+      .get('/-/v1/search')
+      .query(true)
+      .reply(200, { objects: catalog(2), total: 10 });
+    const failed = nock(domain).get('/-/v1/search').query(true).reply(500);
+    const app = await initializeServer('search-abort.yaml');
+    await supertest(app).get('/-/v1/search?text=remote&from=2&size=2').expect(503);
+    expect(failed.isDone()).toBe(true);
+  });
+});

--- a/packages/api/test/integration/search-pagination.spec.ts
+++ b/packages/api/test/integration/search-pagination.spec.ts
@@ -41,6 +41,81 @@ afterEach(() => {
 });
 
 describe('Search v1 progressive pagination', () => {
+  test.each([401, 404, 429, 500, 'connection', 'timeout', 'json'])(
+    'preserves local pagination when the first uplink request fails (%s)',
+    async (failure) => {
+      const upstream = nock(domain).persist().get('/-/v1/search').query(true);
+      if (failure === 'connection' || failure === 'timeout') {
+        upstream.replyWithError({
+          code: failure === 'connection' ? 'ECONNREFUSED' : 'ETIMEDOUT',
+          message: String(failure),
+        });
+      } else if (failure === 'json') {
+        upstream.reply(200, 'invalid JSON');
+      } else {
+        upstream.reply(failure);
+      }
+      const app = await initializeServer('search-abort.yaml');
+      const user = await createUser(app, 'test', 'test');
+      for (const name of ['foo-a', 'foo-b', 'foo-c']) {
+        await publishVersionWithToken(app, name, '1.0.0', user.body.token);
+      }
+      const first = await supertest(app).get('/-/v1/search?text=foo&from=0&size=2').expect(200);
+      const second = await supertest(app).get('/-/v1/search?text=foo&from=2&size=2').expect(200);
+      expect(names(first)).toEqual(['foo-a', 'foo-b']);
+      expect(names(second)).toEqual(['foo-c']);
+    }
+  );
+
+  test('returns an empty successful page when all sources are unavailable and no locals match', async () => {
+    nock(domain)
+      .get('/-/v1/search')
+      .query(true)
+      .replyWithError({ code: 'ECONNREFUSED', message: 'offline' });
+    const app = await initializeServer('search-abort.yaml');
+    const response = await supertest(app)
+      .get('/-/v1/search?text=missing&from=20&size=20')
+      .expect(200);
+    expect(names(response)).toEqual([]);
+  });
+
+  test.each(['first', 'second'])(
+    'continues paging the healthy source when %s is unavailable',
+    async (failed) => {
+      let failures = 0;
+      const offsets: number[] = [];
+      for (const name of ['first', 'second']) {
+        const host = `https://${name}.registry.test`;
+        if (name === failed) {
+          nock(host)
+            .get('/-/v1/search')
+            .query(true)
+            .reply(503, () => {
+              failures++;
+              return {};
+            });
+        } else {
+          nock(host)
+            .persist()
+            .get('/-/v1/search')
+            .query(true)
+            .reply(200, (uri) => {
+              const from = Number(new URL(uri, host).searchParams.get('from'));
+              offsets.push(from);
+              return { objects: catalog(6).slice(from, from + 2), total: 6 };
+            });
+        }
+      }
+      const app = await initializeServer('search-pagination.yaml');
+      const response = await supertest(app)
+        .get('/-/v1/search?text=remote&from=3&size=2')
+        .expect(200);
+      expect(names(response)).toEqual(['remote-3', 'remote-4']);
+      expect(offsets).toEqual([0, 2, 4]);
+      expect(failures).toBe(1);
+    }
+  );
+
   test.each([
     ['first', 15, 0],
     ['second', 0, 15],

--- a/packages/api/test/integration/search.spec.ts
+++ b/packages/api/test/integration/search.spec.ts
@@ -140,6 +140,29 @@ describe('search', () => {
     });
   });
   describe('pagination', () => {
+    test('should paginate remote results only once', async () => {
+      const packages = Array.from({ length: 60 }, (_, i) => ({
+        package: { name: `remote-${i}`, version: '1.0.0' },
+      }));
+      const uplink = nock('https://registry.npmjs.org')
+        .get('/-/v1/search')
+        .query(true)
+        .reply(200, (uri) => {
+          const query = new URL(uri, 'https://registry.npmjs.org').searchParams;
+          const from = Number(query.get('from'));
+          const size = Number(query.get('size'));
+          return { objects: packages.slice(from, from + size), total: packages.length };
+        });
+      const remoteApp = await initializeServer('search-abort.yaml');
+      const response = await supertest(remoteApp)
+        .get('/-/v1/search?text=remote&from=20&size=20')
+        .expect(HTTP_STATUS.OK);
+      expect(response.body.objects.map((item) => item.package.name)).toEqual(
+        packages.slice(20, 40).map((item) => item.package.name)
+      );
+      expect(uplink.isDone()).toBe(true);
+    });
+
     test('should honor the size and from parameters', async () => {
       const res = await createUser(app, 'test', 'test');
       await publishVersionWithToken(app, 'foo-a', '1.0.0', res.body.token);
@@ -196,7 +219,7 @@ describe('search', () => {
       nock.cleanAll();
     });
 
-    test('should forward the clamped size and from values to the uplink', async () => {
+    test('should start bounded uplink pages at zero even for a large client offset', async () => {
       let forwardedPath;
       nock('https://registry.npmjs.org')
         .get(/\/-\/v1\/search/)
@@ -214,7 +237,7 @@ describe('search', () => {
       const forwardedQuery = new URL(forwardedPath, 'https://registry.npmjs.org').searchParams;
       expect(forwardedQuery.get('text')).toBe('clamp-check');
       expect(forwardedQuery.get('size')).toBe('250');
-      expect(forwardedQuery.get('from')).toBe('10000');
+      expect(forwardedQuery.get('from')).toBe('0');
     });
 
     test('should preserve optional package fields returned by an uplink', async () => {

--- a/packages/api/test/unit/search-pagination.spec.ts
+++ b/packages/api/test/unit/search-pagination.spec.ts
@@ -1,0 +1,100 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import search from '../../src/v1/search';
+
+function harness(storage, allowAccess = (_pkg, _user, cb) => cb(null, true)) {
+  const route = { get: vi.fn() };
+  const logger = { debug: vi.fn(), error: vi.fn() };
+  search(route, { allow_access: allowAccess } as never, storage, {} as never, logger as never);
+  const handler = route.get.mock.calls[0].at(-1);
+  const req = {
+    query: { text: 'foo', from: 0, size: 2 },
+    url: '/-/v1/search?text=foo',
+    remote_user: {},
+  };
+  const res = Object.assign(new EventEmitter(), {
+    writableEnded: false,
+    destroyed: false,
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  });
+  const next = vi.fn();
+  return { req, res, next, run: () => handler(req, res, next) };
+}
+
+afterEach(() => vi.useRealTimers());
+
+describe('search pagination lifecycle', () => {
+  test('cancels upstream work when the response connection closes', async () => {
+    let signal: AbortSignal | undefined;
+    let stopped = false;
+    const storage = {
+      async *searchPages(options) {
+        signal = options.abort.signal;
+        try {
+          await new Promise((_resolve, reject) =>
+            signal!.addEventListener('abort', () => reject(signal!.reason), { once: true })
+          );
+          yield [];
+        } finally {
+          stopped = true;
+        }
+      },
+    };
+    const h = harness(storage);
+    const running = h.run();
+    h.res.destroyed = true;
+    h.res.emit('close');
+    await running;
+    expect(signal?.aborted).toBe(true);
+    expect(stopped).toBe(true);
+    expect(h.next).not.toHaveBeenCalled();
+    expect(h.res.json).not.toHaveBeenCalled();
+    expect(h.res.listenerCount('close')).toBe(0);
+  });
+
+  test('the total deadline also interrupts a stalled authorization plugin', async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    let rounds = 0;
+    const storage = {
+      async *searchPages(options) {
+        signal = options.abort.signal;
+        rounds++;
+        yield [{ package: { name: 'foo', version: '1.0.0' } }];
+        rounds++;
+        yield [];
+      },
+    };
+    const authorize = vi.fn();
+    const h = harness(storage, authorize);
+    const timers = vi.getTimerCount();
+    const running = h.run();
+    await vi.advanceTimersByTimeAsync(30_000);
+    await running;
+    expect(authorize).toHaveBeenCalledOnce();
+    expect(signal?.aborted).toBe(true);
+    expect(h.next).toHaveBeenCalledWith(
+      expect.objectContaining({ statusCode: 503, message: 'search pagination timed out' })
+    );
+    expect(rounds).toBe(1);
+    expect(vi.getTimerCount()).toBe(timers);
+  });
+
+  test('normal completion removes timers and listeners', async () => {
+    vi.useFakeTimers();
+    const storage = {
+      async *searchPages() {
+        yield [];
+      },
+    };
+    const h = harness(storage);
+    const timers = vi.getTimerCount();
+    await h.run();
+    expect(h.res.status).toHaveBeenCalledWith(200);
+    expect(h.next).not.toHaveBeenCalled();
+    expect(h.res.listenerCount('close')).toBe(0);
+    expect(vi.getTimerCount()).toBe(timers);
+  });
+});

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -53,6 +53,7 @@ export type ProxySearchParams = {
   query?: searchUtils.SearchQuery;
   headers?: Headers;
   retry?: Partial<RetryOptions>;
+  onSearchPage?: (total: number | undefined) => void;
 };
 export interface IProxy {
   uplinkName: string;
@@ -503,7 +504,12 @@ class ProxyStorage implements IProxy {
    * @param {*} options request options
    * @return {Stream}
    */
-  public async search({ url, abort, retry }: ProxySearchParams): Promise<Stream.Readable> {
+  public async search({
+    url,
+    abort,
+    retry,
+    onSearchPage,
+  }: ProxySearchParams): Promise<Stream.Readable> {
     try {
       // Incoming URL is relative ie /-/v1/search...
       const uri = new URL(url, this.url).href;
@@ -521,6 +527,7 @@ class ProxyStorage implements IProxy {
 
       const res = await (response.text() as unknown as Promise<string>);
       const total = JSON.parse(res).total;
+      onSearchPage?.(Number.isSafeInteger(total) && total >= 0 ? total : undefined);
       debug('number of packages found: %o', total);
       const streamSearch = new PassThrough({ objectMode: true });
       const streamResponse = Readable.from(res);
@@ -528,6 +535,11 @@ class ProxyStorage implements IProxy {
       streamResponse.pipe(JSONStream.parse('objects')).pipe(streamSearch, { end: true });
       return streamSearch;
     } catch (err: any) {
+      if (onSearchPage) {
+        throw abort?.signal.aborted
+          ? abort.signal.reason
+          : errorUtils.getServiceUnavailable('uplink search failed');
+      }
       debug('search error %s', err);
       if (err.response.statusCode === 409) {
         throw errorUtils.getInternalError(`bad status code ${err.response.statusCode} from uplink`);

--- a/packages/proxy/src/proxy.ts
+++ b/packages/proxy/src/proxy.ts
@@ -536,6 +536,12 @@ class ProxyStorage implements IProxy {
       return streamSearch;
     } catch (err: any) {
       if (onSearchPage) {
+        if (!abort?.signal.aborted) {
+          this.logger.error(
+            { errorMessage: err?.message, name: this.uplinkName },
+            'proxy uplink @{name} search error: @{errorMessage}'
+          );
+        }
         throw abort?.signal.aborted
           ? abort.signal.reason
           : errorUtils.getServiceUnavailable('uplink search failed');

--- a/packages/proxy/test/proxy.search.spec.ts
+++ b/packages/proxy/test/proxy.search.spec.ts
@@ -2,7 +2,7 @@
 import getStream from 'get-stream';
 import nock from 'nock';
 import path from 'node:path';
-import { beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { Config, parseConfigFile } from '@verdaccio/config';
 import { streamUtils } from '@verdaccio/core';
@@ -20,6 +20,7 @@ beforeEach(() => {
   nock.cleanAll();
   nock.abortPendingRequests();
 });
+afterEach(() => vi.restoreAllMocks());
 
 const domain = 'https://registry.npmjs.org';
 
@@ -32,6 +33,26 @@ describe('proxy', () => {
   const conf = new Config(parseConfigFile(proxyPath));
 
   describe('search', () => {
+    test('logs the original paginated request failure and uplink without exposing it to clients', async () => {
+      nock(domain)
+        .get(queryUrl)
+        .replyWithError({ code: 'ECONNREFUSED', message: 'connection refused in test' });
+      const prox1 = new ProxyStorage('uplink', defaultRequestOptions, conf, logger);
+      const log = vi.spyOn(prox1.logger, 'error');
+      await expect(
+        prox1.search({
+          url: queryUrl,
+          abort: new AbortController(),
+          retry: { limit: 0 },
+          onSearchPage: () => {},
+        })
+      ).rejects.toThrow('uplink search failed');
+      expect(log).toHaveBeenCalledWith(
+        { name: 'uplink', errorMessage: expect.stringContaining('connection refused in test') },
+        'proxy uplink @{name} search error: @{errorMessage}'
+      );
+    });
+
     test('get response from endpoint', async () => {
       const response = require('./partials/search-v1.json');
       nock(domain)

--- a/packages/search/src/index.ts
+++ b/packages/search/src/index.ts
@@ -1,2 +1,3 @@
 export { Search as default } from './search';
 export * from './search-utils';
+export { SEARCH_MAX_CANDIDATES } from './search-pages';

--- a/packages/search/src/search-pages.ts
+++ b/packages/search/src/search-pages.ts
@@ -1,0 +1,84 @@
+import { errorUtils } from '@verdaccio/core';
+import type { searchUtils } from '@verdaccio/core';
+import type { ProxyInstanceList, ProxySearchParams } from '@verdaccio/proxy';
+
+export const SEARCH_PAGE_SIZE = 250;
+export const SEARCH_MAX_REQUESTS = 100;
+export const SEARCH_MAX_CANDIDATES = 25_000;
+
+/** Read one page per uplink per round, in configuration order, never arrival order. */
+export async function* searchPages(
+  uplinks: ProxyInstanceList,
+  options: ProxySearchParams
+): AsyncGenerator<searchUtils.SearchPackageItem[]> {
+  const states = Object.values(uplinks).map((uplink) => ({
+    uplink,
+    offset: 0,
+    done: false,
+    seen: new Set<string>(),
+  }));
+  let requests = 0;
+  let candidates = 0;
+  while (states.some((state) => !state.done)) {
+    const round: searchUtils.SearchPackageItem[] = [];
+    for (const state of states) {
+      options.abort.signal.throwIfAborted();
+      if (state.done) continue;
+      if (requests >= SEARCH_MAX_REQUESTS || candidates >= SEARCH_MAX_CANDIDATES) {
+        throw errorUtils.getServiceUnavailable('search pagination budget exhausted');
+      }
+      const url = new URL(options.url, 'http://localhost');
+      url.searchParams.set('from', String(state.offset));
+      url.searchParams.set('size', String(SEARCH_PAGE_SIZE));
+      let total: number | undefined;
+      requests++;
+      // Retries would bypass the request budget; the caller can retry the search.
+      const stream = await state.uplink.search({
+        ...options,
+        url: `${url.pathname}${url.search}`,
+        retry: { limit: 0 },
+        onSearchPage: (value) => {
+          total = value;
+        },
+      });
+      const onAbort = () => stream.destroy(options.abort.signal.reason);
+      options.abort.signal.addEventListener('abort', onAbort, { once: true });
+      const page: searchUtils.SearchPackageItem[] = [];
+      try {
+        options.abort.signal.throwIfAborted();
+        for await (const chunk of stream) {
+          options.abort.signal.throwIfAborted();
+          if (!Array.isArray(chunk) || page.length + chunk.length > SEARCH_PAGE_SIZE) {
+            throw errorUtils.getServiceUnavailable('invalid uplink search page');
+          }
+          page.push(...chunk);
+        }
+      } finally {
+        options.abort.signal.removeEventListener('abort', onAbort);
+        stream.destroy();
+      }
+      candidates += page.length;
+      if (candidates > SEARCH_MAX_CANDIDATES) {
+        throw errorUtils.getServiceUnavailable('search pagination budget exhausted');
+      }
+      let progress = false;
+      for (const item of page) {
+        if (typeof item?.package?.name !== 'string' || typeof item.package.version !== 'string') {
+          throw errorUtils.getServiceUnavailable('invalid uplink search package');
+        }
+        const key = JSON.stringify([item.package.name, item.package.version]);
+        if (!state.seen.has(key)) progress = true;
+        state.seen.add(key);
+        round.push({ ...item, verdaccioPkgCached: false, verdaccioPrivate: false });
+      }
+      if (page.length > 0 && !progress) {
+        throw errorUtils.getServiceUnavailable('uplink search pagination did not advance');
+      }
+      state.offset += page.length;
+      // A short page can be an uplink's smaller cap. Only a reported total or an
+      // empty page proves exhaustion; otherwise request the next offset.
+      state.done = page.length === 0 || (total !== undefined && state.offset >= total);
+    }
+    yield round;
+  }
+}

--- a/packages/search/src/search-pages.ts
+++ b/packages/search/src/search-pages.ts
@@ -33,14 +33,24 @@ export async function* searchPages(
       let total: number | undefined;
       requests++;
       // Retries would bypass the request budget; the caller can retry the search.
-      const stream = await state.uplink.search({
-        ...options,
-        url: `${url.pathname}${url.search}`,
-        retry: { limit: 0 },
-        onSearchPage: (value) => {
-          total = value;
-        },
-      });
+      let stream;
+      try {
+        stream = await state.uplink.search({
+          ...options,
+          url: `${url.pathname}${url.search}`,
+          retry: { limit: 0 },
+          onSearchPage: (value) => {
+            total = value;
+          },
+        });
+      } catch (error) {
+        options.abort.signal.throwIfAborted();
+        // Preserve best-effort search for an unavailable source. Once a source
+        // has contributed results, losing its next page must not look like EOF.
+        if (state.offset > 0) throw error;
+        state.done = true;
+        continue;
+      }
       const onAbort = () => stream.destroy(options.abort.signal.reason);
       options.abort.signal.addEventListener('abort', onAbort, { once: true });
       const page: searchUtils.SearchPackageItem[] = [];

--- a/packages/search/src/search.ts
+++ b/packages/search/src/search.ts
@@ -7,6 +7,7 @@ import { setupUpLinks } from '@verdaccio/proxy';
 import type { Config, Logger } from '@verdaccio/types';
 
 import { removeDuplicates } from './search-utils';
+import { searchPages } from './search-pages';
 
 const debug = buildDebug('verdaccio:search');
 
@@ -22,6 +23,10 @@ class Search {
     const uplinksList = Object.keys(this.uplinks);
 
     return uplinksList;
+  }
+
+  public searchPages(options: ProxySearchParams) {
+    return searchPages(this.uplinks, options);
   }
 
   /**

--- a/packages/search/test/search-pages.test.ts
+++ b/packages/search/test/search-pages.test.ts
@@ -19,6 +19,28 @@ async function consume(pages) {
 }
 
 describe('bounded uplink pages', () => {
+  test('does not suppress cancellation while awaiting the first request', async () => {
+    const opts = options();
+    const request = vi.fn(async () => {
+      opts.abort.abort(new Error('cancelled'));
+      throw new Error('request failed');
+    });
+    await expect(consume(searchPages(uplinks(request), opts))).rejects.toThrow('cancelled');
+  });
+
+  test('a failed source is retried on a new search, not on subsequent rounds', async () => {
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('offline'))
+      .mockResolvedValueOnce(Readable.from([[item('foo')]]));
+    await consume(searchPages(uplinks(request), options()));
+    const pages = searchPages(uplinks(request), options());
+    const page = await pages.next();
+    expect(page.value?.[0].package.name).toBe('foo');
+    expect(request).toHaveBeenCalledTimes(2);
+    await pages.return(undefined);
+  });
+
   test('aborting between rounds prevents another request', async () => {
     const request = vi.fn(async () => Readable.from([[item('foo')]]));
     const opts = options();

--- a/packages/search/test/search-pages.test.ts
+++ b/packages/search/test/search-pages.test.ts
@@ -1,0 +1,88 @@
+import { PassThrough, Readable } from 'node:stream';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { ProxyInstanceList, ProxySearchParams } from '@verdaccio/proxy';
+
+import { SEARCH_MAX_REQUESTS, searchPages } from '../src/search-pages';
+
+const item = (name: string) => ({ package: { name, version: '1.0.0' } });
+const options = (): ProxySearchParams => ({
+  url: '/-/v1/search?text=foo',
+  abort: new AbortController(),
+});
+const uplinks = (search) => ({ npmjs: { search } }) as unknown as ProxyInstanceList;
+
+async function consume(pages) {
+  for await (const _page of pages) {
+    /* exhaust */
+  }
+}
+
+describe('bounded uplink pages', () => {
+  test('aborting between rounds prevents another request', async () => {
+    const request = vi.fn(async () => Readable.from([[item('foo')]]));
+    const opts = options();
+    const pages = searchPages(uplinks(request), opts);
+    await pages.next();
+    opts.abort.abort(new Error('cancelled'));
+    await expect(pages.next()).rejects.toThrow('cancelled');
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  test('aborting while consuming a page destroys its stream', async () => {
+    const stream = new PassThrough({ objectMode: true });
+    const opts = options();
+    const pages = searchPages(
+      uplinks(async () => stream),
+      opts
+    );
+    const pending = pages.next();
+    await Promise.resolve();
+    opts.abort.abort(new Error('cancelled'));
+    await expect(pending).rejects.toThrow('cancelled');
+    expect(stream.destroyed).toBe(true);
+  });
+
+  test('propagates stream errors instead of hanging', async () => {
+    const stream = new PassThrough({ objectMode: true });
+    const pages = searchPages(
+      uplinks(async () => stream),
+      options()
+    );
+    const pending = pages.next();
+    await Promise.resolve();
+    stream.destroy(new Error('broken stream'));
+    await expect(pending).rejects.toThrow('broken stream');
+  });
+
+  test('rejects oversized pages', async () => {
+    const request = async () =>
+      Readable.from([Array.from({ length: 251 }, (_, i) => item(String(i)))]);
+    await expect(consume(searchPages(uplinks(request), options()))).rejects.toThrow(
+      'invalid uplink search page'
+    );
+  });
+
+  test('limits all uplinks using one shared request budget and disables retries', async () => {
+    const request = vi.fn(async (params) => {
+      const offset = new URL(params.url, 'http://localhost').searchParams.get('from');
+      return Readable.from([[item(`pkg-${offset}`)]]);
+    });
+    const sources = {
+      ...uplinks(request),
+      second: { search: request },
+    } as unknown as ProxyInstanceList;
+    await expect(consume(searchPages(sources, options()))).rejects.toThrow('budget exhausted');
+    expect(request).toHaveBeenCalledTimes(SEARCH_MAX_REQUESTS);
+    expect(request.mock.calls.every(([params]) => params.retry.limit === 0)).toBe(true);
+  });
+
+  test('does not interpret a missing or unknown total as an empty catalog', async () => {
+    const request = vi.fn(async (params) => {
+      const offset = Number(new URL(params.url, 'http://localhost').searchParams.get('from'));
+      return Readable.from([offset < 2 ? [item(`pkg-${offset}`)] : []]);
+    });
+    await consume(searchPages(uplinks(request), options()));
+    expect(request).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/store/src/storage.ts
+++ b/packages/store/src/storage.ts
@@ -30,7 +30,7 @@ import type {
   ProxySearchParams,
 } from '@verdaccio/proxy';
 import { ProxyStorage, setupUpLinks, updateVersionsHiddenUpLinkNext } from '@verdaccio/proxy';
-import Search from '@verdaccio/search';
+import Search, { SEARCH_MAX_CANDIDATES } from '@verdaccio/search';
 import type { TarballDetails } from '@verdaccio/tarball';
 import {
   convertDistRemoteToLocalTarballUrls,
@@ -74,7 +74,7 @@ import {
   lookupDistFile,
   uplinkServesUrl,
 } from './lib/storage-utils';
-import { getVersion, removeLowerVersions } from './lib/versions-utils';
+import { getVersion, isNewerVersion, removeLowerVersions } from './lib/versions-utils';
 import { StageStorage } from './stage-storage';
 import { LocalStorage } from './local-storage';
 import type { IGetPackageOptionsNext, OwnerManifestBody } from './type';
@@ -246,6 +246,46 @@ class Storage {
     const uniqueResults = removeLowerVersions(totalResults);
     debug('unique results %o', uniqueResults.length);
     return uniqueResults;
+  }
+
+  /** Cumulative, stable prefixes for Search v1; consumers stop once their page is full. */
+  public async *searchPages(options: ProxySearchParams) {
+    options.abort.signal.throwIfAborted();
+    const local = await this.getCachedPackages({
+      ...options.query,
+      from: 0,
+      size: SEARCH_MAX_CANDIDATES,
+    } as searchUtils.SearchQuery);
+    const merged = new Map<string, searchUtils.SearchPackageItem>();
+    let candidates = 0;
+    const append = (items: searchUtils.SearchPackageItem[]) => {
+      options.abort.signal.throwIfAborted();
+      candidates += items.length;
+      if (candidates > SEARCH_MAX_CANDIDATES) {
+        throw errorUtils.getServiceUnavailable('search pagination budget exhausted');
+      }
+      for (const item of items) {
+        const previous = merged.get(item.package.name);
+        if (
+          !previous ||
+          (item.package.version !== previous.package.version &&
+            isNewerVersion(item.package.version, previous.package.version))
+        ) {
+          // Replacing metadata must not move a package to a later page.
+          merged.set(item.package.name, item);
+        }
+      }
+      return [...merged.values()];
+    };
+    // Complete the first remote round before selecting a page so duplicate remote
+    // versions participate even when local results alone would fill it.
+    append(local);
+    let hadRound = false;
+    for await (const round of this.searchService.searchPages(options)) {
+      hadRound = true;
+      yield append(round);
+    }
+    if (!hadRound) yield [...merged.values()];
   }
 
   private async getTarballFromUpstream(name: string, filename: string, { signal }) {

--- a/packages/store/test/search-pagination.spec.ts
+++ b/packages/store/test/search-pagination.spec.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import type { searchUtils } from '@verdaccio/core';
+
+import { Storage } from '../src/storage';
+
+const item = (name: string, version = '1.0.0', description = '') =>
+  ({ package: { name, version, description } }) as searchUtils.SearchPackageItem;
+
+function setup(local: searchUtils.SearchPackageItem[], rounds: searchUtils.SearchPackageItem[][]) {
+  const storage = Object.create(Storage.prototype);
+  storage.getCachedPackages = vi.fn(async () => local);
+  storage.searchService = {
+    async *searchPages() {
+      for (const round of rounds) yield round;
+    },
+  };
+  return storage as Storage;
+}
+const options = () => ({
+  url: '/-/v1/search?text=foo&from=20&size=20',
+  abort: new AbortController(),
+  query: { text: 'foo', size: 20, from: 20 } as searchUtils.SearchQuery,
+});
+
+describe('stable combined search prefixes', () => {
+  test('keeps local metadata on equal versions and updates newer versions without moving names', async () => {
+    const storage = setup(
+      [item('a', '1.0.0', 'local'), item('b')],
+      [
+        [item('a', '1.0.0', 'remote'), item('c')],
+        [item('a', '2.0.0', 'newer'), item('d')],
+      ]
+    );
+    const pages = [];
+    for await (const page of storage.searchPages(options())) pages.push(page);
+    expect(pages.map((page) => page.map((entry) => entry.package.name))).toEqual([
+      ['a', 'b', 'c'],
+      ['a', 'b', 'c', 'd'],
+    ]);
+    expect(pages[0][0].package.description).toBe('local');
+    expect(pages[1][0].package.description).toBe('newer');
+    expect(storage.getCachedPackages).toHaveBeenCalledWith(expect.objectContaining({ from: 0 }));
+  });
+
+  test('counts local and remote candidates together, including duplicates', async () => {
+    const storage = setup(
+      Array.from({ length: 24_999 }, () => item('a')),
+      [[item('b'), item('c')]]
+    );
+    const pages = storage.searchPages(options());
+    await expect(pages.next()).rejects.toThrow('budget exhausted');
+  });
+
+  test('bounds local candidates even without any uplinks', async () => {
+    const storage = setup(
+      Array.from({ length: 25_001 }, () => item('a')),
+      []
+    );
+    await expect(storage.searchPages(options()).next()).rejects.toThrow('budget exhausted');
+  });
+
+  test('stops before touching local storage when already cancelled', async () => {
+    const storage = setup([], []);
+    const params = options();
+    params.abort.abort(new Error('cancelled'));
+    await expect(storage.searchPages(params).next()).rejects.toThrow('cancelled');
+    expect(storage.getCachedPackages).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Search v1 applies `from` twice to remote results: once in the uplink request and again after merging and checking access. With only an uplink, `from=20&size=20` can therefore return an empty page instead of results 20–39.

This change reads bounded uplink pages from offset zero, merges candidates by name, checks access, and applies the client offset once. It continues fetching when permissions or duplicates leave too few results. Each round visits active uplinks in configuration order; replacing a duplicate with a newer version preserves its original position, and equal versions retain the first metadata. Short pages do not imply exhaustion when an uplink has a smaller page-size cap.

### Operational behavior

- Up to 250 candidates per upstream page, 100 logical upstream requests and 25,000 combined local/remote candidates per search, with a 30-second HTTP deadline. Automatic upstream retries are disabled for this path.
- Client disconnects cancel in-flight work. Non-advancing or invalid pages, upstream failures, and exhausted budgets return **503**, rather than a successful partial page. This changes Search v1's previous best-effort behavior when an uplink fails.
- The first remote round participates even when local results would fill the page. Versions outside fetched pages are not inspected. Catalog changes between requests can still change results; there is no snapshot guarantee.
- The existing local storage plugin scan remains unchanged internally. Candidate limits are not byte limits or bounds on the plugin's internal scan.
- The combined `total`, missing-text validation and timestamp format remain separate follow-ups. Existing consumers of `Storage.search` retain their current path.

### Validation

- Added an HTTP regression with an uplink that actually slices by `from`/`size`: failed against the previous implementation and passes with this change.
- Coverage includes deep pages, smaller uplink caps, missing totals, exhaustion, local/remote duplicates and versions, ACL filtering, deterministic multi-uplink ordering, zero size, repeated pages, shared budgets, stream errors and cancellation.
- Focused API/search/store/proxy tests: **43 passed**.
- Full `pnpm test`: **2049 passed, 9 skipped, 27 todo**.
- Subsequently added cancellation during the second upstream HTTP page; final progressive HTTP suite: **15 passed**.
- Full `pnpm build`, `pnpm type-check`, `pnpm lint`, formatting checks for changed files and `git diff --check` passed. Lint reports existing warnings outside edited files.
- Changeset included for api, proxy, search and store.

Related search pagination follow-up to #5357.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correcciones**
  - Mejorada la paginación de las búsquedas para combinar resultados locales y remotos de forma estable, sin duplicados y respetando correctamente los desplazamientos.
  - Los uplinks con fallos iniciales ya no impiden mostrar resultados locales o de otras fuentes disponibles.
  - Se devuelven errores de servicio cuando una fuente falla tras aportar resultados o se superan los límites de búsqueda.
  - Las búsquedas se cancelan al desconectarse el cliente o tras 30 segundos.

- **Pruebas**
  - Ampliada la cobertura de paginación, errores de uplinks, permisos, cancelación y límites de resultados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->