### PR TITLE
chore(loader): remove console log during tests

### DIFF
--- a/.changeset/cozy-otters-nail.md
+++ b/.changeset/cozy-otters-nail.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/loaders': patch
+---
+
+chore(loader): remove console log

--- a/packages/loaders/src/plugin-async-loader.ts
+++ b/packages/loaders/src/plugin-async-loader.ts
@@ -94,7 +94,6 @@ export async function asyncLoadPlugin<T extends pluginUtils.Plugin<T>>(
         let plugin = await tryLoadAsync<T>(externalFilePlugin, (a: any, b: any) => {
           logger.error(a, b);
         });
-        debug('external plugin %o', plugin);
         if (plugin && isValid(plugin)) {
           plugin = executePlugin(
             plugin,

--- a/packages/loaders/test/partials/test-plugin-storage/verdaccio-plugin/index.js
+++ b/packages/loaders/test/partials/test-plugin-storage/verdaccio-plugin/index.js
@@ -2,7 +2,6 @@ class ValidVerdaccioPlugin {
   config;
   options;
   constructor(config, options) {
-    console.log('ValidVerdaccioPlugin constructor', config);
     this.config = config;
     this.options = options;
   }


### PR DESCRIPTION
Remove console log and debug output of plugin object: 

<img width="937" height="565" alt="image" src="https://github.com/user-attachments/assets/b658f005-8bdb-47b1-8ccf-252a61fb264a" />
