### PR TITLE
fix: register body parser before the JWT middleware on 6.x

### DIFF
--- a/.changeset/publish-with-generated-token.md
+++ b/.changeset/publish-with-generated-token.md
@@ -1,0 +1,7 @@
+---
+'verdaccio': patch
+---
+
+Fix `npm publish` failing with `request size did not match content length` when authenticating with a token created by `npm token create`.
+
+The JSON body parser was registered by the API router, which runs after `apiJWTmiddleware()` and after `enforceGeneratedTokenMetadata()`. The latter awaits a storage lookup for tokens that carry a server-issued key, so the request body was partially consumed before the parser attached. It is now registered before both, as it already is on `master`.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -9,7 +9,13 @@ import { getUserAgent } from '@verdaccio/config';
 import type { pluginUtils } from '@verdaccio/core';
 import { PLUGIN_CATEGORY } from '@verdaccio/core';
 import { asyncLoadPlugin } from '@verdaccio/loaders';
-import { errorReportingMiddleware, final, handleError, log } from '@verdaccio/middleware';
+import {
+  errorReportingMiddleware,
+  final,
+  handleError,
+  log,
+  registerBodyParser,
+} from '@verdaccio/middleware';
 import { SearchMemoryIndexer } from '@verdaccio/search-indexer';
 import type { ConfigYaml, Config as IConfig } from '@verdaccio/types';
 
@@ -93,6 +99,15 @@ const defineAPI = async function (config: IConfig, storage: Storage): Promise<ex
     config?.serverSettings?.pluginPrefix ?? 'verdaccio',
     PLUGIN_CATEGORY.MIDDLEWARE
   );
+
+  // Buffer the request body before anything that can suspend the request.
+  // apiJWTmiddleware() pauses the stream, and the API router's
+  // enforceGeneratedTokenMetadata() awaits a storage lookup for tokens minted
+  // via `npm token create` -- both run ahead of the router's own body parser,
+  // so without this the parser sees fewer bytes than Content-Length announced
+  // and the request is rejected. Registering here also lets middleware plugins
+  // read req.body.
+  registerBodyParser(app, config);
 
   // Register JWT middleware so middleware plugins can access req.remote_user
   app.use(auth.apiJWTmiddleware());

--- a/test/unit/modules/api/publish-generated-token.spec.ts
+++ b/test/unit/modules/api/publish-generated-token.spec.ts
@@ -1,0 +1,90 @@
+import supertest from 'supertest';
+import { beforeAll, describe, expect, test, vi } from 'vitest';
+
+import {
+  HEADERS,
+  HEADER_TYPE,
+  HTTP_STATUS,
+  TOKEN_BEARER,
+  authUtils,
+  fileUtils,
+} from '@verdaccio/core';
+import { generatePackageMetadata } from '@verdaccio/test-helper';
+
+import endPointAPI from '../../../../src/api/index';
+import { setup } from '../../../../src/lib/logger';
+import { addUser } from '../../__helper/api';
+import configDefault from '../../partials/config';
+
+const { buildToken } = authUtils;
+
+setup({});
+
+const credentials = { name: 'jwtPublisher', password: 'secretPass123' };
+
+/**
+ * Tokens minted through `POST /-/npm/v1/tokens` (what `npm token create`
+ * issues) carry a server-issued key, which makes enforceGeneratedTokenMetadata
+ * await a storage lookup before the API router parses the body. The body
+ * parser has to be registered ahead of that, otherwise the buffered request
+ * data is lost and the publish is rejected with
+ * "request size did not match content length".
+ */
+describe('publish with a token from the npm token API', () => {
+  vi.setConfig({ testTimeout: 30000 });
+  let app;
+  let generatedToken;
+
+  beforeAll(async () => {
+    const storage = await fileUtils.createTempStorageFolder('publish-generated-token');
+    app = await endPointAPI(
+      configDefault(
+        {
+          storage,
+          self_path: storage,
+          auth: { htpasswd: { file: './htpasswd-publish-generated-token' } },
+          packages: { '**': { access: '$all', publish: '$authenticated', proxy: [] } },
+        },
+        'api-jwt/jwt.yaml'
+      )
+    );
+
+    const [, loginResponse] = await addUser(supertest(app), credentials.name, credentials);
+
+    const tokenResponse = await supertest(app)
+      .post('/-/npm/v1/tokens')
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, loginResponse.body.token))
+      .send(
+        JSON.stringify({
+          password: credentials.password,
+          readonly: false,
+          cidr_whitelist: [],
+        })
+      )
+      .expect(HTTP_STATUS.OK);
+
+    generatedToken = tokenResponse.body.token;
+  });
+
+  test('receives the whole request body', async () => {
+    const pkgName = 'generated-token-publish';
+
+    expect(typeof generatedToken).toBe('string');
+
+    await supertest(app)
+      .put(`/${encodeURIComponent(pkgName)}`)
+      .set(HEADER_TYPE.CONTENT_TYPE, HEADERS.JSON)
+      .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, generatedToken))
+      .send(JSON.stringify(generatePackageMetadata(pkgName, '1.0.0')))
+      .expect(HTTP_STATUS.CREATED);
+
+    const manifest = await supertest(app)
+      .get(`/${encodeURIComponent(pkgName)}`)
+      .set(HEADERS.AUTHORIZATION, buildToken(TOKEN_BEARER, generatedToken))
+      .expect(HTTP_STATUS.OK);
+
+    expect(manifest.body.name).toEqual(pkgName);
+    expect(manifest.body.versions['1.0.0']).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #6080.

## What is wrong

On 6.x, `npm publish` with a token from `npm token create` always fails:

```
400 Bad Request - PUT http://localhost:4873/@acme%2frepro-probe - request size did not match content length
```

The body parser is registered by the API router, in `src/api/endpoint/index.ts`:

```js
app.use(enforceGeneratedTokenMetadata(storage, logger));
app.use(express.json({ strict: false, limit: config.max_body_size || '10mb' }));
```

Two things run before it. `apiJWTmiddleware()` is registered on the parent app in
`src/api/index.ts` (since #5962), and it pauses the request stream.
`enforceGeneratedTokenMetadata()` then `await`s a storage lookup — but only for tokens
that carry a server-issued `remote_user.token.key`, which is exactly what the npm token
API mints. During that await the buffered request data is lost, so `express.json()`
attaches to a stream that delivers fewer bytes than `Content-Length` announced, and
raw-body rejects the request.

That is also why the auth method matters, which the report found puzzling: Basic and AES
tokens have no `token.key`, so `enforceGeneratedTokenMetadata()` hits its
`if (!tokenKey) return next();` short-circuit and returns synchronously. No await, no
gap, body intact. Only the generated-token path is affected.

`master` does not have this problem because #5655 registers the parser first. That change
was cherry-picked to the 8.x packages — `@verdaccio/middleware@8.1.3`, which 6.x already
depends on, exports `registerBodyParser` — but the 6.x application never calls it.

## The change

One call, placed ahead of the JWT middleware, mirroring `packages/api/src/index.ts` on
`master`. `registerBodyParser()` no-ops when a parser is already on the stack, so the
router's own `express.json()` is unaffected.

## Reproduction

Added `test/unit/modules/api/publish-generated-token.spec.ts`: create a user, mint a token
through `POST /-/npm/v1/tokens`, publish with it.

On `6.x` at e2602b3, before the fix:

```
http <-- 400, user: jwtPublisher(::ffff:127.0.0.1), req: 'PUT /generated-token-publish', error: request size did not match content length
 Test Files  1 failed (1)
```

With the fix it returns 201 and the manifest reads back, which is what the assertion
checks — the point is that the whole body arrived, not just that the status changed.

@mbtools' three-command npm reproduction on the issue also works as an end-to-end check.

## What I verified, and what I did not

Ran on macOS arm64, Node 22.18, against `6.x` at e2602b3.

```
 Test Files  48 passed (48)
      Tests  503 passed | 5 skipped | 7 todo (515)
```

Baseline on the same machine without this change is 47 files / 502 tests, so the delta is
the one added test and nothing else. `yarn lint`, `yarn format:check` and `yarn type-check`
are clean. Note the suite needs `yarn build` first — without it the smoke tests and the
specs that spawn `bin/verdaccio` fail for unrelated reasons.

I did not run the Cypress e2e suite, and I did not reproduce against the Docker image;
CI will need to confirm Linux.

## Judgement call

I registered the parser on the parent app rather than at the top of the API router.
Registering it in the router would also fix the reported 400, since the await that loses
the data is in the router. I put it on the parent app because that is where `master` has
it, and because it also covers middleware plugins — which is the case #5655 was originally
about, and those are registered between the JWT middleware and the router here.

The cost is that JSON bodies are now parsed slightly earlier for every route. In practice
that is already true: `apiEndpoint` is mounted at `/`, so its parser already runs for web
UI requests on their way through. Same parser, same `max_body_size` limit, earlier. If you
would rather keep the blast radius inside the API router, say so and I will move it.


## References

- Fixes #6080
- #5167 → #5962: why `apiJWTmiddleware()` runs on the parent app; that order is kept — plugins still see `req.remote_user`, and now `req.body` too
- #5655: the master ordering this change mirrors (`packages/api/src/index.ts`)
