### PR TITLE
fix(config): get path via process.env.HOME on windows

### DIFF
--- a/.changeset/wicked-kiwis-press.md
+++ b/.changeset/wicked-kiwis-press.md
@@ -1,0 +1,5 @@
+---
+'@verdaccio/config': patch
+---
+
+fix(config): get path via process.env.HOME on windows

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -24,7 +24,7 @@ const debug = buildDebug('verdaccio:config:config-path');
  * Find and get the first config file that match.
  * @return {String} the config file path
  */
-function findConfigFile(configPath?: string): string {
+export function findConfigFile(configPath?: string): string {
   debug('searching for config file %o', configPath);
   if (typeof configPath !== 'undefined') {
     const configLocation = path.resolve(configPath);
@@ -102,8 +102,9 @@ function updateStorageLinks(configLocation: SetupDirectory, defaultConfig: strin
   // $XDG_DATA_HOME defines the base directory relative to which user specific data
   // files should be stored, If $XDG_DATA_HOME is either not set or empty, a default
   // equal to $HOME/.local/share should be used.
-  let dataDir = process.env.XDG_DATA_HOME || path.join(os.homedir(), '.local', 'share');
-  if (folderExists(dataDir)) {
+  let dataDir = process.env.XDG_DATA_HOME ||
+    (process.env.HOME && path.join(process.env.HOME, '.local', 'share'));
+  if (dataDir && folderExists(dataDir)) {
     debug(`previous storage located`);
     debug(`update storage links to %s`, dataDir);
     dataDir = path.resolve(path.join(dataDir, pkgJSON.name, 'storage'));
@@ -125,7 +126,7 @@ function getConfigPaths(): SetupDirectory[] {
     getOldDirectory(),
   ];
 
-  return listPaths.reduce(function (acc, currentValue: SetupDirectory | void): SetupDirectory[] {
+  return listPaths.reduce(function(acc, currentValue: SetupDirectory | void): SetupDirectory[] {
     if (typeof currentValue !== 'undefined') {
       debug(
         'posible directory path generated %s for type %s',
@@ -145,15 +146,12 @@ function getConfigPaths(): SetupDirectory[] {
  * which aims to standardize the locations where applications store configuration files and other
  * user-specific data on Unix-like operating systems.
  *
- *
- *
  * https://specifications.freedesktop.org/basedir-spec/latest/
- *
- *
  * @returns
  */
 const getXDGDirectory = (): SetupDirectory | void => {
-  const xDGConfigPath = process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config');
+  const xDGConfigPath = process.env.XDG_CONFIG_HOME ||
+    (process.env.HOME && path.join(process.env.HOME, '.config'));
   debug('XDGConfig folder path %s', xDGConfigPath);
   if (xDGConfigPath && folderExists(xDGConfigPath)) {
     debug('XDGConfig folder path %s', xDGConfigPath);
@@ -205,5 +203,3 @@ const getOldDirectory = (): SetupDirectory => {
     type: 'old',
   };
 };
-
-export { findConfigFile };

--- a/packages/config/src/config-path.ts
+++ b/packages/config/src/config-path.ts
@@ -113,7 +113,8 @@ function updateStorageLinks(configLocation: SetupDirectory, defaultConfig: strin
   // $XDG_DATA_HOME defines the base directory relative to which user specific data
   // files should be stored, If $XDG_DATA_HOME is either not set or empty, a default
   // equal to $HOME/.local/share should be used.
-  let dataDir = process.env.XDG_DATA_HOME ||
+  let dataDir =
+    process.env.XDG_DATA_HOME ||
     (process.env.HOME && path.join(process.env.HOME, '.local', 'share'));
   if (dataDir && folderExists(dataDir)) {
     debug(`previous storage located`);
@@ -137,7 +138,7 @@ function getConfigPaths(): SetupDirectory[] {
     getOldDirectory(),
   ];
 
-  return listPaths.reduce(function(acc, currentValue: SetupDirectory | void): SetupDirectory[] {
+  return listPaths.reduce(function (acc, currentValue: SetupDirectory | void): SetupDirectory[] {
     if (typeof currentValue !== 'undefined') {
       debug(
         'posible directory path generated %s for type %s',
@@ -161,8 +162,8 @@ function getConfigPaths(): SetupDirectory[] {
  * @returns
  */
 const getXDGDirectory = (): SetupDirectory | void => {
-  const xDGConfigPath = process.env.XDG_CONFIG_HOME ||
-    (process.env.HOME && path.join(process.env.HOME, '.config'));
+  const xDGConfigPath =
+    process.env.XDG_CONFIG_HOME || (process.env.HOME && path.join(process.env.HOME, '.config'));
   debug('XDGConfig folder path %s', xDGConfigPath);
   if (xDGConfigPath && folderExists(xDGConfigPath)) {
     debug('XDGConfig folder path %s', xDGConfigPath);

--- a/packages/config/test/config.path.spec.ts
+++ b/packages/config/test/config.path.spec.ts
@@ -1,14 +1,14 @@
 import fs from 'node:fs';
 import os from 'node:os';
-import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi, type MockInstance } from 'vitest';
 
 import { findConfigFile } from '../src/config-path';
 
 describe('config-path', () => {
-  let statSyncMock;
-  let mkdirSyncMock;
-  let writeFileSyncMock;
-  let accessSyncMock;
+  let statSyncMock: MockInstance;
+  let mkdirSyncMock: MockInstance;
+  let writeFileSyncMock: MockInstance;
+  let accessSyncMock: MockInstance;
   const fakeStats = {
     isDirectory: vi.fn().mockReturnValue(true),
   };


### PR DESCRIPTION
Unfortunately, #6220 was breaking on Win since `os.homedir` doesn't match `HOME`. So it's back to using `process.env.HOME` if defined (ref [node docs](https://nodejs.org/docs/latest/api/os.html#oshomedir)).


<img width="663" height="403" alt="image" src="https://github.com/user-attachments/assets/538ebc91-dcde-4f4d-96bc-cc900850f22a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration file and storage path resolution on Windows by using the user’s `HOME` environment variable.
  * Prevented errors when a storage data directory is unavailable.
  * Improved handling when no existing configuration file can be found.

* **Tests**
  * Added coverage for locating existing configuration files and handling missing files.
  * Improved type safety for filesystem mocks used in configuration path tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->