### PR TITLE
chore: replace __dirname with import.meta.dirname

### DIFF
--- a/.changeset/gold-windows-open.md
+++ b/.changeset/gold-windows-open.md
@@ -1,0 +1,14 @@
+---
+'@verdaccio/cli': patch
+'@verdaccio/config': patch
+'@verdaccio/loaders': patch
+'@verdaccio/logger': patch
+'@verdaccio/node-api': patch
+'@verdaccio/plugin-verifier': patch
+'@verdaccio/server': patch
+'@verdaccio/ui-components': patch
+'@verdaccio/ui-theme': patch
+'@verdaccio/web': patch
+---
+
+chore: replace \_\_dirname with import.meta.dirname

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,11 +34,7 @@ export function runCli(options: CliRuntimeOptions = {}): Promise<void> {
   const [node, app, ...args] = process.argv;
 
   const version =
-    options.version ??
-    (pkgUtils.getPackageJson(
-      typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname,
-      '..'
-    ).version as string);
+    options.version ?? (pkgUtils.getPackageJson(import.meta.dirname, '..').version as string);
 
   const cli = new Cli({
     binaryLabel: `verdaccio`,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -64,7 +64,7 @@ export class InitCommand extends Command {
 
       process.title = web?.title || DEFAULT_PROCESS_NAME;
 
-      const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
+      const currentDir = import.meta.dirname;
       const pkg = pkgUtils.getPackageJson(currentDir, '../..');
       const version = getVersionOverride() ?? (pkg.version as string);
       const name = getPkgNameOverride() ?? (pkg.name as string);

--- a/packages/cli/src/commands/version.ts
+++ b/packages/cli/src/commands/version.ts
@@ -8,7 +8,7 @@ export class VersionCommand extends Command {
   static paths = [[`--version`], [`-v`]];
 
   async execute() {
-    const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
+    const currentDir = import.meta.dirname;
     const version = getVersionOverride() ?? pkgUtils.getPackageJson(currentDir, '../..').version;
     this.context.stdout.write(`v${version}\n`);
     process.exit(0);

--- a/packages/config/src/conf/index.ts
+++ b/packages/config/src/conf/index.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 
 import { parseConfigFile } from '../parse';
 
-const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
+const currentDir = import.meta.dirname;
 
 export function getDefaultConfig(fileName: string = 'default.yaml') {
   const file = join(currentDir, `./${fileName}`);

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -65,7 +65,7 @@ function createConfigFile(configLocation: SetupDirectory): SetupDirectory {
 }
 
 export function readDefaultConfig(): string {
-  const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
+  const currentDir = import.meta.dirname;
   const pathDefaultConf: string = path.resolve(currentDir, 'conf/default.yaml');
   try {
     debug('the path of default config used from %s', pathDefaultConf);

--- a/packages/loaders/src/utils.ts
+++ b/packages/loaders/src/utils.ts
@@ -13,12 +13,8 @@ const ERR_REQUIRE_ESM = 'ERR_REQUIRE_ESM';
 const ERR_REQUIRE_ASYNC_MODULE = 'ERR_REQUIRE_ASYNC_MODULE';
 
 // the ESM build has no ambient require; create one so CJS plugins keep loading.
-// rolldown rewrites bare `require` to a throwing stub in the ESM output and
-// lowers `import.meta` to `{}` in the CJS output, so `import.meta.url` is only
-// truthy in the ESM build; module-scoped __filename covers the CJS build
-// (checking `typeof __filename`/`typeof require` instead is unsafe: node -e and
-// the REPL leak both as globals into ES modules)
-const requireModule = import.meta.url ? createRequire(import.meta.url) : createRequire(__filename);
+// rolldown rewrites bare `require` to a throwing stub in the ESM output.
+const requireModule = createRequire(import.meta.filename);
 
 export type PluginType<T> = T extends pluginUtils.Plugin<T> ? T : never;
 

--- a/packages/logger/src/transport.ts
+++ b/packages/logger/src/transport.ts
@@ -1,16 +1,11 @@
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 
 import type { LoggerConfigItem, LoggerFormat } from '@verdaccio/types';
 
 import { hasColors } from './colors';
 
 // Pino transports run in a worker thread via require(), so CJS output must work.
-// rolldown lowers `import.meta` to `{}` in the CJS output, so `import.meta.url`
-// is only truthy in the ESM build; module-scoped __dirname covers the CJS build
-// (checking `typeof __dirname` instead is unsafe: node -e and the REPL leak it
-// as a global into ES modules)
-const currentDir = import.meta.url ? dirname(fileURLToPath(import.meta.url)) : __dirname;
+const currentDir = import.meta.dirname;
 const prettifyPath = join(currentDir, '..', 'build', 'prettify.js');
 
 export function isPrettyFormat(format: LoggerFormat | undefined): boolean {

--- a/packages/node-api/test/create-server-factory.spec.ts
+++ b/packages/node-api/test/create-server-factory.spec.ts
@@ -12,7 +12,7 @@ const mockApp = (_req: any, res: any) => {
   res.end();
 };
 
-const certsDir = path.join(__dirname, 'partials', 'certs');
+const certsDir = path.join(import.meta.dirname, 'partials', 'certs');
 
 describe('createServerFactory', () => {
   describe('http', () => {

--- a/packages/plugins/ui-theme/vite.config.mjs
+++ b/packages/plugins/ui-theme/vite.config.mjs
@@ -114,6 +114,7 @@ export default defineConfig(({ command }) => ({
     minify: true,
     chunkSizeWarningLimit: 2560,
     rolldownOptions: {
+      platform: 'browser',
       input: { main: path.resolve(import.meta.dirname, './src/index.tsx') },
       output: {
         entryFileNames: '[name].[hash].js',

--- a/packages/server/express/src/server.ts
+++ b/packages/server/express/src/server.ts
@@ -40,7 +40,7 @@ import type { $NextFunctionVer, $RequestExtend, $ResponseExtend } from '../types
 import hookDebug from './debug';
 
 const debug = buildDebug('verdaccio:server');
-const currentDir = typeof __dirname !== 'undefined' ? __dirname : import.meta.dirname;
+const currentDir = import.meta.dirname;
 const { version } = pkgUtils.getPackageJson(currentDir, '..');
 
 export const defineAPI = async function (config: IConfig, storage: Storage): Promise<Express> {

--- a/packages/tools/plugin-verifier/src/diagnostics.ts
+++ b/packages/tools/plugin-verifier/src/diagnostics.ts
@@ -11,10 +11,7 @@ import type { DiagnosticStep, VerifyPluginOptions } from './types';
 
 const debug = buildDebug('verdaccio:plugin:verifier:diagnostics');
 
-// createRequire needs an absolute path; works in both ESM and CJS contexts
-const requireModule = createRequire(
-  typeof __filename !== 'undefined' ? __filename : import.meta.url
-);
+const requireModule = createRequire(import.meta.filename);
 
 function isValidExport(plugin: any): boolean {
   return typeof plugin === 'function' || typeof plugin?.default === 'function';

--- a/packages/ui-components/tools/generate-github-markdown.mjs
+++ b/packages/ui-components/tools/generate-github-markdown.mjs
@@ -1,11 +1,9 @@
 import { writeFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
 
 import githubMarkdownCss from 'generate-github-markdown-css';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const OUTPUT = resolve(__dirname, '../src/components/Readme/github-markdown.css');
+const OUTPUT = resolve(import.meta.dirname, '../src/components/Readme/github-markdown.css');
 
 async function generate() {
   const baseStyles = await githubMarkdownCss({

--- a/packages/ui-components/vite.config.mjs
+++ b/packages/ui-components/vite.config.mjs
@@ -11,4 +11,11 @@ const baseConfig = createLibConfig(import.meta.dirname, {
 export default defineConfig({
   ...baseConfig,
   plugins: [react(), svgInlinePlugin(), linkEntryCssPlugin(), ...baseConfig.plugins],
+  build: {
+    ...baseConfig.build,
+    rolldownOptions: {
+      ...baseConfig.build.rolldownOptions,
+      platform: 'browser',
+    },
+  },
 });

--- a/packages/web/test/web-assets.test.ts
+++ b/packages/web/test/web-assets.test.ts
@@ -15,7 +15,7 @@ vi.mock('@verdaccio/ui-theme', () => ({ default: (...args: any[]) => mockManifes
 describe('test web server', () => {
   beforeAll(() => {
     mockManifest.mockReturnValue(() => ({
-      staticPath: path.join(__dirname, 'static'),
+      staticPath: path.join(import.meta.dirname, 'static'),
       manifestFiles: {
         js: ['runtime.js', 'vendors.js', 'main.js'],
       },

--- a/vite.lib.config.mjs
+++ b/vite.lib.config.mjs
@@ -137,6 +137,7 @@ export function createLibConfig(dirname, options = {}) {
         ...(esmOnly && { formats: ['es'] }),
       },
       rolldownOptions: {
+        platform: 'node',
         external: isExternal,
         output: esmOnly
           ? {


### PR DESCRIPTION
Second try... (it was missing the right [rolldown option](https://rolldown.rs/reference/InputOptions.platform) before)

Use `import.meta.dirname` in source. Vite lib mode was treating the build as a browser library, leading to `[EMPTY_IMPORT_META]` `import.meta` may not be a valid syntax with the `cjs` output format.

The PR sets `platform: 'node'` on the shared lib config. Rolldown then rewrites CJS only:

ESM: `import.meta.dirname` stays as-is
CJS: `import.meta.dirname` changes to `__dirname`

Same for `import.meta.filename` `__filename`.

UI packages are set to `platform: 'browser'`.
