### PR TITLE
chore: ci for windows

### DIFF
--- a/.github/actions/build-app-win/action.yml
+++ b/.github/actions/build-app-win/action.yml
@@ -1,0 +1,22 @@
+name: 'Build app (Windows)'
+description: 'build verdaccio application on Windows runners'
+
+inputs:
+  registry-url:
+    description: 'Registry URL for pnpm'
+    required: false
+    default: 'https://registry.npmjs.org'
+  node-version:
+    description: 'Node.js version to use'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies with a custom registry version ${{ inputs.node-version }}
+      uses: ./.github/actions/install-app-win
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: build
+      run: pnpm build
+      shell: pwsh

--- a/.github/actions/build-app-win/action.yml
+++ b/.github/actions/build-app-win/action.yml
@@ -17,6 +17,7 @@ runs:
       uses: ./.github/actions/install-app-win
       with:
         node-version: ${{ inputs.node-version }}
+        registry-url: ${{ inputs.registry-url }}
     - name: build
       run: pnpm build
       shell: pwsh

--- a/.github/actions/install-app-win/action.yml
+++ b/.github/actions/install-app-win/action.yml
@@ -1,0 +1,43 @@
+name: 'Install app (Windows)'
+description: 'install application on Windows runners'
+
+inputs:
+  registry-url:
+    description: 'Registry URL for pnpm'
+    required: false
+    default: 'https://registry.npmjs.org'
+  reporter:
+    description: 'Reporter for pnpm'
+    required: false
+    default: 'silent'
+  loglevel:
+    description: 'Log level for pnpm'
+    required: false
+    default: 'error'
+  node-version:
+    description: 'Node.js version to use. When empty, falls back to .nvmrc.'
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install pnpm
+      run: |
+        npm install --global corepack@latest
+        corepack enable
+        corepack prepare
+      shell: pwsh
+    - name: Use Node (explicit version)
+      if: inputs.node-version != ''
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Use Node (from .nvmrc)
+      if: inputs.node-version == ''
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      with:
+        node-version-file: '.nvmrc'
+    - name: Install
+      run: pnpm install --reporter=${{ inputs.reporter }} --ignore-scripts --registry ${{ inputs.registry-url }} --loglevel=${{ inputs.loglevel }}
+      shell: pwsh

--- a/.github/actions/install-app-win/action.yml
+++ b/.github/actions/install-app-win/action.yml
@@ -39,5 +39,9 @@ runs:
       with:
         node-version-file: '.nvmrc'
     - name: Install
-      run: pnpm install --reporter=${{ inputs.reporter }} --ignore-scripts --registry ${{ inputs.registry-url }} --loglevel=${{ inputs.loglevel }}
+      env:
+        REPORTER: ${{ inputs.reporter }}
+        REGISTRY_URL: ${{ inputs.registry-url }}
+        LOGLEVEL: ${{ inputs.loglevel }}
+      run: pnpm install --reporter="$env:REPORTER" --ignore-scripts --registry "$env:REGISTRY_URL" --loglevel="$env:LOGLEVEL"
       shell: pwsh

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -5,7 +5,6 @@ on:
 permissions:
   actions: read
   contents: read
-  security-events: write
 concurrency:
   group: ci-win-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci-win.yml
+++ b/.github/workflows/ci-win.yml
@@ -1,0 +1,81 @@
+name: CI Windows
+
+on:
+  workflow_dispatch:
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+concurrency:
+  group: ci-win-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: ${{ always() && !failure() && !cancelled() && github.event.pull_request.draft == false }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-latest]
+        node_version: [24]
+    name: Build / ${{ matrix.os }} / Node ${{ matrix.node_version }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Build application with Node ${{ matrix.node_version }}
+        uses: ./.github/actions/build-app-win
+        with:
+          node-version: ${{ matrix.node_version }}
+      - name: Cache build artifacts
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            packages/*/build
+            packages/*/dist
+            packages/*/*/build
+            packages/*/*/dist
+            packages/plugins/ui-theme/static
+          key: ci-build-win-${{ github.run_id }}-${{ github.run_attempt }}-node-${{ matrix.node_version }}
+  test:
+    needs: [build]
+    if: ${{ always() && !failure() && !cancelled() && github.event.pull_request.draft == false }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [windows-latest]
+        node_version: [24]
+    name: Test / ${{ matrix.os }} / Node ${{ matrix.node_version }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install dependencies
+        uses: ./.github/actions/install-app-win
+        with:
+          node-version: ${{ matrix.node_version }}
+      - name: Restore build artifacts
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: |
+            packages/*/build
+            packages/*/dist
+            packages/*/*/build
+            packages/*/*/dist
+            packages/plugins/ui-theme/static
+          key: ci-build-win-${{ github.run_id }}-${{ github.run_attempt }}-node-${{ matrix.node_version }}
+          fail-on-cache-miss: true
+      - name: Test
+        run: pnpm test
+  cleanup:
+    needs: [test]
+    if: always()
+    runs-on: windows-latest
+    name: Cleanup caches
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Delete build artifact caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh cache delete "ci-build-win-${{ github.run_id }}-${{ github.run_attempt }}-node-24" --repo ${{ github.repository }} || true


### PR DESCRIPTION
Add a basic build and test workflow for Windows. 

Limited to node 24 and manual dispatch at the moment. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Added a manually triggered Windows build and test pipeline.
  * Added configurable Node.js setup and package installation for Windows environments, including registry and logging options.
  * Windows builds now produce reusable artifacts for testing.
  * Added automatic cleanup of temporary build artifacts after workflow completion.
  * Prevented overlapping Windows CI runs from interfering with one another.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->