### PR TITLE
fix(logger): honor JSON sync and avoid unused pretty destinations

### DIFF
--- a/.changeset/avoid-unused-stdout-destination.md
+++ b/.changeset/avoid-unused-stdout-destination.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/logger': patch
+---
+
+Avoid creating an unused stdout destination when pretty logging uses its own transport.

--- a/.changeset/young-toes-look.md
+++ b/.changeset/young-toes-look.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/logger': patch
+---
+
+Honor the configured `sync` option for JSON logs written to stdout or files, including in production. Keep asynchronous writes as the default.

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -112,7 +112,11 @@ export async function prepareSetup(
     }
     // For file destinations (json format), wait for the fd to be ready
     // so we fail fast on bad paths / permissions instead of losing early logs
-    const destination = pino.destination(loggerConfig.path);
+    const destination = pino.destination({
+      dest: loggerConfig.path,
+      sync: loggerConfig.sync ?? false,
+      minLength: 0,
+    });
     await new Promise<void>((resolve, reject) => {
       destination.once('ready', resolve);
       destination.once('error', reject);
@@ -122,6 +126,8 @@ export async function prepareSetup(
     return createLogger(loggerConfig, destination, loggerConfig.format, pino);
   }
   debug('logging stdout enabled');
-  const destination = willUseTransport(loggerConfig.format) ? undefined : pino.destination(1);
+  const destination = willUseTransport(loggerConfig.format)
+    ? undefined
+    : pino.destination({ dest: 1, sync: loggerConfig.sync ?? false, minLength: 0 });
   return createLogger(loggerConfig, destination, loggerConfig.format, pino);
 }

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -122,5 +122,6 @@ export async function prepareSetup(
     return createLogger(loggerConfig, destination, loggerConfig.format, pino);
   }
   debug('logging stdout enabled');
-  return createLogger(loggerConfig, pino.destination(1), loggerConfig.format, pino);
+  const destination = willUseTransport(loggerConfig.format) ? undefined : pino.destination(1);
+  return createLogger(loggerConfig, destination, loggerConfig.format, pino);
 }

--- a/packages/logger/test/stdout-destination.spec.ts
+++ b/packages/logger/test/stdout-destination.spec.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import type { LoggerFormat } from '@verdaccio/types';
+
+describe.each(['development', 'production'])('stdout destination in %s', (environment) => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  const formats: (LoggerFormat | undefined)[] = ['pretty', 'pretty-timestamped', 'json', undefined];
+
+  test.each(formats)('selects the output for format %s', async (format) => {
+    vi.stubEnv('NODE_ENV', environment);
+    vi.resetModules();
+    const { prepareSetup } = await import('../src/logger');
+
+    const destination = {};
+    const transport = {};
+    const logger = { on: vi.fn() };
+    const pino = Object.assign(vi.fn().mockReturnValue(logger), {
+      destination: vi.fn().mockReturnValue(destination),
+      transport: vi.fn().mockReturnValue(transport),
+      stdSerializers: {},
+    });
+
+    expect(await prepareSetup({ type: 'stdout', level: 'info', format }, pino)).toBe(logger);
+
+    if (environment === 'development' && format !== 'json') {
+      expect(pino.destination).not.toHaveBeenCalled();
+      expect(pino.transport).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          options: expect.objectContaining({ destination: 1 }),
+        })
+      );
+      expect(pino).toHaveBeenCalledExactlyOnceWith(expect.any(Object), transport);
+    } else {
+      expect(pino.transport).not.toHaveBeenCalled();
+      expect(pino.destination).toHaveBeenCalledExactlyOnceWith(1);
+      expect(pino).toHaveBeenCalledExactlyOnceWith(expect.any(Object), destination);
+    }
+  });
+});

--- a/packages/logger/test/stdout-destination.spec.ts
+++ b/packages/logger/test/stdout-destination.spec.ts
@@ -10,34 +10,45 @@ describe.each(['development', 'production'])('stdout destination in %s', (enviro
 
   const formats: (LoggerFormat | undefined)[] = ['pretty', 'pretty-timestamped', 'json', undefined];
 
-  test.each(formats)('selects the output for format %s', async (format) => {
-    vi.stubEnv('NODE_ENV', environment);
-    vi.resetModules();
-    const { prepareSetup } = await import('../src/logger');
+  describe.each([true, false, undefined])('sync=%s', (sync) => {
+    test.each(formats)('selects the output for format %s', async (format) => {
+      vi.stubEnv('NODE_ENV', environment);
+      vi.resetModules();
+      const { prepareSetup } = await import('../src/logger');
 
-    const destination = {};
-    const transport = {};
-    const logger = { on: vi.fn() };
-    const pino = Object.assign(vi.fn().mockReturnValue(logger), {
-      destination: vi.fn().mockReturnValue(destination),
-      transport: vi.fn().mockReturnValue(transport),
-      stdSerializers: {},
+      const destination = {};
+      const transport = {};
+      const logger = { on: vi.fn() };
+      const pino = Object.assign(vi.fn().mockReturnValue(logger), {
+        destination: vi.fn().mockReturnValue(destination),
+        transport: vi.fn().mockReturnValue(transport),
+        stdSerializers: {},
+      });
+
+      expect(
+        await prepareSetup(
+          { type: 'stdout', level: 'info', format, ...(sync === undefined ? {} : { sync }) },
+          pino
+        )
+      ).toBe(logger);
+
+      if (environment === 'development' && format !== 'json') {
+        expect(pino.destination).not.toHaveBeenCalled();
+        expect(pino.transport).toHaveBeenCalledExactlyOnceWith(
+          expect.objectContaining({
+            options: expect.objectContaining({ destination: 1, sync: sync ?? false }),
+          })
+        );
+        expect(pino).toHaveBeenCalledExactlyOnceWith(expect.any(Object), transport);
+      } else {
+        expect(pino.transport).not.toHaveBeenCalled();
+        expect(pino.destination).toHaveBeenCalledExactlyOnceWith({
+          dest: 1,
+          sync: sync ?? false,
+          minLength: 0,
+        });
+        expect(pino).toHaveBeenCalledExactlyOnceWith(expect.any(Object), destination);
+      }
     });
-
-    expect(await prepareSetup({ type: 'stdout', level: 'info', format }, pino)).toBe(logger);
-
-    if (environment === 'development' && format !== 'json') {
-      expect(pino.destination).not.toHaveBeenCalled();
-      expect(pino.transport).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({
-          options: expect.objectContaining({ destination: 1 }),
-        })
-      );
-      expect(pino).toHaveBeenCalledExactlyOnceWith(expect.any(Object), transport);
-    } else {
-      expect(pino.transport).not.toHaveBeenCalled();
-      expect(pino.destination).toHaveBeenCalledExactlyOnceWith(1);
-      expect(pino).toHaveBeenCalledExactlyOnceWith(expect.any(Object), destination);
-    }
   });
 });

--- a/packages/logger/test/sync-destination.spec.ts
+++ b/packages/logger/test/sync-destination.spec.ts
@@ -1,0 +1,91 @@
+import { once } from 'node:events';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import pino from 'pino';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { LoggerFormat } from '@verdaccio/types';
+
+describe.each(['development', 'production'])('file destination in %s', (environment) => {
+  let directory: string;
+  let destinations: ReturnType<typeof pino.destination>[];
+  let originalListeners: ReturnType<typeof process.listeners>;
+
+  beforeEach(() => {
+    directory = mkdtempSync(join(tmpdir(), 'logger-sync-'));
+    destinations = [];
+    originalListeners = process.listeners('SIGUSR2');
+    vi.stubEnv('NODE_ENV', environment);
+    vi.resetModules();
+    const createDestination = pino.destination;
+    vi.spyOn(pino, 'destination').mockImplementation((options) => {
+      const destination = createDestination(options);
+      destinations.push(destination);
+      return destination;
+    });
+  });
+
+  afterEach(async () => {
+    for (const destination of destinations) {
+      if (destination.destroyed) continue;
+      const closed = once(destination, 'close');
+      destination.end();
+      await closed;
+    }
+    for (const listener of process.listeners('SIGUSR2')) {
+      if (!originalListeners.includes(listener)) process.removeListener('SIGUSR2', listener);
+    }
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    rmSync(directory, { recursive: true, force: true });
+  });
+
+  describe.each([true, false, undefined])('sync=%s', (sync) => {
+    const formats: (LoggerFormat | undefined)[] =
+      environment === 'production' ? ['json', 'pretty', 'pretty-timestamped', undefined] : ['json'];
+
+    test.each(formats)('writes JSON with the requested mode for format %s', async (format) => {
+      const { prepareSetup } = await import('../src/logger');
+      const path = join(directory, 'logger.log');
+      const logger = await prepareSetup(
+        { type: 'file', path, level: 'info', format, ...(sync === undefined ? {} : { sync }) },
+        pino
+      );
+
+      expect(destinations).toHaveLength(1);
+      expect(destinations[0].sync).toBe(sync ?? false);
+      logger.info('first message');
+      logger.info('second message');
+      // Sync must make even short messages readable before yielding or flushing.
+      if (!sync) {
+        const closed = once(destinations[0], 'close');
+        destinations[0].end();
+        await closed;
+      }
+      expect(
+        readFileSync(path, 'utf8')
+          .trim()
+          .split('\n')
+          .map((line) => JSON.parse(line).msg)
+      ).toEqual(['first message', 'second message']);
+    });
+
+    test('rejects setup when the log directory does not exist', async () => {
+      vi.restoreAllMocks();
+      const { prepareSetup } = await import('../src/logger');
+      await expect(
+        prepareSetup(
+          {
+            type: 'file',
+            path: join(directory, 'missing', 'logger.log'),
+            format: 'json',
+            ...(sync === undefined ? {} : { sync }),
+          },
+          pino
+        )
+      ).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+  });
+});


### PR DESCRIPTION
JSON logging ignored the configured `sync` option for both stdout and files, including in production. Pass `sync` explicitly to each JSON destination, keeping asynchronous writes as the default and `minLength: 0` for short messages.

Pretty stdout logging also created an unused destination. Create it only when the logger actually uses it.

Includes patch changesets and regression coverage for development/production, all supported formats, synchronous/asynchronous/default writes, immediate file visibility, and invalid file paths.

Validation (2026-09-10):
- Logger suite: 117 tests passed across 10 files.
- Logger build and TypeScript check passed.
- Oxfmt, Oxlint, and git diff --check passed for the changed code.
- The build retains the existing import.meta warning for CommonJS transport output.

The full workspace suite previously passed with 2068 tests during implementation on 2026-09-08; it was not rerun for this publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The logger now honors the configured synchronous or asynchronous write mode for JSON logs sent to stdout and files.
  * Prevented creation of an unused stdout destination when pretty logging uses a dedicated transport.
  * Maintained asynchronous logging as the default when no synchronization option is specified.

* **Tests**
  * Added coverage for stdout and file logging across environments, formats, and synchronization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->